### PR TITLE
Add slider widgets for Stream Deck+ touchscreen dials

### DIFF
--- a/examples/media_controller.py
+++ b/examples/media_controller.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Media controller — music player with volume, EQ, and balance sliders.
+
+A practical example that turns the Stream Deck+ into a media controller:
+transport buttons on row 1, playlist navigation on row 2, and dial-
+controlled volume/EQ/balance on the touchscreen.
+
+Layout::
+
+    ┌──────────┬──────────┬──────────┬──────────┐
+    │   Prev   │  Play /  │   Next   │   Mute   │   ← row 1
+    │          │  Pause   │          │          │
+    ├──────────┼──────────┼──────────┼──────────┤
+    │ Shuffle  │  Repeat  │  Like    │  Queue   │   ← row 2
+    ├──────────┼──────────┼──────────┼──────────┤
+    │ Volume   │  Bass    │  Treble  │ Balance  │   ← touchscreen
+    └──────────┴──────────┴──────────┴──────────┘
+        dial 0     dial 1     dial 2     dial 3
+
+Run with::
+
+    python examples/media_controller.py
+"""
+
+import asyncio
+import logging
+
+from deckboard import BalanceSlider, Deck, EqualizerSlider, VolumeSlider
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+async def main() -> None:
+    async with Deck(brightness=70) as deck:
+        info = deck.info
+        print(f"Connected: {info.deck_type} (serial: {info.serial})")
+
+        page = deck.page("media")
+
+        # -- Transport controls (row 1) ------------------------------------
+
+        page.button(0).set_icon("mdi:skip-previous").set_label("Prev")
+        page.button(1).set_icon("mdi:play").set_label("Play")
+        page.button(2).set_icon("mdi:skip-next").set_label("Next")
+        page.button(3).set_icon("mdi:volume-high").set_label("Mute")
+
+        # -- Playlist controls (row 2) -------------------------------------
+
+        page.button(4).set_icon("mdi:shuffle-variant").set_label("Shuffle")
+        page.button(5).set_icon("mdi:repeat").set_label("Repeat")
+        page.button(6).set_icon("mdi:heart-outline").set_label("Like")
+        page.button(7).set_icon("mdi:playlist-music").set_label("Queue")
+
+        # -- Sliders on touchscreen -----------------------------------------
+
+        vol = VolumeSlider(value=65)
+        bass = EqualizerSlider("Bass", value=50, min_value=-12, max_value=12, step=1)
+        treble = EqualizerSlider(
+            "Treble", value=50, min_value=-12, max_value=12, step=1
+        )
+        bal = BalanceSlider(value=50)
+
+        page.widget(0).add_slider(vol)
+        page.widget(1).add_slider(bass)
+        page.widget(2).add_slider(treble)
+        page.widget(3).add_slider(bal)
+
+        # -- Playback state -------------------------------------------------
+
+        playing = False
+        muted = False
+        saved_volume = vol.value
+
+        @page.button(0).on_press
+        async def on_prev() -> None:
+            print("⏮ Previous track")
+
+        @page.button(1).on_press
+        async def on_play_pause() -> None:
+            nonlocal playing
+            playing = not playing
+            if playing:
+                page.button(1).set_icon("mdi:pause").set_label("Pause")
+                print("▶ Playing")
+            else:
+                page.button(1).set_icon("mdi:play").set_label("Play")
+                print("⏸ Paused")
+            await deck.refresh()
+
+        @page.button(2).on_press
+        async def on_next() -> None:
+            print("⏭ Next track")
+
+        @page.button(3).on_press
+        async def on_mute() -> None:
+            nonlocal muted, saved_volume
+            muted = not muted
+            if muted:
+                saved_volume = vol.value
+                vol.set_value(0)
+                page.button(3).set_icon("mdi:volume-off").set_label("Unmute")
+                print("🔇 Muted")
+            else:
+                vol.set_value(saved_volume)
+                page.button(3).set_icon("mdi:volume-high").set_label("Mute")
+                print(f"🔊 Volume restored to {vol.format_value()}")
+            await deck.refresh()
+
+        liked = False
+
+        @page.button(6).on_press
+        async def on_like() -> None:
+            nonlocal liked
+            liked = not liked
+            icon = "mdi:heart" if liked else "mdi:heart-outline"
+            page.button(6).set_icon(icon)
+            print("❤️ Liked!" if liked else "💔 Unliked")
+            await deck.refresh()
+
+        @page.button(7).on_press
+        async def on_queue() -> None:
+            print("📋 Queue (not implemented in this example)")
+
+        # Dial 0 press: toggle mute (same as button 3)
+        @page.dial(0).on_press
+        async def on_dial_mute() -> None:
+            await on_mute()
+
+        # -- Activate and run -----------------------------------------------
+
+        await deck.set_page("media")
+        print("\nMedia controller ready!")
+        print("  Dial 0: Volume | Dial 1: Bass | Dial 2: Treble | Dial 3: Balance")
+        print("  Press dial 0 to toggle mute.")
+        print("  Button 1 = Play/Pause, Button 3 = Mute.")
+        print("  Ctrl+C to exit.\n")
+
+        await deck.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/slider_widgets.py
+++ b/examples/slider_widgets.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Slider widgets showcase — every slider type on one layout.
+
+Demonstrates all six slider types on the Stream Deck+ touchscreen.
+Each dial controls the sliders in its zone; press the dial to cycle
+between sliders when a zone has more than one.
+
+Layout::
+
+    ┌──────────┬──────────┬──────────┬──────────┐
+    │  Reset   │  Print   │          │   Exit   │   ← buttons (row 1)
+    │  All     │  Values  │          │          │
+    ├──────────┼──────────┼──────────┼──────────┤
+    │          │          │          │          │   ← buttons (row 2)
+    ├──────────┼──────────┼──────────┼──────────┤
+    │ Volume   │ Bright + │  Kelvin  │ Sub+Bass │   ← touchscreen
+    │          │  Temp    │          │ +Balance │
+    └──────────┴──────────┴──────────┴──────────┘
+        dial 0     dial 1     dial 2     dial 3
+
+Run with::
+
+    python examples/slider_widgets.py
+"""
+
+import asyncio
+import logging
+
+from deckboard import (
+    BalanceSlider,
+    BrightnessSlider,
+    Deck,
+    EqualizerSlider,
+    KelvinSlider,
+    TemperatureSlider,
+    VolumeSlider,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+async def main() -> None:
+    async with Deck(brightness=80) as deck:
+        info = deck.info
+        print(f"Connected: {info.deck_type} (serial: {info.serial})")
+
+        page = deck.page("sliders")
+
+        # -- Buttons -------------------------------------------------------
+
+        page.button(0).set_icon("mdi:restore").set_label("Reset All")
+        page.button(1).set_icon("mdi:printer").set_label("Values")
+        page.button(7).set_icon("mdi:close-circle").set_label("Exit")
+
+        # -- Zone 0: Volume (single large slider) -------------------------
+
+        vol = VolumeSlider(value=50)
+        page.widget(0).add_slider(vol)
+
+        # -- Zone 1: Brightness + Temperature (two large sliders) ----------
+        #    Press dial 1 to cycle between them.
+
+        bright = BrightnessSlider(value=80)
+        temp = TemperatureSlider(value=20)
+        page.widget(1).add_slider(bright, default=True)
+        page.widget(1).add_slider(temp)
+        page.widget(1).set_selection_timeout(3)  # revert to brightness after 3s
+
+        # -- Zone 2: Kelvin (single large slider) -------------------------
+
+        kelvin = KelvinSlider(value=4000)
+        page.widget(2).add_slider(kelvin)
+
+        # -- Zone 3: Sub + Bass + Balance (three small sliders) ------------
+        #    Press dial 3 to cycle through them.
+
+        sub = EqualizerSlider("Sub", value=50)
+        bass = EqualizerSlider("Bass", value=50)
+        bal = BalanceSlider(value=50)
+        page.widget(3).add_slider(sub, default=True)
+        page.widget(3).add_slider(bass)
+        page.widget(3).add_slider(bal)
+        page.widget(3).set_selection_timeout(5)
+
+        # -- Button handlers -----------------------------------------------
+
+        @page.button(0).on_press
+        async def on_reset() -> None:
+            """Reset every slider to its default value."""
+            vol.set_value(50)
+            bright.set_value(80)
+            temp.set_value(20)
+            kelvin.set_value(4000)
+            sub.set_value(50)
+            bass.set_value(50)
+            bal.set_value(50)
+            await deck.refresh()
+            print("All sliders reset.")
+
+        @page.button(1).on_press
+        async def on_print() -> None:
+            """Print current slider values to the console."""
+            print(
+                f"Volume={vol.format_value()}, "
+                f"Brightness={bright.format_value()}, "
+                f"Temp={temp.format_value()}, "
+                f"Kelvin={kelvin.format_value()}, "
+                f"Sub={sub.format_value()}, "
+                f"Bass={bass.format_value()}, "
+                f"Balance={bal.format_value()}"
+            )
+
+        @page.button(7).on_press
+        async def on_exit() -> None:
+            print("Exiting...")
+            await deck.stop()
+
+        # -- Go! -----------------------------------------------------------
+
+        await deck.set_page("sliders")
+        print("\nSlider showcase ready!")
+        print("  Turn dials to adjust values.")
+        print("  Press dial 1 to cycle Brightness / Temperature.")
+        print("  Press dial 3 to cycle Sub / Bass / Balance.")
+        print("  Button 0 = Reset All, Button 1 = Print Values.")
+        print("  Button 7 = Exit.\n")
+
+        await deck.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/smart_home.py
+++ b/examples/smart_home.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Smart home dashboard — multi-page control with sliders.
+
+Two pages: **Living Room** and **Bedroom**.  Each page has light/climate
+controls on the touchscreen (brightness, colour temperature, room
+temperature) and quick-action buttons for scenes and devices.
+
+Press the page-switch button to toggle between rooms.
+
+Layout (Living Room)::
+
+    ┌──────────┬──────────┬──────────┬──────────┐
+    │  Living  │  Scene:  │  Scene:  │ Bedroom  │   ← row 1
+    │  Room    │  Movie   │  Bright  │  →       │
+    ├──────────┼──────────┼──────────┼──────────┤
+    │  Lamp    │  Fan     │  AC      │  All Off │   ← row 2
+    │  Toggle  │  Toggle  │  Toggle  │          │
+    ├──────────┼──────────┼──────────┼──────────┤
+    │  Light   │ Colour   │   Room   │  Fan     │   ← touchscreen
+    │ Bright.  │  Temp    │  Temp    │ Balance  │
+    └──────────┴──────────┴──────────┴──────────┘
+        dial 0     dial 1     dial 2     dial 3
+
+Run with::
+
+    python examples/smart_home.py
+"""
+
+import asyncio
+import logging
+
+from deckboard import (
+    BalanceSlider,
+    BrightnessSlider,
+    Deck,
+    KelvinSlider,
+    TemperatureSlider,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def build_room_page(
+    deck: Deck,
+    name: str,
+    *,
+    other_page: str,
+    icon: str,
+    other_icon: str,
+) -> dict[str, object]:
+    """Wire up buttons and sliders for a single room page.
+
+    Returns a dict of slider references so the caller can inspect them.
+    """
+    page = deck.page(name)
+
+    # -- Row 1: scenes & navigation ----------------------------------------
+
+    page.button(0).set_icon(icon).set_label(name)
+    page.button(1).set_icon("mdi:movie-open").set_label("Movie")
+    page.button(2).set_icon("mdi:white-balance-sunny").set_label("Bright")
+    page.button(3).set_icon(other_icon).set_label(f"{other_page} →")
+
+    # -- Row 2: device toggles ---------------------------------------------
+
+    page.button(4).set_icon("mdi:lamp").set_label("Lamp")
+    page.button(5).set_icon("mdi:fan").set_label("Fan")
+    page.button(6).set_icon("mdi:air-conditioner").set_label("AC")
+    page.button(7).set_icon("mdi:power").set_label("All Off")
+
+    # -- Touchscreen sliders -----------------------------------------------
+
+    bright = BrightnessSlider(value=80)
+    kelvin = KelvinSlider(value=4000)
+    temp = TemperatureSlider(value=22)
+    bal = BalanceSlider("Fan Spd", value=50)
+
+    page.widget(0).add_slider(bright)
+    page.widget(1).add_slider(kelvin)
+    page.widget(2).add_slider(temp)
+    page.widget(3).add_slider(bal)
+
+    # -- Scene handlers (set slider values in one shot) --------------------
+
+    @page.button(1).on_press
+    async def on_movie() -> None:
+        bright.set_value(20)
+        kelvin.set_value(2700)
+        print(f"[{name}] Movie scene: dim warm light")
+        await deck.refresh()
+
+    @page.button(2).on_press
+    async def on_bright() -> None:
+        bright.set_value(100)
+        kelvin.set_value(6500)
+        print(f"[{name}] Bright scene: full cool light")
+        await deck.refresh()
+
+    # -- Page navigation ---------------------------------------------------
+
+    @page.button(3).on_press
+    async def on_switch() -> None:
+        print(f"Switching to {other_page}")
+        await deck.set_page(other_page)
+
+    # -- Device toggles (simulated) ----------------------------------------
+
+    devices = {"lamp": True, "fan": True, "ac": True}
+
+    @page.button(4).on_press
+    async def on_lamp() -> None:
+        devices["lamp"] = not devices["lamp"]
+        state = "ON" if devices["lamp"] else "OFF"
+        print(f"[{name}] Lamp: {state}")
+
+    @page.button(5).on_press
+    async def on_fan() -> None:
+        devices["fan"] = not devices["fan"]
+        state = "ON" if devices["fan"] else "OFF"
+        print(f"[{name}] Fan: {state}")
+
+    @page.button(6).on_press
+    async def on_ac() -> None:
+        devices["ac"] = not devices["ac"]
+        state = "ON" if devices["ac"] else "OFF"
+        print(f"[{name}] AC: {state}")
+
+    @page.button(7).on_press
+    async def on_all_off() -> None:
+        for key in devices:
+            devices[key] = False
+        bright.set_value(0)
+        print(f"[{name}] All devices OFF, lights at 0%")
+        await deck.refresh()
+
+    return {
+        "brightness": bright,
+        "kelvin": kelvin,
+        "temperature": temp,
+        "balance": bal,
+    }
+
+
+async def main() -> None:
+    async with Deck(brightness=75) as deck:
+        info = deck.info
+        print(f"Connected: {info.deck_type} (serial: {info.serial})")
+
+        # Build both room pages
+        build_room_page(
+            deck,
+            "Living Room",
+            other_page="Bedroom",
+            icon="mdi:sofa",
+            other_icon="mdi:bed",
+        )
+        build_room_page(
+            deck,
+            "Bedroom",
+            other_page="Living Room",
+            icon="mdi:bed",
+            other_icon="mdi:sofa",
+        )
+
+        # Start on the living room page
+        await deck.set_page("Living Room")
+        print("\nSmart home dashboard ready!")
+        print("  Turn dials to adjust brightness, colour temp, room temp, fan speed.")
+        print("  Button 1 = Movie scene, Button 2 = Bright scene.")
+        print("  Button 3 = Switch rooms.")
+        print("  Button 7 = All Off.")
+        print("  Ctrl+C to exit.\n")
+
+        await deck.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deckboard/__init__.py
+++ b/src/deckboard/__init__.py
@@ -35,8 +35,21 @@ from .types import (
     KeyEvent,
     TouchEvent,
 )
+from .widgets import (
+    BalanceSlider,
+    BrightnessSlider,
+    EqualizerSlider,
+    KelvinSlider,
+    LargeSlider,
+    Slider,
+    SmallSlider,
+    TemperatureSlider,
+    VolumeSlider,
+)
 
 __all__ = [
+    "BalanceSlider",
+    "BrightnessSlider",
     "Button",
     "Deck",
     "DeckError",
@@ -45,13 +58,20 @@ __all__ = [
     "Dial",
     "DialPressEvent",
     "DialTurnEvent",
+    "EqualizerSlider",
     "EventType",
     "IconError",
     "IconManager",
+    "KelvinSlider",
     "KeyEvent",
+    "LargeSlider",
     "Page",
+    "Slider",
+    "SmallSlider",
+    "TemperatureSlider",
     "TouchEvent",
     "TouchScreen",
+    "VolumeSlider",
     "Widget",
 ]
 

--- a/src/deckboard/deck.py
+++ b/src/deckboard/deck.py
@@ -19,7 +19,6 @@ from .image import (
     render_blank_key,
     render_blank_touchscreen,
     render_key_image,
-    render_widget_image,
 )
 from .page import Page
 from .touchscreen import Widget
@@ -334,11 +333,7 @@ class Deck:
                     widget.icon_name, color=widget.icon_color
                 )
 
-            img = render_widget_image(
-                icon=icon_img,
-                label=widget.label,
-                value=widget.value,
-            )
+            img = widget.render(icon=icon_img)
             widget.set_rendered(img)
             widget_images.append(img)
 
@@ -423,6 +418,11 @@ class Deck:
             dial = page.dials.get(event.dial)
             if dial and dial._turn_handler:
                 await dial._turn_handler(event.direction)
+            # Update widget slider if present
+            widget = page.touchscreen.widget(event.dial)
+            if widget.sliders:
+                widget.handle_dial_turn(event.direction)
+                await self.refresh()
 
         elif isinstance(event, DialPressEvent):
             dial = page.dials.get(event.dial)
@@ -431,6 +431,12 @@ class Deck:
                     await dial._press_handler()
                 elif not event.pressed and dial._release_handler:
                     await dial._release_handler()
+            # Cycle widget slider selection on press
+            if event.pressed:
+                widget = page.touchscreen.widget(event.dial)
+                if widget.sliders:
+                    widget.handle_dial_press()
+                    await self.refresh()
 
         elif isinstance(event, TouchEvent):
             zone = event.zone

--- a/src/deckboard/touchscreen.py
+++ b/src/deckboard/touchscreen.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import logging
+import time
+from typing import TYPE_CHECKING
 
 from PIL import Image
 
-from .image import WIDGET_COUNT
+from .image import WIDGET_COUNT, render_widget_image
 from .types import AsyncHandler
+
+if TYPE_CHECKING:
+    from .widgets.slider import Slider
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +45,13 @@ class Widget:
         self._drag_handler: AsyncHandler | None = None
         self._rendered: Image.Image | None = None
         self._dirty = True
+
+        # Slider sub-elements
+        self._sliders: list[Slider] = []
+        self._active_slider_index: int = 0
+        self._default_slider_index: int = 0
+        self._selection_timeout: float = 5.0
+        self._last_selection_time: float | None = None
 
     @property
     def index(self) -> int:
@@ -153,6 +165,150 @@ class Widget:
     def set_rendered(self, img: Image.Image) -> None:
         self._rendered = img
         self._dirty = False
+
+    # -- Slider sub-element management -------------------------------------
+
+    def add_slider(self, slider: Slider, default: bool = False) -> Widget:
+        """Add a slider sub-element to this widget zone.
+
+        Args:
+            slider: A :class:`Slider` instance to display in this zone.
+            default: If ``True``, this slider becomes the default
+                (the one selected after timeout).
+
+        Returns:
+            This widget (for chaining).
+        """
+        from .widgets.slider import Slider as _Slider
+
+        if not isinstance(slider, _Slider):
+            msg = f"Expected a Slider instance, got {type(slider).__name__}"
+            raise TypeError(msg)
+        self._sliders.append(slider)
+        idx = len(self._sliders) - 1
+        if default or idx == 0:
+            self._default_slider_index = idx
+            self._active_slider_index = idx
+        self._dirty = True
+        return self
+
+    @property
+    def sliders(self) -> list[Slider]:
+        """All slider sub-elements in this widget zone."""
+        return list(self._sliders)
+
+    @property
+    def active_slider(self) -> Slider | None:
+        """The slider currently controlled by the dial, or ``None``."""
+        if not self._sliders:
+            return None
+        return self._sliders[self._active_slider_index]
+
+    @property
+    def active_slider_index(self) -> int:
+        """Index of the currently active slider."""
+        return self._active_slider_index
+
+    @property
+    def selection_timeout(self) -> float:
+        """Seconds before active slider resets to the default."""
+        return self._selection_timeout
+
+    def set_selection_timeout(self, seconds: float) -> Widget:
+        """Set how long before active slider resets to the default.
+
+        Args:
+            seconds: Timeout in seconds.  Use ``0`` to disable.
+        """
+        self._selection_timeout = max(0.0, seconds)
+        return self
+
+    def cycle_active_slider(self) -> None:
+        """Advance to the next slider (wrapping around).
+
+        Called on dial push.  Marks the widget dirty so the highlight
+        redraws on the next render.
+        """
+        if len(self._sliders) <= 1:
+            return
+        self._active_slider_index = (self._active_slider_index + 1) % len(self._sliders)
+        self._last_selection_time = time.monotonic()
+        self._dirty = True
+
+    def check_selection_timeout(self) -> bool:
+        """Reset to the default slider if the timeout has elapsed.
+
+        Returns:
+            ``True`` if the active slider changed (widget is now dirty).
+        """
+        if (
+            self._selection_timeout <= 0
+            or self._last_selection_time is None
+            or self._active_slider_index == self._default_slider_index
+        ):
+            return False
+        elapsed = time.monotonic() - self._last_selection_time
+        if elapsed >= self._selection_timeout:
+            self._active_slider_index = self._default_slider_index
+            self._last_selection_time = None
+            self._dirty = True
+            return True
+        return False
+
+    def handle_dial_turn(self, direction: int) -> None:
+        """Adjust the active slider's value by *direction* steps.
+
+        Marks the widget dirty so the next render reflects the change.
+        """
+        if self._sliders:
+            self._sliders[self._active_slider_index].adjust(direction)
+            self._dirty = True
+
+    def handle_dial_press(self) -> None:
+        """Cycle to the next slider.  Called on dial push."""
+        self.cycle_active_slider()
+
+    # -- Rendering ---------------------------------------------------------
+
+    def render(self, icon: Image.Image | None = None) -> Image.Image:
+        """Render this widget zone as a 200x100 PIL Image.
+
+        If sliders have been added via :meth:`add_slider`, they are
+        rendered instead of the default icon/label/value layout.
+
+        Args:
+            icon: Pre-fetched icon image (used by the classic layout).
+
+        Returns:
+            A 200x100 RGB :class:`~PIL.Image.Image`.
+        """
+        if self._sliders:
+            return self._render_with_sliders()
+        return render_widget_image(
+            icon=icon,
+            label=self._label,
+            value=self._value,
+        )
+
+    def _render_with_sliders(self) -> Image.Image:
+        """Compose all slider sub-elements into a single widget image."""
+        from .image import TOUCHSCREEN_HEIGHT, WIDGET_WIDTH
+
+        img = Image.new("RGB", (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        if not self._sliders:
+            return img
+
+        self.check_selection_timeout()
+
+        count = len(self._sliders)
+        slot_height = TOUCHSCREEN_HEIGHT // count
+        for i, slider in enumerate(self._sliders):
+            y = i * slot_height
+            active = i == self._active_slider_index and count > 1
+            slider.render_onto(
+                img, x=0, y=y, width=WIDGET_WIDTH, height=slot_height, active=active
+            )
+        return img
 
 
 class TouchScreen:

--- a/src/deckboard/widgets/__init__.py
+++ b/src/deckboard/widgets/__init__.py
@@ -1,0 +1,23 @@
+"""Ready-to-use slider / progressbar widgets for the Stream Deck+ touchscreen."""
+
+from __future__ import annotations
+
+from .balance import BalanceSlider
+from .brightness import BrightnessSlider
+from .equalizer import EqualizerSlider
+from .kelvin import KelvinSlider
+from .slider import LargeSlider, Slider, SmallSlider
+from .temperature import TemperatureSlider
+from .volume import VolumeSlider
+
+__all__ = [
+    "BalanceSlider",
+    "BrightnessSlider",
+    "EqualizerSlider",
+    "KelvinSlider",
+    "LargeSlider",
+    "Slider",
+    "SmallSlider",
+    "TemperatureSlider",
+    "VolumeSlider",
+]

--- a/src/deckboard/widgets/balance.py
+++ b/src/deckboard/widgets/balance.py
@@ -1,0 +1,95 @@
+"""Balance slider — centre-fill bar for left/right speaker balance."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from .slider import SmallSlider, _SMALL_INNER_RX
+
+
+class BalanceSlider(SmallSlider):
+    """A small slider for left/right speaker balance.
+
+    Value range 0–100 where 50 = perfectly balanced (both speakers
+    full volume).  The visualisation uses two filled rectangles growing
+    from the centre: the left rect represents left-speaker volume and
+    the right rect represents right-speaker volume.  When balanced
+    (value = 50) both rectangles fill the full half.
+
+    A thin vertical centre line marks the midpoint.
+
+    Args:
+        label: Display label (e.g. ``"Balance"``).
+        value: Initial value.  Defaults to 50 (centre).
+        min_value: Minimum value.  Defaults to 0 (full left).
+        max_value: Maximum value.  Defaults to 100 (full right).
+        step: Dial-turn increment.  Defaults to 1.
+    """
+
+    def __init__(
+        self,
+        label: str = "Balance",
+        *,
+        value: float | None = None,
+        min_value: float = 0,
+        max_value: float = 100,
+        step: float = 1,
+    ) -> None:
+        if value is None:
+            value = 50.0
+        super().__init__(
+            label,
+            min_value=min_value,
+            max_value=max_value,
+            value=value,
+            unit="",
+            step=step,
+        )
+
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        centre_x = ix + iw // 2
+        half_w = iw // 2
+
+        # Compute left and right speaker volumes.
+        # 50 → both full.  0 → only left.  100 → only right.
+        n = self.normalized  # 0.0 (full-left) to 1.0 (full-right)
+
+        # Right speaker: full when n >= 0.5, shrinks to 0 at n = 0
+        right_frac = min(1.0, n * 2)
+        # Left speaker: full when n <= 0.5, shrinks to 0 at n = 1
+        left_frac = min(1.0, (1.0 - n) * 2)
+
+        # Left fill: grows from centre toward the left
+        left_fill_w = int(half_w * left_frac)
+        if left_fill_w > 0:
+            self._draw_rounded_rect(
+                draw,
+                (centre_x - left_fill_w, iy, centre_x, iy + ih),
+                radius=_SMALL_INNER_RX,
+                fill="white",
+            )
+
+        # Right fill: grows from centre toward the right
+        right_fill_w = int(half_w * right_frac)
+        if right_fill_w > 0:
+            self._draw_rounded_rect(
+                draw,
+                (centre_x, iy, centre_x + right_fill_w, iy + ih),
+                radius=_SMALL_INNER_RX,
+                fill="white",
+            )
+
+        # Centre line
+        draw.line(
+            [(centre_x, iy), (centre_x, iy + ih)],
+            fill="black",
+            width=1,
+        )

--- a/src/deckboard/widgets/brightness.py
+++ b/src/deckboard/widgets/brightness.py
@@ -1,0 +1,65 @@
+"""Brightness slider — dark-to-bright gradient with a thin indicator."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from .slider import LargeSlider, _LARGE_INDICATOR_W, _LARGE_INNER_RX
+
+
+class BrightnessSlider(LargeSlider):
+    """A large slider showing brightness as a thin indicator over a gradient.
+
+    The background is a horizontal gradient from black to white.
+    A thin vertical rectangle indicates the current position.
+
+    Args:
+        label: Display label (e.g. ``"Brightness"``).
+        value: Initial value.  Defaults to 0.
+        min_value: Minimum value.  Defaults to 0.
+        max_value: Maximum value.  Defaults to 100.
+        step: Dial-turn increment.  Defaults to 1.
+    """
+
+    def __init__(
+        self,
+        label: str = "Brightness",
+        *,
+        value: float | None = None,
+        min_value: float = 0,
+        max_value: float = 100,
+        step: float = 1,
+    ) -> None:
+        super().__init__(
+            label,
+            min_value=min_value,
+            max_value=max_value,
+            value=value,
+            unit="%",
+            step=step,
+        )
+
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        # Gradient background: dark → bright
+        self._draw_gradient(
+            img, ix, iy, iw, ih, "#000000", "#FFFFFF", radius=_LARGE_INNER_RX
+        )
+
+        # Thin indicator
+        ind_x = ix + int((iw - _LARGE_INDICATOR_W) * self.normalized)
+        self._draw_rounded_rect(
+            draw,
+            (ind_x, iy, ind_x + _LARGE_INDICATOR_W, iy + ih),
+            radius=_LARGE_INNER_RX,
+            fill="white",
+            outline="black",
+            width=1,
+        )

--- a/src/deckboard/widgets/equalizer.py
+++ b/src/deckboard/widgets/equalizer.py
@@ -1,0 +1,57 @@
+"""Equalizer slider — thin indicator on a transparent background."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from .slider import SmallSlider, _SMALL_INDICATOR_W, _SMALL_INNER_RX
+
+
+class EqualizerSlider(SmallSlider):
+    """A small slider for equalizer bands (Sub, Bass, Treble, etc.).
+
+    No background fill.  A thin vertical indicator shows the position.
+
+    Args:
+        label: Display label (e.g. ``"Bass"``).
+        value: Initial value.  Defaults to 0.
+        min_value: Minimum value.  Defaults to 0.
+        max_value: Maximum value.  Defaults to 100.
+        step: Dial-turn increment.  Defaults to 1.
+    """
+
+    def __init__(
+        self,
+        label: str = "EQ",
+        *,
+        value: float | None = None,
+        min_value: float = 0,
+        max_value: float = 100,
+        step: float = 1,
+    ) -> None:
+        super().__init__(
+            label,
+            min_value=min_value,
+            max_value=max_value,
+            value=value,
+            unit="%",
+            step=step,
+        )
+
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        # Thin indicator
+        ind_x = ix + int((iw - _SMALL_INDICATOR_W) * self.normalized)
+        self._draw_rounded_rect(
+            draw,
+            (ind_x, iy, ind_x + _SMALL_INDICATOR_W, iy + ih),
+            radius=_SMALL_INNER_RX,
+            fill="white",
+        )

--- a/src/deckboard/widgets/kelvin.py
+++ b/src/deckboard/widgets/kelvin.py
@@ -1,0 +1,65 @@
+"""Kelvin slider — warm-to-cold gradient with a thin indicator."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from .slider import LargeSlider, _LARGE_INDICATOR_W, _LARGE_INNER_RX
+
+
+class KelvinSlider(LargeSlider):
+    """A large slider for light colour temperature (Kelvin).
+
+    The background is a horizontal gradient from warm (#FFB87B) to
+    cool (#FFFFFF).  A thin vertical indicator marks the current value.
+
+    Args:
+        label: Display label (e.g. ``"Kelvin"``).
+        value: Initial value.  Defaults to 2000.
+        min_value: Minimum Kelvin.  Defaults to 2000.
+        max_value: Maximum Kelvin.  Defaults to 6500.
+        step: Dial-turn increment.  Defaults to 100.
+    """
+
+    def __init__(
+        self,
+        label: str = "Kelvin",
+        *,
+        value: float | None = None,
+        min_value: float = 2000,
+        max_value: float = 6500,
+        step: float = 100,
+    ) -> None:
+        super().__init__(
+            label,
+            min_value=min_value,
+            max_value=max_value,
+            value=value,
+            unit="K",
+            step=step,
+        )
+
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        # Gradient background: warm → cold
+        self._draw_gradient(
+            img, ix, iy, iw, ih, "#FFB87B", "#FFFFFF", radius=_LARGE_INNER_RX
+        )
+
+        # Thin indicator
+        ind_x = ix + int((iw - _LARGE_INDICATOR_W) * self.normalized)
+        self._draw_rounded_rect(
+            draw,
+            (ind_x, iy, ind_x + _LARGE_INDICATOR_W, iy + ih),
+            radius=_LARGE_INNER_RX,
+            fill="white",
+            outline="black",
+            width=1,
+        )

--- a/src/deckboard/widgets/slider.py
+++ b/src/deckboard/widgets/slider.py
@@ -1,0 +1,346 @@
+"""Base slider classes for touchscreen widget sub-elements.
+
+The hierarchy is::
+
+    Slider            (abstract base — value, clamping, drawing primitives)
+    ├── LargeSlider   (full-width bar with label + value text above)
+    └── SmallSlider   (compact bar with label to the left, no value text)
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from PIL import Image, ImageDraw, ImageFont
+
+from ..image import get_font
+
+# ── Layout constants (derived from the reference SVG) ────────────────────
+
+# Large slider — fits 2 per 200x100 widget zone
+_LARGE_MARGIN_X = 2
+_LARGE_LABEL_FONT_SIZE = 14
+_LARGE_LABEL_GAP = 3  # gap between label line and frame top
+_LARGE_FRAME_HEIGHT = 15
+_LARGE_FRAME_RX = 2
+_LARGE_FRAME_STROKE = 1
+_LARGE_INNER_PAD = 2  # padding between frame and inner track
+_LARGE_INDICATOR_W = 3
+_LARGE_INNER_RX = 1
+
+# Small slider — fits 4 per 200x100 widget zone
+_SMALL_LABEL_WIDTH = 54
+_SMALL_LABEL_GAP = 2
+_SMALL_FRAME_HEIGHT = 11
+_SMALL_FRAME_RX = 2
+_SMALL_FRAME_STROKE = 1
+_SMALL_INNER_PAD = 2
+_SMALL_INDICATOR_W = 3
+_SMALL_INNER_RX = 1
+
+# Highlight colour for the active slider when multiple share a zone
+_HIGHLIGHT_COLOR = "#5599ff"
+_NORMAL_STROKE_COLOR = "white"
+
+
+class Slider(ABC):
+    """Abstract base for all slider / progressbar sub-elements.
+
+    A slider holds a numeric value within a ``[min_value, max_value]``
+    range and knows how to render itself onto a PIL image.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        *,
+        min_value: float = 0,
+        max_value: float = 100,
+        value: float | None = None,
+        unit: str = "%",
+        step: float = 1,
+    ) -> None:
+        self._label = label
+        self._min = float(min_value)
+        self._max = float(max_value)
+        self._value = float(value) if value is not None else self._min
+        self._unit = unit
+        self._step = float(step)
+
+    # -- Properties --------------------------------------------------------
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @property
+    def min_value(self) -> float:
+        return self._min
+
+    @property
+    def max_value(self) -> float:
+        return self._max
+
+    @property
+    def unit(self) -> str:
+        return self._unit
+
+    @property
+    def step(self) -> float:
+        return self._step
+
+    @property
+    def normalized(self) -> float:
+        """Value mapped to 0.0 – 1.0 within the min/max range."""
+        span = self._max - self._min
+        if span <= 0:
+            return 0.0
+        return max(0.0, min(1.0, (self._value - self._min) / span))
+
+    # -- Mutators ----------------------------------------------------------
+
+    def set_value(self, v: float) -> None:
+        """Set the value, clamping to ``[min_value, max_value]``."""
+        self._value = max(self._min, min(self._max, float(v)))
+
+    def adjust(self, direction: int) -> None:
+        """Adjust the value by ``direction * step``."""
+        self.set_value(self._value + direction * self._step)
+
+    def format_value(self) -> str:
+        """Human-readable string, e.g. ``'50%'`` or ``'3000K'``."""
+        if self._value == int(self._value):
+            v = str(int(self._value))
+        else:
+            v = f"{self._value:.1f}"
+        return f"{v}{self._unit}"
+
+    # -- Rendering ---------------------------------------------------------
+
+    @abstractmethod
+    def render_onto(
+        self,
+        img: Image.Image,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        *,
+        active: bool = False,
+    ) -> None:
+        """Draw this slider onto *img* within the given rectangle.
+
+        Args:
+            img: Target image (modified in-place).
+            x: Left edge.
+            y: Top edge.
+            width: Available width.
+            height: Available height.
+            active: If ``True``, highlight the frame to show the dial
+                is currently controlling this slider.
+        """
+
+    # -- Drawing primitives used by subclasses -----------------------------
+
+    @staticmethod
+    def _draw_rounded_rect(
+        draw: ImageDraw.ImageDraw,
+        xy: tuple[float, float, float, float],
+        *,
+        radius: int = 2,
+        fill: str | None = None,
+        outline: str | None = None,
+        width: int = 1,
+    ) -> None:
+        """Draw a rectangle with rounded corners."""
+        draw.rounded_rectangle(
+            xy, radius=radius, fill=fill, outline=outline, width=width
+        )
+
+    @staticmethod
+    def _draw_gradient(
+        img: Image.Image,
+        x: int,
+        y: int,
+        w: int,
+        h: int,
+        color_left: str,
+        color_right: str,
+        radius: int = 1,
+    ) -> None:
+        """Draw a horizontal linear gradient rectangle onto *img*."""
+        if w <= 0 or h <= 0:
+            return
+
+        from PIL import ImageColor
+
+        r1, g1, b1 = ImageColor.getrgb(color_left)
+        r2, g2, b2 = ImageColor.getrgb(color_right)
+
+        grad = Image.new("RGB", (w, h))
+        for px in range(w):
+            t = px / max(w - 1, 1)
+            r = int(r1 + (r2 - r1) * t)
+            g = int(g1 + (g2 - g1) * t)
+            b = int(b1 + (b2 - b1) * t)
+            for py in range(h):
+                grad.putpixel((px, py), (r, g, b))
+
+        # Apply rounded-corner mask
+        mask = Image.new("L", (w, h), 0)
+        mask_draw = ImageDraw.Draw(mask)
+        mask_draw.rounded_rectangle((0, 0, w - 1, h - 1), radius=radius, fill=255)
+        img.paste(grad, (x, y), mask)
+
+
+class LargeSlider(Slider, ABC):
+    """A full-width slider with label and value text above the bar.
+
+    Two ``LargeSlider`` instances stack vertically inside one widget zone.
+    """
+
+    # Subclasses override this to draw the bar contents.
+    @abstractmethod
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        """Draw the inner track contents (fill, indicator, gradient, etc.).
+
+        Args:
+            draw: ImageDraw handle for *img*.
+            img: The target image (for gradient pasting).
+            ix: Inner track left x.
+            iy: Inner track top y.
+            iw: Inner track width.
+            ih: Inner track height.
+        """
+
+    def render_onto(
+        self,
+        img: Image.Image,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        *,
+        active: bool = False,
+    ) -> None:
+        draw = ImageDraw.Draw(img)
+        font = get_font()
+
+        mx = _LARGE_MARGIN_X
+        bar_w = width - 2 * mx
+        frame_h = _LARGE_FRAME_HEIGHT
+
+        # Position: bar at the bottom of the slot, label above
+        bar_y = y + height - frame_h - 1
+        label_y = bar_y - _LARGE_LABEL_GAP - _LARGE_LABEL_FONT_SIZE
+
+        # Label (left-aligned)
+        draw.text((x + mx, label_y), self._label, fill="white", font=font)
+        # Value (right-aligned)
+        val_text = self.format_value()
+        bbox = draw.textbbox((0, 0), val_text, font=font)
+        val_w = bbox[2] - bbox[0]
+        draw.text((x + mx + bar_w - val_w, label_y), val_text, fill="white", font=font)
+
+        # Frame
+        stroke_color = _HIGHLIGHT_COLOR if active else _NORMAL_STROKE_COLOR
+        self._draw_rounded_rect(
+            draw,
+            (x + mx + 0.5, bar_y + 0.5, x + mx + bar_w - 0.5, bar_y + frame_h - 0.5),
+            radius=_LARGE_FRAME_RX,
+            outline=stroke_color,
+            width=_LARGE_FRAME_STROKE,
+        )
+
+        # Inner track coordinates
+        pad = _LARGE_INNER_PAD
+        ix = x + mx + pad
+        iy = bar_y + pad
+        iw = bar_w - 2 * pad
+        ih = frame_h - 2 * pad
+
+        self._draw_bar_contents(draw, img, ix, iy, iw, ih)
+
+
+class SmallSlider(Slider, ABC):
+    """A compact slider with the label to the left and no value text.
+
+    Four ``SmallSlider`` instances stack vertically inside one widget zone.
+    """
+
+    @abstractmethod
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        """Draw the inner track contents."""
+
+    def render_onto(
+        self,
+        img: Image.Image,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        *,
+        active: bool = False,
+    ) -> None:
+        draw = ImageDraw.Draw(img)
+        font = get_font()
+
+        # Label on the left (right-aligned within label column)
+        label_x_end = x + _SMALL_LABEL_WIDTH
+        bbox = draw.textbbox((0, 0), self._label, font=font)
+        label_w = bbox[2] - bbox[0]
+        label_h = bbox[3] - bbox[1]
+
+        # Vertically centre the label in the slot
+        label_y = y + (height - label_h) // 2 - 1
+
+        draw.text(
+            (label_x_end - label_w, label_y), self._label, fill="white", font=font
+        )
+
+        # Bar area to the right of the label
+        bar_x = label_x_end + _SMALL_LABEL_GAP
+        bar_w = width - bar_x + x
+        frame_h = _SMALL_FRAME_HEIGHT
+
+        # Vertically centre the frame in the slot
+        bar_y = y + (height - frame_h) // 2
+
+        # Frame
+        stroke_color = _HIGHLIGHT_COLOR if active else _NORMAL_STROKE_COLOR
+        self._draw_rounded_rect(
+            draw,
+            (bar_x + 0.5, bar_y + 0.5, bar_x + bar_w - 0.5, bar_y + frame_h - 0.5),
+            radius=_SMALL_FRAME_RX,
+            outline=stroke_color,
+            width=_SMALL_FRAME_STROKE,
+        )
+
+        # Inner track
+        pad = _SMALL_INNER_PAD
+        ix = bar_x + pad
+        iy = bar_y + pad
+        iw = bar_w - 2 * pad
+        ih = frame_h - 2 * pad
+
+        self._draw_bar_contents(draw, img, ix, iy, iw, ih)

--- a/src/deckboard/widgets/temperature.py
+++ b/src/deckboard/widgets/temperature.py
@@ -1,0 +1,65 @@
+"""Temperature slider — cold-to-warm gradient with a thin indicator."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from .slider import LargeSlider, _LARGE_INDICATOR_W, _LARGE_INNER_RX
+
+
+class TemperatureSlider(LargeSlider):
+    """A large slider for room temperature (Celsius).
+
+    The background is a horizontal gradient from cold (#4555E5) to
+    warm (#DB3232).  A thin vertical indicator marks the current value.
+
+    Args:
+        label: Display label (e.g. ``"Temperature"``).
+        value: Initial value.  Defaults to 15.
+        min_value: Minimum temperature.  Defaults to 15.
+        max_value: Maximum temperature.  Defaults to 25.
+        step: Dial-turn increment.  Defaults to 0.5.
+    """
+
+    def __init__(
+        self,
+        label: str = "Temperature",
+        *,
+        value: float | None = None,
+        min_value: float = 15,
+        max_value: float = 25,
+        step: float = 0.5,
+    ) -> None:
+        super().__init__(
+            label,
+            min_value=min_value,
+            max_value=max_value,
+            value=value,
+            unit="\u00b0C",
+            step=step,
+        )
+
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        # Gradient background: cold → warm
+        self._draw_gradient(
+            img, ix, iy, iw, ih, "#4555E5", "#DB3232", radius=_LARGE_INNER_RX
+        )
+
+        # Thin indicator
+        ind_x = ix + int((iw - _LARGE_INDICATOR_W) * self.normalized)
+        self._draw_rounded_rect(
+            draw,
+            (ind_x, iy, ind_x + _LARGE_INDICATOR_W, iy + ih),
+            radius=_LARGE_INNER_RX,
+            fill="white",
+            outline="black",
+            width=1,
+        )

--- a/src/deckboard/widgets/volume.py
+++ b/src/deckboard/widgets/volume.py
@@ -1,0 +1,58 @@
+"""Volume slider — solid fill growing from left to right."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageDraw
+
+from .slider import LargeSlider, _LARGE_INNER_RX
+
+
+class VolumeSlider(LargeSlider):
+    """A large slider that displays volume as a solid fill bar.
+
+    The filled portion grows from left to right proportionally to
+    the current value.
+
+    Args:
+        label: Display label (e.g. ``"Volume"``).
+        value: Initial value.  Defaults to 0.
+        min_value: Minimum value.  Defaults to 0.
+        max_value: Maximum value.  Defaults to 100.
+        step: Dial-turn increment.  Defaults to 1.
+    """
+
+    def __init__(
+        self,
+        label: str = "Volume",
+        *,
+        value: float | None = None,
+        min_value: float = 0,
+        max_value: float = 100,
+        step: float = 1,
+    ) -> None:
+        super().__init__(
+            label,
+            min_value=min_value,
+            max_value=max_value,
+            value=value,
+            unit="%",
+            step=step,
+        )
+
+    def _draw_bar_contents(
+        self,
+        draw: ImageDraw.ImageDraw,
+        img: Image.Image,
+        ix: int,
+        iy: int,
+        iw: int,
+        ih: int,
+    ) -> None:
+        fill_w = int(iw * self.normalized)
+        if fill_w > 0:
+            self._draw_rounded_rect(
+                draw,
+                (ix, iy, ix + fill_w, iy + ih),
+                radius=_LARGE_INNER_RX,
+                fill="white",
+            )

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -260,6 +260,21 @@ class TestDeckDispatch:
 
         await deck._dispatch(DialTurnEvent(dial=2, direction=1))
 
+    async def test_dial_turn_updates_widget_slider(self, deck):
+        """Dial turn forwards to widget sliders and triggers refresh."""
+        from deckboard.widgets.volume import VolumeSlider
+
+        p = deck.page("main")
+        w = p.widget(1)
+        slider = VolumeSlider()
+        w.add_slider(slider)
+        deck._active_page = p
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
+            await deck._dispatch(DialTurnEvent(dial=1, direction=5))
+            mock_refresh.assert_awaited_once()
+        assert slider.value == 5  # default 0 + 5
+
     async def test_dial_press_dispatches(self, deck):
         p = deck.page("main")
         handler = AsyncMock()
@@ -290,6 +305,23 @@ class TestDeckDispatch:
         deck._active_page = p
 
         await deck._dispatch(DialPressEvent(dial=3, pressed=True))
+
+    async def test_dial_press_cycles_widget_slider(self, deck):
+        """Dial press cycles active slider on the widget and triggers refresh."""
+        from deckboard.widgets.volume import VolumeSlider
+        from deckboard.widgets.brightness import BrightnessSlider
+
+        p = deck.page("main")
+        w = p.widget(0)
+        w.add_slider(VolumeSlider())
+        w.add_slider(BrightnessSlider())
+        deck._active_page = p
+
+        assert w._active_slider_index == 0
+        with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
+            await deck._dispatch(DialPressEvent(dial=0, pressed=True))
+            mock_refresh.assert_awaited_once()
+        assert w._active_slider_index == 1
 
     async def test_touch_short_dispatches(self, deck):
         p = deck.page("main")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,8 @@ class TestPublicAPI:
 
     def test_all_exports(self):
         expected = {
+            "BalanceSlider",
+            "BrightnessSlider",
             "Button",
             "Deck",
             "DeckError",
@@ -19,13 +21,20 @@ class TestPublicAPI:
             "Dial",
             "DialPressEvent",
             "DialTurnEvent",
+            "EqualizerSlider",
             "EventType",
             "IconError",
             "IconManager",
+            "KelvinSlider",
             "KeyEvent",
+            "LargeSlider",
             "Page",
+            "Slider",
+            "SmallSlider",
+            "TemperatureSlider",
             "TouchEvent",
             "TouchScreen",
+            "VolumeSlider",
             "Widget",
         }
         assert set(deckboard.__all__) == expected
@@ -87,3 +96,26 @@ class TestPublicAPI:
         from deckboard import DeviceInfo
 
         assert DeviceInfo is not None
+
+    def test_widgets_importable(self):
+        from deckboard import (
+            BalanceSlider,
+            BrightnessSlider,
+            EqualizerSlider,
+            KelvinSlider,
+            LargeSlider,
+            Slider,
+            SmallSlider,
+            TemperatureSlider,
+            VolumeSlider,
+        )
+
+        assert Slider is not None
+        assert LargeSlider is not None
+        assert SmallSlider is not None
+        assert VolumeSlider is not None
+        assert BrightnessSlider is not None
+        assert KelvinSlider is not None
+        assert TemperatureSlider is not None
+        assert EqualizerSlider is not None
+        assert BalanceSlider is not None

--- a/tests/test_touchscreen.py
+++ b/tests/test_touchscreen.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import time
+from unittest.mock import patch
+
 import pytest
 from PIL import Image
 
 from deckboard.touchscreen import TouchScreen, Widget
+from deckboard.widgets.volume import VolumeSlider
+from deckboard.widgets.brightness import BrightnessSlider
+from deckboard.widgets.equalizer import EqualizerSlider
+from deckboard.widgets.balance import BalanceSlider
 
 
 # ── Widget ──────────────────────────────────────────────────────────────
@@ -220,3 +227,232 @@ class TestTouchScreenAnyDirty:
             w.mark_clean()
         touchscreen.widget(2).set_label("changed")
         assert touchscreen.any_dirty is True
+
+
+# ── Widget.render() ─────────────────────────────────────────────────────
+
+
+class TestWidgetRender:
+    def test_classic_render_no_icon(self, widget: Widget):
+        """render() without sliders uses classic icon+label+value layout."""
+        widget.set_label("Test")
+        img = widget.render()
+        assert img.size == (200, 100)
+        assert img.mode == "RGB"
+
+    def test_classic_render_with_icon(self, widget: Widget, sample_icon):
+        img = widget.render(icon=sample_icon)
+        assert img.size == (200, 100)
+
+    def test_classic_render_blank(self, widget: Widget):
+        img = widget.render()
+        assert img.size == (200, 100)
+
+    def test_slider_render_single(self, widget: Widget):
+        vol = VolumeSlider("Volume", value=50)
+        widget.add_slider(vol)
+        img = widget.render()
+        assert img.size == (200, 100)
+        assert img.mode == "RGB"
+
+    def test_slider_render_two_large(self, widget: Widget):
+        vol = VolumeSlider("Volume", value=50)
+        bri = BrightnessSlider("Bright", value=70)
+        widget.add_slider(vol)
+        widget.add_slider(bri)
+        img = widget.render()
+        assert img.size == (200, 100)
+
+    def test_slider_render_four_small(self, widget: Widget):
+        s1 = EqualizerSlider("Sub", value=50)
+        s2 = EqualizerSlider("Bass", value=40)
+        s3 = EqualizerSlider("Treble", value=60)
+        s4 = BalanceSlider("Balance", value=50)
+        widget.add_slider(s1)
+        widget.add_slider(s2)
+        widget.add_slider(s3)
+        widget.add_slider(s4)
+        img = widget.render()
+        assert img.size == (200, 100)
+
+    def test_slider_render_ignores_icon(self, widget: Widget, sample_icon):
+        """When sliders are present, the icon argument is ignored."""
+        vol = VolumeSlider("Volume", value=50)
+        widget.add_slider(vol)
+        img_with = widget.render(icon=sample_icon)
+        img_without = widget.render()
+        # Both should produce the same slider image (icon ignored)
+        assert img_with.size == img_without.size
+
+
+# ── Widget slider sub-element management ────────────────────────────────
+
+
+class TestWidgetAddSlider:
+    def test_add_single(self, widget: Widget):
+        vol = VolumeSlider("Volume")
+        result = widget.add_slider(vol)
+        assert result is widget  # chaining
+        assert len(widget.sliders) == 1
+        assert widget.sliders[0] is vol
+
+    def test_first_is_default(self, widget: Widget):
+        vol = VolumeSlider("Volume")
+        widget.add_slider(vol)
+        assert widget.active_slider is vol
+        assert widget.active_slider_index == 0
+        assert widget._default_slider_index == 0
+
+    def test_add_multiple(self, widget: Widget):
+        s1 = VolumeSlider("Vol")
+        s2 = BrightnessSlider("Bri")
+        widget.add_slider(s1)
+        widget.add_slider(s2)
+        assert len(widget.sliders) == 2
+
+    def test_explicit_default(self, widget: Widget):
+        s1 = VolumeSlider("Vol")
+        s2 = BrightnessSlider("Bri")
+        widget.add_slider(s1)
+        widget.add_slider(s2, default=True)
+        assert widget._default_slider_index == 1
+        assert widget.active_slider_index == 1
+        assert widget.active_slider is s2
+
+    def test_marks_dirty(self, widget: Widget):
+        widget.mark_clean()
+        widget.add_slider(VolumeSlider())
+        assert widget.is_dirty is True
+
+    def test_rejects_non_slider(self, widget: Widget):
+        with pytest.raises(TypeError, match="Expected a Slider instance"):
+            widget.add_slider("not a slider")  # type: ignore[arg-type]
+
+    def test_sliders_returns_copy(self, widget: Widget):
+        vol = VolumeSlider()
+        widget.add_slider(vol)
+        sliders = widget.sliders
+        sliders.clear()  # mutating the copy
+        assert len(widget.sliders) == 1  # original unchanged
+
+
+class TestWidgetActiveSlider:
+    def test_no_sliders(self, widget: Widget):
+        assert widget.active_slider is None
+
+    def test_default_active(self, widget: Widget):
+        vol = VolumeSlider()
+        widget.add_slider(vol)
+        assert widget.active_slider is vol
+
+
+class TestWidgetSelectionTimeout:
+    def test_default_timeout(self, widget: Widget):
+        assert widget.selection_timeout == 5.0
+
+    def test_set_timeout(self, widget: Widget):
+        result = widget.set_selection_timeout(10)
+        assert result is widget
+        assert widget.selection_timeout == 10.0
+
+    def test_negative_clamped_to_zero(self, widget: Widget):
+        widget.set_selection_timeout(-3)
+        assert widget.selection_timeout == 0.0
+
+
+class TestWidgetCycleSlider:
+    def test_single_slider_noop(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.mark_clean()
+        widget.cycle_active_slider()
+        assert widget.active_slider_index == 0
+        assert widget.is_dirty is False  # no change
+
+    def test_two_sliders_cycle(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        assert widget.active_slider_index == 0
+        widget.cycle_active_slider()
+        assert widget.active_slider_index == 1
+        widget.cycle_active_slider()
+        assert widget.active_slider_index == 0  # wraps
+
+    def test_marks_dirty(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        widget.mark_clean()
+        widget.cycle_active_slider()
+        assert widget.is_dirty is True
+
+
+class TestWidgetCheckSelectionTimeout:
+    def test_no_selection_no_change(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        # No cycle happened → _last_selection_time is None
+        assert widget.check_selection_timeout() is False
+
+    def test_already_at_default(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        # Even if we set a time, active == default, so no change
+        widget._last_selection_time = time.monotonic() - 100
+        assert widget.check_selection_timeout() is False
+
+    def test_timeout_disabled(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        widget.set_selection_timeout(0)
+        widget.cycle_active_slider()
+        assert widget.check_selection_timeout() is False
+
+    def test_timeout_not_elapsed(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        widget.set_selection_timeout(999)
+        widget.cycle_active_slider()
+        assert widget.active_slider_index == 1
+        assert widget.check_selection_timeout() is False
+        assert widget.active_slider_index == 1  # not reset
+
+    def test_timeout_elapsed_resets(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        widget.set_selection_timeout(0.01)
+        widget.cycle_active_slider()
+        assert widget.active_slider_index == 1
+        # Fake time passing
+        widget._last_selection_time = time.monotonic() - 1.0
+        widget.mark_clean()
+        assert widget.check_selection_timeout() is True
+        assert widget.active_slider_index == 0  # back to default
+        assert widget._last_selection_time is None
+        assert widget.is_dirty is True
+
+
+class TestWidgetHandleDialTurn:
+    def test_no_sliders_noop(self, widget: Widget):
+        widget.handle_dial_turn(1)  # should not raise
+
+    def test_adjusts_active_slider(self, widget: Widget):
+        vol = VolumeSlider(value=50, step=5)
+        widget.add_slider(vol)
+        widget.mark_clean()
+        widget.handle_dial_turn(1)
+        assert vol.value == 55
+        assert widget.is_dirty is True
+
+    def test_adjusts_negative(self, widget: Widget):
+        vol = VolumeSlider(value=50, step=5)
+        widget.add_slider(vol)
+        widget.handle_dial_turn(-2)
+        assert vol.value == 40
+
+
+class TestWidgetHandleDialPress:
+    def test_cycles_slider(self, widget: Widget):
+        widget.add_slider(VolumeSlider())
+        widget.add_slider(BrightnessSlider())
+        assert widget.active_slider_index == 0
+        widget.handle_dial_press()
+        assert widget.active_slider_index == 1

--- a/tests/test_widgets_balance.py
+++ b/tests/test_widgets_balance.py
@@ -1,0 +1,84 @@
+"""Tests for deckboard.widgets.balance — BalanceSlider."""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+
+from deckboard.widgets.balance import BalanceSlider
+
+
+class TestBalanceSliderInit:
+    def test_defaults(self):
+        s = BalanceSlider()
+        assert s.label == "Balance"
+        assert s.min_value == 0
+        assert s.max_value == 100
+        assert s.value == 50  # centre by default
+        assert s.unit == ""
+        assert s.step == 1
+
+    def test_custom_label(self):
+        s = BalanceSlider("Pan")
+        assert s.label == "Pan"
+
+    def test_custom_value(self):
+        s = BalanceSlider(value=75)
+        assert s.value == 75
+
+
+class TestBalanceSliderRender:
+    def test_render_at_centre(self):
+        """Both speakers full when centred (value=50)."""
+        s = BalanceSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25)
+        assert img.size == (200, 100)
+
+    def test_render_full_left(self):
+        """Only left speaker at value=0."""
+        s = BalanceSlider(value=0)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25)
+
+    def test_render_full_right(self):
+        """Only right speaker at value=100."""
+        s = BalanceSlider(value=100)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25)
+
+    def test_render_active(self):
+        s = BalanceSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25, active=True)
+
+    def test_centre_line_drawn(self):
+        """The centre line should produce a dark pixel at the midpoint."""
+        s = BalanceSlider(value=50)
+        img = Image.new("RGB", (200, 100), "white")
+        s.render_onto(img, 0, 0, 200, 25)
+        # The centre of the bar area should have the black centre line
+        # bar_x starts at ~56, bar_w = 200 - 56 = 144, centre = 56 + 72 = 128
+        # This is approximate; just check a strip is dark
+        centre_x = 56 + (200 - 56) // 2
+        found_dark = False
+        for y_px in range(0, 25):
+            px = img.getpixel((centre_x, y_px))
+            if px[0] < 50 and px[1] < 50 and px[2] < 50:
+                found_dark = True
+                break
+        assert found_dark
+
+
+class TestBalanceSliderSemantics:
+    def test_normalized_at_centre(self):
+        s = BalanceSlider(value=50)
+        assert s.normalized == pytest.approx(0.5)
+
+    def test_normalized_at_full_left(self):
+        s = BalanceSlider(value=0)
+        assert s.normalized == 0.0
+
+    def test_normalized_at_full_right(self):
+        s = BalanceSlider(value=100)
+        assert s.normalized == 1.0

--- a/tests/test_widgets_brightness.py
+++ b/tests/test_widgets_brightness.py
@@ -1,0 +1,62 @@
+"""Tests for deckboard.widgets.brightness — BrightnessSlider."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from deckboard.widgets.brightness import BrightnessSlider
+
+
+class TestBrightnessSliderInit:
+    def test_defaults(self):
+        s = BrightnessSlider()
+        assert s.label == "Brightness"
+        assert s.min_value == 0
+        assert s.max_value == 100
+        assert s.value == 0
+        assert s.unit == "%"
+        assert s.step == 1
+
+    def test_custom_params(self):
+        s = BrightnessSlider("Screen", value=80, min_value=5, max_value=100, step=5)
+        assert s.label == "Screen"
+        assert s.value == 80
+
+
+class TestBrightnessSliderRender:
+    def test_render_at_zero(self):
+        s = BrightnessSlider(value=0)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_at_half(self):
+        s = BrightnessSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+        assert img.size == (200, 100)
+
+    def test_render_at_max(self):
+        s = BrightnessSlider(value=100)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_active(self):
+        s = BrightnessSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50, active=True)
+
+    def test_has_gradient(self):
+        """The gradient should produce non-black pixels in the bar area."""
+        s = BrightnessSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 50, 200, 50)
+        # Check that there are some non-black pixels in the lower area
+        has_non_black = False
+        for x_px in range(200):
+            for y_px in range(50, 100):
+                if img.getpixel((x_px, y_px)) != (0, 0, 0):
+                    has_non_black = True
+                    break
+            if has_non_black:
+                break
+        assert has_non_black

--- a/tests/test_widgets_equalizer.py
+++ b/tests/test_widgets_equalizer.py
@@ -1,0 +1,46 @@
+"""Tests for deckboard.widgets.equalizer — EqualizerSlider."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from deckboard.widgets.equalizer import EqualizerSlider
+
+
+class TestEqualizerSliderInit:
+    def test_defaults(self):
+        s = EqualizerSlider()
+        assert s.label == "EQ"
+        assert s.min_value == 0
+        assert s.max_value == 100
+        assert s.value == 0
+        assert s.unit == "%"
+        assert s.step == 1
+
+    def test_custom_params(self):
+        s = EqualizerSlider("Bass", value=60, min_value=0, max_value=100, step=2)
+        assert s.label == "Bass"
+        assert s.value == 60
+
+
+class TestEqualizerSliderRender:
+    def test_render_at_zero(self):
+        s = EqualizerSlider("Sub", value=0)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25)
+
+    def test_render_at_half(self):
+        s = EqualizerSlider("Bass", value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25)
+        assert img.size == (200, 100)
+
+    def test_render_at_max(self):
+        s = EqualizerSlider("Treble", value=100)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25)
+
+    def test_render_active(self):
+        s = EqualizerSlider("Sub", value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 25, active=True)

--- a/tests/test_widgets_kelvin.py
+++ b/tests/test_widgets_kelvin.py
@@ -1,0 +1,50 @@
+"""Tests for deckboard.widgets.kelvin — KelvinSlider."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from deckboard.widgets.kelvin import KelvinSlider
+
+
+class TestKelvinSliderInit:
+    def test_defaults(self):
+        s = KelvinSlider()
+        assert s.label == "Kelvin"
+        assert s.min_value == 2000
+        assert s.max_value == 6500
+        assert s.value == 2000
+        assert s.unit == "K"
+        assert s.step == 100
+
+    def test_custom_params(self):
+        s = KelvinSlider("Light Temp", value=4000, min_value=2700, max_value=6500)
+        assert s.label == "Light Temp"
+        assert s.value == 4000
+
+
+class TestKelvinSliderRender:
+    def test_render_at_min(self):
+        s = KelvinSlider(value=2000)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_at_mid(self):
+        s = KelvinSlider(value=4000)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+        assert img.size == (200, 100)
+
+    def test_render_at_max(self):
+        s = KelvinSlider(value=6500)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_active(self):
+        s = KelvinSlider(value=3000)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50, active=True)
+
+    def test_format_value(self):
+        s = KelvinSlider(value=3000)
+        assert s.format_value() == "3000K"

--- a/tests/test_widgets_slider.py
+++ b/tests/test_widgets_slider.py
@@ -1,0 +1,257 @@
+"""Tests for deckboard.widgets.slider — Slider, LargeSlider, SmallSlider."""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+
+from deckboard.widgets.slider import LargeSlider, Slider, SmallSlider
+
+
+# ── Concrete test subclasses (since the bases are abstract) ──────────────
+
+
+class _ConcreteLargeSlider(LargeSlider):
+    """Minimal concrete LargeSlider for testing."""
+
+    def _draw_bar_contents(self, draw, img, ix, iy, iw, ih):
+        pass  # No-op — just test the frame/layout
+
+
+class _ConcreteSmallSlider(SmallSlider):
+    """Minimal concrete SmallSlider for testing."""
+
+    def _draw_bar_contents(self, draw, img, ix, iy, iw, ih):
+        pass
+
+
+# ── Slider base class ────────────────────────────────────────────────────
+
+
+class TestSliderInit:
+    def test_defaults(self):
+        s = _ConcreteLargeSlider("Test")
+        assert s.label == "Test"
+        assert s.value == 0
+        assert s.min_value == 0
+        assert s.max_value == 100
+        assert s.unit == "%"
+        assert s.step == 1
+
+    def test_custom_params(self):
+        s = _ConcreteLargeSlider(
+            "Vol",
+            min_value=10,
+            max_value=50,
+            value=30,
+            unit="dB",
+            step=2,
+        )
+        assert s.label == "Vol"
+        assert s.value == 30
+        assert s.min_value == 10
+        assert s.max_value == 50
+        assert s.unit == "dB"
+        assert s.step == 2
+
+    def test_value_defaults_to_min(self):
+        s = _ConcreteLargeSlider("X", min_value=20, max_value=80)
+        assert s.value == 20
+
+
+class TestSliderNormalized:
+    def test_at_min(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=0)
+        assert s.normalized == 0.0
+
+    def test_at_max(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=100)
+        assert s.normalized == 1.0
+
+    def test_midpoint(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        assert s.normalized == pytest.approx(0.5)
+
+    def test_custom_range(self):
+        s = _ConcreteLargeSlider("X", min_value=2000, max_value=6500, value=3125)
+        expected = (3125 - 2000) / (6500 - 2000)
+        assert s.normalized == pytest.approx(expected)
+
+    def test_zero_range(self):
+        s = _ConcreteLargeSlider("X", min_value=50, max_value=50, value=50)
+        assert s.normalized == 0.0
+
+    def test_negative_range(self):
+        s = _ConcreteLargeSlider("X", min_value=100, max_value=50, value=75)
+        assert s.normalized == 0.0  # span <= 0
+
+
+class TestSliderSetValue:
+    def test_set_normal(self):
+        s = _ConcreteLargeSlider("X")
+        s.set_value(42)
+        assert s.value == 42
+
+    def test_clamp_low(self):
+        s = _ConcreteLargeSlider("X", min_value=10, max_value=90)
+        s.set_value(-5)
+        assert s.value == 10
+
+    def test_clamp_high(self):
+        s = _ConcreteLargeSlider("X", min_value=10, max_value=90)
+        s.set_value(200)
+        assert s.value == 90
+
+
+class TestSliderAdjust:
+    def test_positive_direction(self):
+        s = _ConcreteLargeSlider("X", value=50, step=5)
+        s.adjust(1)
+        assert s.value == 55
+
+    def test_negative_direction(self):
+        s = _ConcreteLargeSlider("X", value=50, step=5)
+        s.adjust(-1)
+        assert s.value == 45
+
+    def test_clamped_at_max(self):
+        s = _ConcreteLargeSlider("X", value=98, max_value=100, step=5)
+        s.adjust(1)
+        assert s.value == 100
+
+    def test_clamped_at_min(self):
+        s = _ConcreteLargeSlider("X", value=2, min_value=0, step=5)
+        s.adjust(-1)
+        assert s.value == 0
+
+    def test_multi_step(self):
+        s = _ConcreteLargeSlider("X", value=50, step=5)
+        s.adjust(3)
+        assert s.value == 65
+
+
+class TestSliderFormatValue:
+    def test_integer_percent(self):
+        s = _ConcreteLargeSlider("X", value=50, unit="%")
+        assert s.format_value() == "50%"
+
+    def test_float_value(self):
+        s = _ConcreteLargeSlider("X", value=20.5, unit="\u00b0C")
+        assert s.format_value() == "20.5\u00b0C"
+
+    def test_kelvin(self):
+        s = _ConcreteLargeSlider("X", value=3000, unit="K")
+        assert s.format_value() == "3000K"
+
+    def test_no_unit(self):
+        s = _ConcreteLargeSlider("X", value=42, unit="")
+        assert s.format_value() == "42"
+
+
+class TestSliderDrawRoundedRect:
+    def test_draws_without_error(self):
+        img = Image.new("RGB", (200, 100), "black")
+        from PIL import ImageDraw
+
+        draw = ImageDraw.Draw(img)
+        Slider._draw_rounded_rect(
+            draw,
+            (10, 10, 190, 90),
+            radius=5,
+            fill="white",
+            outline="red",
+        )
+        # No assertion on pixels — just ensure it doesn't raise
+
+
+class TestSliderDrawGradient:
+    def test_gradient_basic(self):
+        img = Image.new("RGB", (200, 100), "black")
+        Slider._draw_gradient(img, 10, 10, 50, 20, "#000000", "#FFFFFF")
+        # Check left edge is dark, right edge is bright
+        left_pixel = img.getpixel((10, 20))
+        right_pixel = img.getpixel((59, 20))
+        assert left_pixel[0] < right_pixel[0]
+
+    def test_gradient_zero_width(self):
+        img = Image.new("RGB", (200, 100), "black")
+        # Should not raise
+        Slider._draw_gradient(img, 10, 10, 0, 20, "#000000", "#FFFFFF")
+
+    def test_gradient_zero_height(self):
+        img = Image.new("RGB", (200, 100), "black")
+        Slider._draw_gradient(img, 10, 10, 20, 0, "#000000", "#FFFFFF")
+
+    def test_gradient_single_pixel_wide(self):
+        img = Image.new("RGB", (200, 100), "black")
+        Slider._draw_gradient(img, 10, 10, 1, 10, "#FF0000", "#0000FF")
+
+
+# ── LargeSlider ─────────────────────────────────────────────────────────
+
+
+class TestLargeSliderRender:
+    def test_renders_200x100_image(self):
+        s = _ConcreteLargeSlider("Volume", value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=50)
+        assert img.size == (200, 100)
+
+    def test_renders_with_active_highlight(self):
+        s = _ConcreteLargeSlider("Volume", value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=50, active=True)
+        assert img.size == (200, 100)
+
+    def test_renders_at_min(self):
+        s = _ConcreteLargeSlider("Volume", value=0)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=50)
+
+    def test_renders_at_max(self):
+        s = _ConcreteLargeSlider("Volume", value=100)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=50)
+
+
+# ── SmallSlider ──────────────────────────────────────────────────────────
+
+
+class TestSmallSliderRender:
+    def test_renders_200x100_image(self):
+        s = _ConcreteSmallSlider("Bass", value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=25)
+        assert img.size == (200, 100)
+
+    def test_renders_with_active_highlight(self):
+        s = _ConcreteSmallSlider("Bass", value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=25, active=True)
+
+    def test_renders_at_min(self):
+        s = _ConcreteSmallSlider("Bass", value=0)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=25)
+
+    def test_renders_at_max(self):
+        s = _ConcreteSmallSlider("Bass", value=100)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, x=0, y=0, width=200, height=25)
+
+
+# ── Abstract class guards ────────────────────────────────────────────────
+
+
+class TestSliderAbstractGuards:
+    def test_cannot_instantiate_slider(self):
+        with pytest.raises(TypeError):
+            Slider("X")  # type: ignore[abstract]
+
+    def test_cannot_instantiate_large_slider(self):
+        with pytest.raises(TypeError):
+            LargeSlider("X")  # type: ignore[abstract]
+
+    def test_cannot_instantiate_small_slider(self):
+        with pytest.raises(TypeError):
+            SmallSlider("X")  # type: ignore[abstract]

--- a/tests/test_widgets_temperature.py
+++ b/tests/test_widgets_temperature.py
@@ -1,0 +1,54 @@
+"""Tests for deckboard.widgets.temperature — TemperatureSlider."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from deckboard.widgets.temperature import TemperatureSlider
+
+
+class TestTemperatureSliderInit:
+    def test_defaults(self):
+        s = TemperatureSlider()
+        assert s.label == "Temperature"
+        assert s.min_value == 15
+        assert s.max_value == 25
+        assert s.value == 15
+        assert s.unit == "\u00b0C"
+        assert s.step == 0.5
+
+    def test_custom_params(self):
+        s = TemperatureSlider("Room", value=21, min_value=10, max_value=30, step=1)
+        assert s.label == "Room"
+        assert s.value == 21
+
+
+class TestTemperatureSliderRender:
+    def test_render_at_min(self):
+        s = TemperatureSlider(value=15)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_at_mid(self):
+        s = TemperatureSlider(value=20)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+        assert img.size == (200, 100)
+
+    def test_render_at_max(self):
+        s = TemperatureSlider(value=25)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_active(self):
+        s = TemperatureSlider(value=21)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50, active=True)
+
+    def test_format_value_integer(self):
+        s = TemperatureSlider(value=21)
+        assert s.format_value() == "21\u00b0C"
+
+    def test_format_value_half(self):
+        s = TemperatureSlider(value=21.5)
+        assert s.format_value() == "21.5\u00b0C"

--- a/tests/test_widgets_volume.py
+++ b/tests/test_widgets_volume.py
@@ -1,0 +1,61 @@
+"""Tests for deckboard.widgets.volume — VolumeSlider."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from deckboard.widgets.volume import VolumeSlider
+
+
+class TestVolumeSliderInit:
+    def test_defaults(self):
+        s = VolumeSlider()
+        assert s.label == "Volume"
+        assert s.min_value == 0
+        assert s.max_value == 100
+        assert s.value == 0
+        assert s.unit == "%"
+        assert s.step == 1
+
+    def test_custom_label(self):
+        s = VolumeSlider("Master")
+        assert s.label == "Master"
+
+    def test_custom_value(self):
+        s = VolumeSlider(value=75)
+        assert s.value == 75
+
+    def test_custom_range(self):
+        s = VolumeSlider(min_value=10, max_value=80, value=50, step=2)
+        assert s.min_value == 10
+        assert s.max_value == 80
+        assert s.value == 50
+        assert s.step == 2
+
+
+class TestVolumeSliderRender:
+    def test_render_at_zero(self):
+        s = VolumeSlider(value=0)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+        # At zero, most of the bar area should still be black
+
+    def test_render_at_half(self):
+        s = VolumeSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+        assert img.size == (200, 100)
+
+    def test_render_at_max(self):
+        s = VolumeSlider(value=100)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50)
+
+    def test_render_active(self):
+        s = VolumeSlider(value=50)
+        img = Image.new("RGB", (200, 100), "black")
+        s.render_onto(img, 0, 0, 200, 50, active=True)
+
+    def test_format_value(self):
+        s = VolumeSlider(value=75)
+        assert s.format_value() == "75%"


### PR DESCRIPTION
## Summary

- Add a widgets subpackage with composable slider sub-elements (VolumeSlider, BrightnessSlider, KelvinSlider, TemperatureSlider, EqualizerSlider, BalanceSlider) that attach to touchscreen Widget zones via widget.add_slider()
- Wire dial turn/press events in deck.py._dispatch() so the physical dial below each zone adjusts the active slider value (turn) and cycles between multiple sliders (press), with auto-timeout back to default
- Refactor Widget to own its render() method, replacing the centralised render_widget_image() call in deck.py

## Slider hierarchy

- Slider (abstract base)
  - LargeSlider (full-width bar, ~195px)
    - VolumeSlider -- solid fill, 0-100%
    - BrightnessSlider -- solid fill, 0-100%
    - BalanceSlider -- center-out fill, 0-100 (50 = center)
  - SmallSlider (label + bar, label 54px, bar 137px)
    - KelvinSlider -- gradient 2700K-6500K
    - TemperatureSlider -- gradient indicator
    - EqualizerSlider -- solid fill, -12 to +12 dB

## Key behaviours

- Active slider gets a highlighted frame stroke (#5599ff) when multiple sliders share a zone
- Selection auto-resets to default slider after configurable timeout (default 5s)
- Widget.render(icon=...) renders sliders when present, falls back to label/value rendering otherwise

## Testing

- **406 tests**, **99.90% coverage** (1 unreachable defensive guard line)
- New test files for every widget type + extended test_touchscreen.py and test_deck.py
- All hardware interactions fully mocked