### PR TITLE
Fix inner content misalignment in all slider widgets

### DIFF
--- a/src/deckboard/widgets/balance.py
+++ b/src/deckboard/widgets/balance.py
@@ -72,7 +72,7 @@ class BalanceSlider(SmallSlider):
         if left_fill_w > 0:
             self._draw_rounded_rect(
                 draw,
-                (centre_x - left_fill_w, iy, centre_x, iy + ih),
+                (centre_x - left_fill_w, iy, centre_x, iy + ih - 1),
                 radius=_SMALL_INNER_RX,
                 fill="white",
             )
@@ -82,14 +82,14 @@ class BalanceSlider(SmallSlider):
         if right_fill_w > 0:
             self._draw_rounded_rect(
                 draw,
-                (centre_x, iy, centre_x + right_fill_w, iy + ih),
+                (centre_x, iy, centre_x + right_fill_w, iy + ih - 1),
                 radius=_SMALL_INNER_RX,
                 fill="white",
             )
 
         # Centre line
         draw.line(
-            [(centre_x, iy), (centre_x, iy + ih)],
+            [(centre_x, iy), (centre_x, iy + ih - 1)],
             fill="black",
             width=1,
         )

--- a/src/deckboard/widgets/brightness.py
+++ b/src/deckboard/widgets/brightness.py
@@ -57,7 +57,7 @@ class BrightnessSlider(LargeSlider):
         ind_x = ix + int((iw - _LARGE_INDICATOR_W) * self.normalized)
         self._draw_rounded_rect(
             draw,
-            (ind_x, iy, ind_x + _LARGE_INDICATOR_W, iy + ih),
+            (ind_x, iy, ind_x + _LARGE_INDICATOR_W - 1, iy + ih - 1),
             radius=_LARGE_INNER_RX,
             fill="white",
             outline="black",

--- a/src/deckboard/widgets/equalizer.py
+++ b/src/deckboard/widgets/equalizer.py
@@ -51,7 +51,7 @@ class EqualizerSlider(SmallSlider):
         ind_x = ix + int((iw - _SMALL_INDICATOR_W) * self.normalized)
         self._draw_rounded_rect(
             draw,
-            (ind_x, iy, ind_x + _SMALL_INDICATOR_W, iy + ih),
+            (ind_x, iy, ind_x + _SMALL_INDICATOR_W - 1, iy + ih - 1),
             radius=_SMALL_INNER_RX,
             fill="white",
         )

--- a/src/deckboard/widgets/kelvin.py
+++ b/src/deckboard/widgets/kelvin.py
@@ -57,7 +57,7 @@ class KelvinSlider(LargeSlider):
         ind_x = ix + int((iw - _LARGE_INDICATOR_W) * self.normalized)
         self._draw_rounded_rect(
             draw,
-            (ind_x, iy, ind_x + _LARGE_INDICATOR_W, iy + ih),
+            (ind_x, iy, ind_x + _LARGE_INDICATOR_W - 1, iy + ih - 1),
             radius=_LARGE_INNER_RX,
             fill="white",
             outline="black",

--- a/src/deckboard/widgets/slider.py
+++ b/src/deckboard/widgets/slider.py
@@ -254,11 +254,13 @@ class LargeSlider(Slider, ABC):
         val_w = bbox[2] - bbox[0]
         draw.text((x + mx + bar_w - val_w, label_y), val_text, fill="white", font=font)
 
-        # Frame
+        # Frame (use inclusive integer coords for symmetric stroke)
         stroke_color = _HIGHLIGHT_COLOR if active else _NORMAL_STROKE_COLOR
+        fx = x + mx
+        fy = bar_y
         self._draw_rounded_rect(
             draw,
-            (x + mx + 0.5, bar_y + 0.5, x + mx + bar_w - 0.5, bar_y + frame_h - 0.5),
+            (fx, fy, fx + bar_w - 1, fy + frame_h - 1),
             radius=_LARGE_FRAME_RX,
             outline=stroke_color,
             width=_LARGE_FRAME_STROKE,
@@ -266,8 +268,8 @@ class LargeSlider(Slider, ABC):
 
         # Inner track coordinates
         pad = _LARGE_INNER_PAD
-        ix = x + mx + pad
-        iy = bar_y + pad
+        ix = fx + pad
+        iy = fy + pad
         iw = bar_w - 2 * pad
         ih = frame_h - 2 * pad
 
@@ -326,11 +328,11 @@ class SmallSlider(Slider, ABC):
         # Vertically centre the frame in the slot
         bar_y = y + (height - frame_h) // 2
 
-        # Frame
+        # Frame (use inclusive integer coords for symmetric stroke)
         stroke_color = _HIGHLIGHT_COLOR if active else _NORMAL_STROKE_COLOR
         self._draw_rounded_rect(
             draw,
-            (bar_x + 0.5, bar_y + 0.5, bar_x + bar_w - 0.5, bar_y + frame_h - 0.5),
+            (bar_x, bar_y, bar_x + bar_w - 1, bar_y + frame_h - 1),
             radius=_SMALL_FRAME_RX,
             outline=stroke_color,
             width=_SMALL_FRAME_STROKE,

--- a/src/deckboard/widgets/temperature.py
+++ b/src/deckboard/widgets/temperature.py
@@ -57,7 +57,7 @@ class TemperatureSlider(LargeSlider):
         ind_x = ix + int((iw - _LARGE_INDICATOR_W) * self.normalized)
         self._draw_rounded_rect(
             draw,
-            (ind_x, iy, ind_x + _LARGE_INDICATOR_W, iy + ih),
+            (ind_x, iy, ind_x + _LARGE_INDICATOR_W - 1, iy + ih - 1),
             radius=_LARGE_INNER_RX,
             fill="white",
             outline="black",

--- a/src/deckboard/widgets/volume.py
+++ b/src/deckboard/widgets/volume.py
@@ -52,7 +52,7 @@ class VolumeSlider(LargeSlider):
         if fill_w > 0:
             self._draw_rounded_rect(
                 draw,
-                (ix, iy, ix + fill_w, iy + ih),
+                (ix, iy, ix + fill_w - 1, iy + ih - 1),
                 radius=_LARGE_INNER_RX,
                 fill="white",
             )


### PR DESCRIPTION
## Summary

- Fixes off-by-one pixel alignment in all six slider widget types (VolumeSlider, BrightnessSlider, TemperatureSlider, KelvinSlider, EqualizerSlider, BalanceSlider)
- Inner fills, gradient indicators, and centre lines were overflowing the outer frame by 1px due to _draw_rounded_rect using inclusive coordinates while bar content methods passed exclusive bounds (iy + ih instead of iy + ih - 1)
- All 413 tests pass with 99.90% coverage

## Details

PIL rounded_rectangle treats (x1, y1, x2, y2) as inclusive bounds -- a rect from (0, 0, 10, 10) is 11x11 pixels. The inner track dimensions (ix, iy, iw, ih) are computed as pixel counts (e.g. ih = frame_h - 2 * pad), but the _draw_rounded_rect calls used iy + ih as the bottom bound, which is 1px past the intended area.

This caused:
- **Volume**: fill rect touching the bottom of the outer frame
- **Brightness**: indicator touching the top of the outer frame
- **Temperature/Kelvin**: indicator touching the bottom of the outer frame
- **Equalizer (Sub/Bass/Treble)**: indicator touching top or bottom of the outer frame
- **Balance**: inner fill rects and centre line touching the top of the outer frame

The fix applies -1 to all right/bottom coordinates in _draw_rounded_rect calls within _draw_bar_contents, aligning them with the gradient helper which already handled this correctly via pixel-based Image.paste().