### PR TITLE
Add touchscreen margins and widget gaps for viewing angle

### DIFF
--- a/src/deckboard/image.py
+++ b/src/deckboard/image.py
@@ -13,8 +13,23 @@ ICON_PADDING = (KEY_SIZE[0] - ICON_SIZE) // 2  # 20px
 
 TOUCHSCREEN_WIDTH = 800
 TOUCHSCREEN_HEIGHT = 100
-WIDGET_WIDTH = 200  # 800 / 4 zones
 WIDGET_COUNT = 4
+
+# Touchscreen margins — the bottom of the physical screen is partially
+# hidden by the viewing angle, so we inset the usable area.
+MARGIN_TOP = 4
+MARGIN_BOTTOM = 18
+MARGIN_LEFT = 4
+MARGIN_RIGHT = 4
+WIDGET_GAP = 4  # horizontal gap between adjacent widgets
+
+# Usable area after margins
+USABLE_WIDTH = TOUCHSCREEN_WIDTH - MARGIN_LEFT - MARGIN_RIGHT  # 792
+USABLE_HEIGHT = TOUCHSCREEN_HEIGHT - MARGIN_TOP - MARGIN_BOTTOM  # 78
+
+# Each widget size: (usable_width - 3 gaps) / 4
+WIDGET_WIDTH = (USABLE_WIDTH - (WIDGET_COUNT - 1) * WIDGET_GAP) // WIDGET_COUNT  # 195
+WIDGET_HEIGHT = USABLE_HEIGHT  # 78
 
 # Font for labels/values - use default bitmap font (always available)
 _font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
@@ -111,29 +126,29 @@ def render_widget_image(
     value: str | None = None,
     background: str = "black",
 ) -> Image.Image:
-    """Render a single 200x100 widget zone image (PIL Image, not encoded).
+    """Render a single widget zone image (PIL Image, not encoded).
 
-    Layout (200x100):
-      - Left side: 60x60 icon (centered vertically, 10px from left)
+    Layout (195x78):
+      - Left side: 50x50 icon (centered vertically, 8px from left)
       - Right side: label on top, value below
 
     Args:
-        icon: RGBA icon image (will be resized to 60x60).
+        icon: RGBA icon image (will be resized to 50x50).
         label: Primary text label.
         value: Secondary value text.
         background: Background color.
 
     Returns:
-        PIL Image (RGB, 200x100).
+        PIL Image (RGB, WIDGET_WIDTH x WIDGET_HEIGHT).
     """
-    img = Image.new("RGB", (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT), background)
+    img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), background)
     draw = ImageDraw.Draw(img)
     font = get_font()
     small_font = get_small_font()
 
-    widget_icon_size = 60
-    icon_x = 10
-    icon_y = (TOUCHSCREEN_HEIGHT - widget_icon_size) // 2  # vertically centered
+    widget_icon_size = 50
+    icon_x = 8
+    icon_y = (WIDGET_HEIGHT - widget_icon_size) // 2  # vertically centered
 
     if icon is not None:
         sized = icon.resize((widget_icon_size, widget_icon_size), Image.LANCZOS)
@@ -142,16 +157,16 @@ def render_widget_image(
         else:
             img.paste(sized, (icon_x, icon_y))
 
-    text_x = icon_x + widget_icon_size + 12  # right of icon
+    text_x = icon_x + widget_icon_size + 10  # right of icon
     if label and value:
         # Label at top, value below
-        draw.text((text_x, 25), label, fill="white", font=font)
-        draw.text((text_x, 50), value, fill="#aaaaaa", font=small_font)
+        draw.text((text_x, 18), label, fill="white", font=font)
+        draw.text((text_x, 40), value, fill="#aaaaaa", font=small_font)
     elif label:
         # Label centered vertically
-        draw.text((text_x, 38), label, fill="white", font=font)
+        draw.text((text_x, 30), label, fill="white", font=font)
     elif value:
-        draw.text((text_x, 38), value, fill="#aaaaaa", font=small_font)
+        draw.text((text_x, 30), value, fill="#aaaaaa", font=small_font)
 
     return img
 
@@ -159,8 +174,11 @@ def render_widget_image(
 def compose_touchscreen(widgets: list[Image.Image | None]) -> bytes:
     """Compose 4 widget images into a single 800x100 touchscreen JPEG.
 
+    Widgets are placed within the usable area defined by the margins,
+    separated by ``WIDGET_GAP`` pixels.
+
     Args:
-        widgets: List of up to 4 PIL Images (200x100 each).
+        widgets: List of up to 4 PIL Images (WIDGET_WIDTH x WIDGET_HEIGHT each).
                  None entries render as black.
 
     Returns:
@@ -172,7 +190,8 @@ def compose_touchscreen(widgets: list[Image.Image | None]) -> bytes:
         if i >= WIDGET_COUNT:
             break
         if widget_img is not None:
-            img.paste(widget_img, (i * WIDGET_WIDTH, 0))
+            x = MARGIN_LEFT + i * (WIDGET_WIDTH + WIDGET_GAP)
+            img.paste(widget_img, (x, MARGIN_TOP))
 
     return _encode_jpeg(img)
 

--- a/src/deckboard/touchscreen.py
+++ b/src/deckboard/touchscreen.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from PIL import Image
 
-from .image import WIDGET_COUNT, render_widget_image
+from .image import WIDGET_COUNT, WIDGET_HEIGHT, WIDGET_WIDTH, render_widget_image
 from .types import AsyncHandler
 
 if TYPE_CHECKING:
@@ -18,10 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 class Widget:
-    """Represents a single touchscreen zone (200x100px) under a dial.
+    """Represents a single touchscreen zone (195x78px) under a dial.
 
     The Stream Deck+ touchscreen (800x100) is divided into 4 zones,
-    each aligned with one of the 4 dials.
+    each aligned with one of the 4 dials.  A margin is applied around
+    the usable area (top=4, bottom=18, left=4, right=4) and widgets
+    are separated by a 4px gap, giving each zone 195x78 usable pixels.
 
     Usage::
 
@@ -271,7 +273,7 @@ class Widget:
     # -- Rendering ---------------------------------------------------------
 
     def render(self, icon: Image.Image | None = None) -> Image.Image:
-        """Render this widget zone as a 200x100 PIL Image.
+        """Render this widget zone as a WIDGET_WIDTH x WIDGET_HEIGHT PIL Image.
 
         If sliders have been added via :meth:`add_slider`, they are
         rendered instead of the default icon/label/value layout.
@@ -280,7 +282,7 @@ class Widget:
             icon: Pre-fetched icon image (used by the classic layout).
 
         Returns:
-            A 200x100 RGB :class:`~PIL.Image.Image`.
+            A WIDGET_WIDTH x WIDGET_HEIGHT RGB :class:`~PIL.Image.Image`.
         """
         if self._sliders:
             return self._render_with_sliders()
@@ -292,16 +294,14 @@ class Widget:
 
     def _render_with_sliders(self) -> Image.Image:
         """Compose all slider sub-elements into a single widget image."""
-        from .image import TOUCHSCREEN_HEIGHT, WIDGET_WIDTH
-
-        img = Image.new("RGB", (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
         if not self._sliders:
             return img
 
         self.check_selection_timeout()
 
         count = len(self._sliders)
-        slot_height = TOUCHSCREEN_HEIGHT // count
+        slot_height = WIDGET_HEIGHT // count
         for i, slider in enumerate(self._sliders):
             y = i * slot_height
             active = i == self._active_slider_index and count > 1

--- a/src/deckboard/types.py
+++ b/src/deckboard/types.py
@@ -55,8 +55,19 @@ class TouchEvent:
 
     @property
     def zone(self) -> int:
-        """Which widget zone (0-3) this touch falls in, based on x position."""
-        return min(self.x // 200, 3)
+        """Which widget zone (0-3) this touch falls in, based on x position.
+
+        Accounts for left margin and inter-widget gaps so that touches
+        map correctly to the inset widget layout.
+        """
+        from .image import MARGIN_LEFT, WIDGET_GAP, WIDGET_WIDTH
+
+        # Shift x into the usable coordinate space
+        rel = self.x - MARGIN_LEFT
+        # Each zone spans WIDGET_WIDTH pixels plus the gap to its right
+        stride = WIDGET_WIDTH + WIDGET_GAP
+        zone = rel // stride
+        return max(0, min(zone, 3))
 
 
 # Union of all event types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from deckboard.button import Button
 from deckboard.dial import Dial
 from deckboard.icon import IconManager
 from deckboard.page import Page
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.touchscreen import TouchScreen, Widget
 
 
@@ -66,8 +67,8 @@ def sample_rgb_icon():
 
 @pytest.fixture
 def sample_widget_image():
-    """A 200x100 RGB test image for widgets."""
-    return Image.new("RGB", (200, 100), (0, 0, 255))
+    """A WIDGET_WIDTH x WIDGET_HEIGHT RGB test image for widgets."""
+    return Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), (0, 0, 255))
 
 
 @pytest.fixture

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -350,13 +350,13 @@ class TestDeckDispatch:
         await deck._dispatch(
             TouchEvent(
                 event_type=EventType.TOUCH_DRAG,
-                x=400,
+                x=450,
                 y=20,
-                x_out=500,
+                x_out=550,
                 y_out=80,
             )
         )
-        handler.assert_awaited_once_with(400, 20, 500, 80)
+        handler.assert_awaited_once_with(450, 20, 550, 80)
 
     async def test_touch_no_handler(self, deck):
         p = deck.page("main")

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -13,6 +13,7 @@ from deckboard.image import (
     TOUCHSCREEN_HEIGHT,
     TOUCHSCREEN_WIDTH,
     WIDGET_COUNT,
+    WIDGET_HEIGHT,
     WIDGET_WIDTH,
     _encode_jpeg,
     _get_font,
@@ -154,32 +155,32 @@ class TestRenderWidgetImage:
     def test_blank_returns_image(self):
         result = render_widget_image()
         assert isinstance(result, Image.Image)
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
         assert result.mode == "RGB"
 
     def test_with_icon(self, sample_icon):
         result = render_widget_image(icon=sample_icon)
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_with_rgb_icon(self, sample_rgb_icon):
         result = render_widget_image(icon=sample_rgb_icon)
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_with_label_only(self):
         result = render_widget_image(label="Volume")
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_with_value_only(self):
         result = render_widget_image(value="75%")
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_with_label_and_value(self):
         result = render_widget_image(label="Volume", value="75%")
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_with_all(self, sample_icon):
         result = render_widget_image(icon=sample_icon, label="Vol", value="50%")
-        assert result.size == (WIDGET_WIDTH, TOUCHSCREEN_HEIGHT)
+        assert result.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
 
 # ── compose_touchscreen ─────────────────────────────────────────────────

--- a/tests/test_touchscreen.py
+++ b/tests/test_touchscreen.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.touchscreen import TouchScreen, Widget
 from deckboard.widgets.volume import VolumeSlider
 from deckboard.widgets.brightness import BrightnessSlider
@@ -100,7 +101,7 @@ class TestWidgetClear:
         widget.set_icon("mdi:x")
         widget.set_label("L")
         widget.set_value("V")
-        widget.set_rendered(Image.new("RGB", (200, 100)))
+        widget.set_rendered(Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT)))
         widget.clear()
         assert widget.icon_name is None
         assert widget.label is None
@@ -168,7 +169,7 @@ class TestWidgetEventHandlers:
 
 class TestWidgetRendering:
     def test_set_rendered(self, widget: Widget):
-        img = Image.new("RGB", (200, 100))
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT))
         widget.set_rendered(img)
         assert widget.rendered is img
         assert widget.is_dirty is False
@@ -237,22 +238,22 @@ class TestWidgetRender:
         """render() without sliders uses classic icon+label+value layout."""
         widget.set_label("Test")
         img = widget.render()
-        assert img.size == (200, 100)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
         assert img.mode == "RGB"
 
     def test_classic_render_with_icon(self, widget: Widget, sample_icon):
         img = widget.render(icon=sample_icon)
-        assert img.size == (200, 100)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_classic_render_blank(self, widget: Widget):
         img = widget.render()
-        assert img.size == (200, 100)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_slider_render_single(self, widget: Widget):
         vol = VolumeSlider("Volume", value=50)
         widget.add_slider(vol)
         img = widget.render()
-        assert img.size == (200, 100)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
         assert img.mode == "RGB"
 
     def test_slider_render_two_large(self, widget: Widget):
@@ -261,7 +262,7 @@ class TestWidgetRender:
         widget.add_slider(vol)
         widget.add_slider(bri)
         img = widget.render()
-        assert img.size == (200, 100)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_slider_render_four_small(self, widget: Widget):
         s1 = EqualizerSlider("Sub", value=50)
@@ -273,7 +274,7 @@ class TestWidgetRender:
         widget.add_slider(s3)
         widget.add_slider(s4)
         img = widget.render()
-        assert img.size == (200, 100)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_slider_render_ignores_icon(self, widget: Widget, sample_icon):
         """When sliders are present, the icon argument is ignored."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -131,26 +131,29 @@ class TestTouchEvent:
             e.x = 5  # type: ignore[misc]
 
     def test_zone_first_widget(self):
-        """x in [0, 199] -> zone 0."""
+        """Touches within the first widget zone (left margin to end of widget 0)."""
+        # Left edge of screen (within left margin) still maps to zone 0
         assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=0, y=0).zone == 0
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=199, y=0).zone == 0
+        # Inside widget 0 area
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=4, y=0).zone == 0
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=198, y=0).zone == 0
 
     def test_zone_second_widget(self):
-        """x in [200, 399] -> zone 1."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=200, y=0).zone == 1
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=399, y=0).zone == 1
+        """Touches within the second widget zone."""
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=203, y=0).zone == 1
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=397, y=0).zone == 1
 
     def test_zone_third_widget(self):
-        """x in [400, 599] -> zone 2."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=400, y=0).zone == 2
+        """Touches within the third widget zone."""
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=402, y=0).zone == 2
 
     def test_zone_fourth_widget(self):
-        """x in [600, 799] -> zone 3."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=600, y=0).zone == 3
+        """Touches within the fourth widget zone."""
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=601, y=0).zone == 3
         assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=799, y=0).zone == 3
 
     def test_zone_capped_at_3(self):
-        """x >= 800 should still return zone 3 (capped by min(..., 3))."""
+        """x >= 800 should still return zone 3 (capped)."""
         assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=1000, y=0).zone == 3
         assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=800, y=0).zone == 3
 

--- a/tests/test_widgets_balance.py
+++ b/tests/test_widgets_balance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.balance import BalanceSlider
 
 
@@ -31,38 +32,38 @@ class TestBalanceSliderRender:
     def test_render_at_centre(self):
         """Both speakers full when centred (value=50)."""
         s = BalanceSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_render_full_left(self):
         """Only left speaker at value=0."""
         s = BalanceSlider(value=0)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4)
 
     def test_render_full_right(self):
         """Only right speaker at value=100."""
         s = BalanceSlider(value=100)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4)
 
     def test_render_active(self):
         s = BalanceSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4, active=True)
 
     def test_centre_line_drawn(self):
         """The centre line should produce a dark pixel at the midpoint."""
         s = BalanceSlider(value=50)
-        img = Image.new("RGB", (200, 100), "white")
-        s.render_onto(img, 0, 0, 200, 25)
+        slot_h = WIDGET_HEIGHT // 4
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "white")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, slot_h)
         # The centre of the bar area should have the black centre line
-        # bar_x starts at ~56, bar_w = 200 - 56 = 144, centre = 56 + 72 = 128
-        # This is approximate; just check a strip is dark
-        centre_x = 56 + (200 - 56) // 2
+        # bar_x starts at ~56, bar_w = WIDGET_WIDTH - 56, centre ≈ 56 + bar_w/2
+        centre_x = 56 + (WIDGET_WIDTH - 56) // 2
         found_dark = False
-        for y_px in range(0, 25):
+        for y_px in range(0, slot_h):
             px = img.getpixel((centre_x, y_px))
             if px[0] < 50 and px[1] < 50 and px[2] < 50:
                 found_dark = True

--- a/tests/test_widgets_brightness.py
+++ b/tests/test_widgets_brightness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.brightness import BrightnessSlider
 
 
@@ -26,34 +27,35 @@ class TestBrightnessSliderInit:
 class TestBrightnessSliderRender:
     def test_render_at_zero(self):
         s = BrightnessSlider(value=0)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_at_half(self):
         s = BrightnessSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_render_at_max(self):
         s = BrightnessSlider(value=100)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_active(self):
         s = BrightnessSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2, active=True)
 
     def test_has_gradient(self):
         """The gradient should produce non-black pixels in the bar area."""
         s = BrightnessSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 50, 200, 50)
+        slot_h = WIDGET_HEIGHT // 2
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, slot_h, WIDGET_WIDTH, slot_h)
         # Check that there are some non-black pixels in the lower area
         has_non_black = False
-        for x_px in range(200):
-            for y_px in range(50, 100):
+        for x_px in range(WIDGET_WIDTH):
+            for y_px in range(slot_h, WIDGET_HEIGHT):
                 if img.getpixel((x_px, y_px)) != (0, 0, 0):
                     has_non_black = True
                     break

--- a/tests/test_widgets_equalizer.py
+++ b/tests/test_widgets_equalizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.equalizer import EqualizerSlider
 
 
@@ -26,21 +27,21 @@ class TestEqualizerSliderInit:
 class TestEqualizerSliderRender:
     def test_render_at_zero(self):
         s = EqualizerSlider("Sub", value=0)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4)
 
     def test_render_at_half(self):
         s = EqualizerSlider("Bass", value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_render_at_max(self):
         s = EqualizerSlider("Treble", value=100)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4)
 
     def test_render_active(self):
         s = EqualizerSlider("Sub", value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 25, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 4, active=True)

--- a/tests/test_widgets_kelvin.py
+++ b/tests/test_widgets_kelvin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.kelvin import KelvinSlider
 
 
@@ -26,24 +27,24 @@ class TestKelvinSliderInit:
 class TestKelvinSliderRender:
     def test_render_at_min(self):
         s = KelvinSlider(value=2000)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_at_mid(self):
         s = KelvinSlider(value=4000)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_render_at_max(self):
         s = KelvinSlider(value=6500)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_active(self):
         s = KelvinSlider(value=3000)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2, active=True)
 
     def test_format_value(self):
         s = KelvinSlider(value=3000)

--- a/tests/test_widgets_slider.py
+++ b/tests/test_widgets_slider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.slider import LargeSlider, Slider, SmallSlider
 
 
@@ -150,13 +151,13 @@ class TestSliderFormatValue:
 
 class TestSliderDrawRoundedRect:
     def test_draws_without_error(self):
-        img = Image.new("RGB", (200, 100), "black")
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
         from PIL import ImageDraw
 
         draw = ImageDraw.Draw(img)
         Slider._draw_rounded_rect(
             draw,
-            (10, 10, 190, 90),
+            (10, 10, WIDGET_WIDTH - 10, WIDGET_HEIGHT - 10),
             radius=5,
             fill="white",
             outline="red",
@@ -166,7 +167,7 @@ class TestSliderDrawRoundedRect:
 
 class TestSliderDrawGradient:
     def test_gradient_basic(self):
-        img = Image.new("RGB", (200, 100), "black")
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
         Slider._draw_gradient(img, 10, 10, 50, 20, "#000000", "#FFFFFF")
         # Check left edge is dark, right edge is bright
         left_pixel = img.getpixel((10, 20))
@@ -174,16 +175,16 @@ class TestSliderDrawGradient:
         assert left_pixel[0] < right_pixel[0]
 
     def test_gradient_zero_width(self):
-        img = Image.new("RGB", (200, 100), "black")
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
         # Should not raise
         Slider._draw_gradient(img, 10, 10, 0, 20, "#000000", "#FFFFFF")
 
     def test_gradient_zero_height(self):
-        img = Image.new("RGB", (200, 100), "black")
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
         Slider._draw_gradient(img, 10, 10, 20, 0, "#000000", "#FFFFFF")
 
     def test_gradient_single_pixel_wide(self):
-        img = Image.new("RGB", (200, 100), "black")
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
         Slider._draw_gradient(img, 10, 10, 1, 10, "#FF0000", "#0000FF")
 
 
@@ -191,53 +192,57 @@ class TestSliderDrawGradient:
 
 
 class TestLargeSliderRender:
-    def test_renders_200x100_image(self):
+    def test_renders_widget_size_image(self):
         s = _ConcreteLargeSlider("Volume", value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=50)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 2)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_renders_with_active_highlight(self):
         s = _ConcreteLargeSlider("Volume", value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=50, active=True)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(
+            img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 2, active=True
+        )
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_renders_at_min(self):
         s = _ConcreteLargeSlider("Volume", value=0)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 2)
 
     def test_renders_at_max(self):
         s = _ConcreteLargeSlider("Volume", value=100)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 2)
 
 
 # ── SmallSlider ──────────────────────────────────────────────────────────
 
 
 class TestSmallSliderRender:
-    def test_renders_200x100_image(self):
+    def test_renders_widget_size_image(self):
         s = _ConcreteSmallSlider("Bass", value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=25)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 4)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_renders_with_active_highlight(self):
         s = _ConcreteSmallSlider("Bass", value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=25, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(
+            img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 4, active=True
+        )
 
     def test_renders_at_min(self):
         s = _ConcreteSmallSlider("Bass", value=0)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=25)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 4)
 
     def test_renders_at_max(self):
         s = _ConcreteSmallSlider("Bass", value=100)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, x=0, y=0, width=200, height=25)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, x=0, y=0, width=WIDGET_WIDTH, height=WIDGET_HEIGHT // 4)
 
 
 # ── Abstract class guards ────────────────────────────────────────────────

--- a/tests/test_widgets_temperature.py
+++ b/tests/test_widgets_temperature.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.temperature import TemperatureSlider
 
 
@@ -26,24 +27,24 @@ class TestTemperatureSliderInit:
 class TestTemperatureSliderRender:
     def test_render_at_min(self):
         s = TemperatureSlider(value=15)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_at_mid(self):
         s = TemperatureSlider(value=20)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_render_at_max(self):
         s = TemperatureSlider(value=25)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_active(self):
         s = TemperatureSlider(value=21)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2, active=True)
 
     def test_format_value_integer(self):
         s = TemperatureSlider(value=21)

--- a/tests/test_widgets_volume.py
+++ b/tests/test_widgets_volume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from PIL import Image
 
+from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.volume import VolumeSlider
 
 
@@ -36,25 +37,25 @@ class TestVolumeSliderInit:
 class TestVolumeSliderRender:
     def test_render_at_zero(self):
         s = VolumeSlider(value=0)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
         # At zero, most of the bar area should still be black
 
     def test_render_at_half(self):
         s = VolumeSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
-        assert img.size == (200, 100)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
+        assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
     def test_render_at_max(self):
         s = VolumeSlider(value=100)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2)
 
     def test_render_active(self):
         s = VolumeSlider(value=50)
-        img = Image.new("RGB", (200, 100), "black")
-        s.render_onto(img, 0, 0, 200, 50, active=True)
+        img = Image.new("RGB", (WIDGET_WIDTH, WIDGET_HEIGHT), "black")
+        s.render_onto(img, 0, 0, WIDGET_WIDTH, WIDGET_HEIGHT // 2, active=True)
 
     def test_format_value(self):
         s = VolumeSlider(value=75)


### PR DESCRIPTION
## Summary

- Adds screen margins (top=4, bottom=18, left=4, right=4) to account for the Stream Deck+ viewing angle hiding the bottom of the touchscreen
- Adds 4px horizontal gaps between the 4 widget zones
- Changes widget dimensions from 200x100 to 195x78 (usable area: 792x78)
- Updates TouchEvent.zone calculation for margin-aware coordinate mapping
- Updates all rendering functions, slider layouts, and tests for the new dimensions

## Details

The physical Stream Deck+ touchscreen is 800x100, but due to the device angle, the bottom portion is not visible. This PR insets the rendering area with margins and separates widgets with gaps:

| Constant | Old | New |
|---|---|---|
| Widget size | 200x100 | 195x78 |
| Margins | none | T=4, B=18, L=4, R=4 |
| Widget gap | 0 | 4px |
| Usable area | 800x100 | 792x78 |

All 406 tests pass with 99.90% coverage.