### PR TITLE
Fix Slider.set_value() not marking parent Widget as dirty

### DIFF
--- a/src/deckboard/touchscreen.py
+++ b/src/deckboard/touchscreen.py
@@ -160,6 +160,10 @@ class Widget:
     def mark_clean(self) -> None:
         self._dirty = False
 
+    def mark_dirty(self) -> None:
+        """Flag this widget for re-rendering on the next refresh."""
+        self._dirty = True
+
     @property
     def rendered(self) -> Image.Image | None:
         return self._rendered
@@ -186,6 +190,7 @@ class Widget:
         if not isinstance(slider, _Slider):
             msg = f"Expected a Slider instance, got {type(slider).__name__}"
             raise TypeError(msg)
+        slider._widget = self
         self._sliders.append(slider)
         idx = len(self._sliders) - 1
         if default or idx == 0:

--- a/src/deckboard/widgets/slider.py
+++ b/src/deckboard/widgets/slider.py
@@ -10,10 +10,14 @@ The hierarchy is::
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw, ImageFont
 
 from ..image import get_font
+
+if TYPE_CHECKING:
+    from ..touchscreen import Widget
 
 # ── Layout constants (derived from the reference SVG) ────────────────────
 
@@ -66,6 +70,7 @@ class Slider(ABC):
         self._value = float(value) if value is not None else self._min
         self._unit = unit
         self._step = float(step)
+        self._widget: Widget | None = None  # back-reference set by Widget.add_slider()
 
     # -- Properties --------------------------------------------------------
 
@@ -106,6 +111,8 @@ class Slider(ABC):
     def set_value(self, v: float) -> None:
         """Set the value, clamping to ``[min_value, max_value]``."""
         self._value = max(self._min, min(self._max, float(v)))
+        if self._widget is not None:
+            self._widget.mark_dirty()
 
     def adjust(self, direction: int) -> None:
         """Adjust the value by ``direction * step``."""

--- a/tests/test_touchscreen.py
+++ b/tests/test_touchscreen.py
@@ -179,6 +179,12 @@ class TestWidgetRendering:
         widget.mark_clean()
         assert widget.is_dirty is False
 
+    def test_mark_dirty(self, widget: Widget):
+        widget.mark_clean()
+        assert widget.is_dirty is False
+        widget.mark_dirty()
+        assert widget.is_dirty is True
+
 
 # ── TouchScreen ─────────────────────────────────────────────────────────
 

--- a/tests/test_widgets_slider.py
+++ b/tests/test_widgets_slider.py
@@ -6,6 +6,7 @@ import pytest
 from PIL import Image
 
 from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
+from deckboard.touchscreen import Widget
 from deckboard.widgets.slider import LargeSlider, Slider, SmallSlider
 
 
@@ -260,3 +261,47 @@ class TestSliderAbstractGuards:
     def test_cannot_instantiate_small_slider(self):
         with pytest.raises(TypeError):
             SmallSlider("X")  # type: ignore[abstract]
+
+
+# ── Dirty propagation to parent Widget ───────────────────────────────────
+
+
+class TestSliderWidgetBackReference:
+    def test_no_widget_by_default(self):
+        s = _ConcreteLargeSlider("X", value=50)
+        assert s._widget is None
+
+    def test_add_slider_sets_widget(self):
+        w = Widget(0)
+        s = _ConcreteLargeSlider("X", value=50)
+        w.add_slider(s)
+        assert s._widget is w
+
+    def test_set_value_marks_widget_dirty(self):
+        w = Widget(0)
+        s = _ConcreteLargeSlider("X", value=50)
+        w.add_slider(s)
+        w.mark_clean()
+        assert w.is_dirty is False
+        s.set_value(75)
+        assert w.is_dirty is True
+
+    def test_set_value_without_widget_does_not_raise(self):
+        s = _ConcreteLargeSlider("X", value=50)
+        s.set_value(75)  # no widget attached — should not raise
+        assert s.value == 75
+
+    def test_adjust_marks_widget_dirty(self):
+        w = Widget(0)
+        s = _ConcreteLargeSlider("X", value=50, step=5)
+        w.add_slider(s)
+        w.mark_clean()
+        assert w.is_dirty is False
+        s.adjust(1)
+        assert s.value == 55
+        assert w.is_dirty is True
+
+    def test_adjust_without_widget_does_not_raise(self):
+        s = _ConcreteLargeSlider("X", value=50, step=5)
+        s.adjust(1)
+        assert s.value == 55


### PR DESCRIPTION
## Summary

- **Bug:** Calling slider.set_value() directly (e.g. from the Reset All button in examples/slider_widgets.py) updated the slider's internal value but never marked the parent Widget as dirty. As a result, deck.refresh() saw no dirty widgets and skipped re-rendering the touchscreen — the sliders appeared unchanged.
- **Fix:** Added a _widget back-reference on Slider, set by Widget.add_slider(). Slider.set_value() now calls Widget.mark_dirty() to propagate dirtiness, ensuring the touchscreen re-renders on the next refresh().
- **Tests:** Added Widget.mark_dirty() test, and 6 new tests covering the back-reference setup, dirty propagation from set_value() and adjust(), and safe behavior when no widget is attached.

All 420 tests pass, 99.91% coverage.