### PR TITLE
Add widget-level event callbacks for sliders and dials

### DIFF
--- a/src/deckboard/deck.py
+++ b/src/deckboard/deck.py
@@ -357,9 +357,15 @@ class Deck:
 
         Call this after changing button icons/labels or widget values
         if you need immediate updates outside of ``set_page()``.
+        Also drains any pending callbacks queued by programmatic
+        ``set_value()`` calls on sliders.
         """
         if not self._active_page:
             return
+
+        # Drain pending callbacks from all widgets (programmatic set_value)
+        for widget in self._active_page.widgets:
+            await self._drain_widget_callbacks(widget)
 
         # Render dirty buttons
         for button in self._active_page.buttons.values():
@@ -419,6 +425,16 @@ class Deck:
         finally:
             self._closed_event.set()
 
+    async def _drain_widget_callbacks(self, widget: Widget) -> None:
+        """Drain and await all pending callbacks queued on a widget.
+
+        Callbacks are enqueued by child elements (e.g. sliders) when
+        their value changes synchronously.  This method pops them all
+        and awaits each in order.
+        """
+        for handler, args in widget.drain_pending_callbacks():
+            await handler(*args)
+
     async def _dispatch(self, event: DeckEvent) -> None:
         """Dispatch a single event to the appropriate handler on the active page."""
         page = self._active_page
@@ -437,9 +453,14 @@ class Deck:
             dial = page.dials.get(event.dial)
             if dial and dial._turn_handler:
                 await dial._turn_handler(event.direction)
-            # Forward to widget (e.g. SliderWidget adjusts its active slider)
+            # Widget-level dial turn handler
             widget = page.touchscreen.widget(event.dial)
+            if widget._dial_turn_handler:
+                await widget._dial_turn_handler(event.direction)
+            # Forward to widget (e.g. SliderWidget adjusts its active slider)
             widget.handle_dial_turn(event.direction)
+            # Drain deferred callbacks (e.g. slider on_change)
+            await self._drain_widget_callbacks(widget)
             if widget.is_dirty:
                 await self.refresh()
 
@@ -453,7 +474,12 @@ class Deck:
             # Forward dial press to widget (e.g. SliderWidget cycles sliders)
             if event.pressed:
                 widget = page.touchscreen.widget(event.dial)
+                # Widget-level dial press handler
+                if widget._dial_press_handler:
+                    await widget._dial_press_handler()
                 widget.handle_dial_press()
+                # Drain deferred callbacks (if any)
+                await self._drain_widget_callbacks(widget)
                 if widget.is_dirty:
                     await self.refresh()
 

--- a/src/deckboard/touchscreen.py
+++ b/src/deckboard/touchscreen.py
@@ -49,6 +49,9 @@ class Widget(ABC):
         self._tap_handler: AsyncHandler | None = None
         self._long_press_handler: AsyncHandler | None = None
         self._drag_handler: AsyncHandler | None = None
+        self._dial_turn_handler: AsyncHandler | None = None
+        self._dial_press_handler: AsyncHandler | None = None
+        self._pending_callbacks: list[tuple[AsyncHandler, tuple[float]]] = []
         self._rendered: Image.Image | None = None
         self._dirty = True
 
@@ -96,6 +99,59 @@ class Widget(ABC):
         """
         self._drag_handler = handler
         return handler
+
+    def on_dial_turn(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for dial turn events on this widget.
+
+        The handler receives a single ``direction`` argument:
+        positive = clockwise, negative = counter-clockwise.
+
+        Usage::
+
+            @widget.on_dial_turn
+            async def handle(direction: int):
+                ...
+        """
+        self._dial_turn_handler = handler
+        return handler
+
+    def on_dial_press(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for dial press events on this widget.
+
+        Usage::
+
+            @widget.on_dial_press
+            async def handle():
+                ...
+        """
+        self._dial_press_handler = handler
+        return handler
+
+    # -- Pending callbacks (deferred async invocation) ---------------------
+
+    def queue_pending_callback(self, handler: AsyncHandler, args: tuple[float]) -> None:
+        """Enqueue a callback for deferred async invocation.
+
+        Called by child elements (e.g. sliders) when their value changes
+        synchronously.  The queued callbacks are drained and awaited by
+        :class:`~deckboard.deck.Deck` during event dispatch or refresh.
+
+        Args:
+            handler: The async callback to invoke.
+            args: Positional arguments to pass to the callback.
+        """
+        self._pending_callbacks.append((handler, args))
+
+    def drain_pending_callbacks(self) -> list[tuple[AsyncHandler, tuple[float]]]:
+        """Remove and return all pending callbacks.
+
+        Returns:
+            A list of ``(handler, args)`` tuples.  The list is empty if
+            no callbacks are pending.
+        """
+        callbacks = self._pending_callbacks
+        self._pending_callbacks = []
+        return callbacks
 
     # -- Dirty tracking ----------------------------------------------------
 

--- a/src/deckboard/widgets/slider.py
+++ b/src/deckboard/widgets/slider.py
@@ -18,6 +18,7 @@ from ..image import get_font
 
 if TYPE_CHECKING:
     from ..touchscreen import Widget  # abstract base — any Widget subclass
+    from ..types import AsyncHandler
 
 # ── Layout constants (derived from the reference SVG) ────────────────────
 
@@ -73,6 +74,7 @@ class Slider(ABC):
         self._unit = unit
         self._step = float(step)
         self._widget: Widget | None = None  # back-reference set by Widget.add_slider()
+        self._change_handler: AsyncHandler | None = None
 
     # -- Properties --------------------------------------------------------
 
@@ -110,11 +112,37 @@ class Slider(ABC):
 
     # -- Mutators ----------------------------------------------------------
 
+    def on_change(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for value change events.
+
+        The handler receives the new ``value`` after clamping.  It is
+        invoked asynchronously by the event loop after the value changes
+        (via dial turn or programmatic :meth:`set_value`).
+
+        Usage::
+
+            @slider.on_change
+            async def handle(value: float):
+                print(f"New value: {value}")
+        """
+        self._change_handler = handler
+        return handler
+
     def set_value(self, v: float) -> None:
-        """Set the value, clamping to ``[min_value, max_value]``."""
+        """Set the value, clamping to ``[min_value, max_value]``.
+
+        If the value actually changes and an :meth:`on_change` handler
+        is registered, a callback is queued on the parent widget for
+        deferred async invocation.
+        """
+        old = self._value
         self._value = max(self._min, min(self._max, float(v)))
         if self._widget is not None:
             self._widget.mark_dirty()
+            if self._change_handler is not None and self._value != old:
+                self._widget.queue_pending_callback(
+                    self._change_handler, (self._value,)
+                )
 
     def adjust(self, direction: int) -> None:
         """Adjust the value by ``direction * step``."""

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -379,6 +379,177 @@ class TestDeckDispatch:
         handler.assert_awaited_once()
 
 
+# ── Deck._dispatch — widget event callbacks ─────────────────────────────
+
+
+class TestDeckDispatchWidgetCallbacks:
+    """Tests for widget-level dial decorators and slider on_change callbacks."""
+
+    async def test_dial_turn_calls_widget_dial_turn_handler(self, deck):
+        """Widget on_dial_turn handler is called on DialTurnEvent."""
+        from deckboard.widgets.slider_widget import SliderWidget
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        p.set_widget(0, sw)
+        deck._active_page = p
+
+        handler = AsyncMock()
+        sw.on_dial_turn(handler)
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock):
+            await deck._dispatch(DialTurnEvent(dial=0, direction=3))
+
+        handler.assert_awaited_once_with(3)
+
+    async def test_dial_press_calls_widget_dial_press_handler(self, deck):
+        """Widget on_dial_press handler is called on DialPressEvent."""
+        from deckboard.widgets.slider_widget import SliderWidget
+        from deckboard.widgets.volume import VolumeSlider
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        sw.add_slider(VolumeSlider())
+        sw.add_slider(VolumeSlider())
+        p.set_widget(0, sw)
+        deck._active_page = p
+
+        handler = AsyncMock()
+        sw.on_dial_press(handler)
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock):
+            await deck._dispatch(DialPressEvent(dial=0, pressed=True))
+
+        handler.assert_awaited_once()
+
+    async def test_dial_press_release_does_not_call_widget_handler(self, deck):
+        """Widget on_dial_press is NOT called for release events."""
+        from deckboard.widgets.slider_widget import SliderWidget
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        p.set_widget(0, sw)
+        deck._active_page = p
+
+        handler = AsyncMock()
+        sw.on_dial_press(handler)
+
+        await deck._dispatch(DialPressEvent(dial=0, pressed=False))
+        handler.assert_not_awaited()
+
+    async def test_dial_turn_drains_slider_on_change(self, deck):
+        """Slider on_change callback is awaited after dial turn adjusts value."""
+        from deckboard.widgets.slider_widget import SliderWidget
+        from deckboard.widgets.volume import VolumeSlider
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        vol = VolumeSlider(value=50, step=5)
+        sw.add_slider(vol)
+        p.set_widget(0, sw)
+        deck._active_page = p
+
+        change_handler = AsyncMock()
+        vol.on_change(change_handler)
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock):
+            await deck._dispatch(DialTurnEvent(dial=0, direction=1))
+
+        change_handler.assert_awaited_once_with(55.0)
+
+    async def test_dial_turn_order_dial_then_widget_then_change(self, deck):
+        """Dispatch order: dial handler → widget dial handler → slider on_change."""
+        from deckboard.widgets.slider_widget import SliderWidget
+        from deckboard.widgets.volume import VolumeSlider
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        vol = VolumeSlider(value=50, step=5)
+        sw.add_slider(vol)
+        p.set_widget(0, sw)
+        deck._active_page = p
+
+        call_order = []
+
+        dial_handler = AsyncMock(side_effect=lambda d: call_order.append("dial"))
+        p.dial(0).on_turn(dial_handler)
+
+        widget_handler = AsyncMock(side_effect=lambda d: call_order.append("widget"))
+        sw.on_dial_turn(widget_handler)
+
+        change_handler = AsyncMock(side_effect=lambda v: call_order.append("change"))
+        vol.on_change(change_handler)
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock):
+            await deck._dispatch(DialTurnEvent(dial=0, direction=1))
+
+        assert call_order == ["dial", "widget", "change"]
+
+    async def test_refresh_drains_pending_callbacks(self, deck):
+        """Programmatic set_value + refresh drains on_change callbacks."""
+        from deckboard.widgets.slider_widget import SliderWidget
+        from deckboard.widgets.volume import VolumeSlider
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        vol = VolumeSlider(value=50)
+        sw.add_slider(vol)
+        p.set_widget(0, sw)
+        deck._active_page = p
+        deck._render_button = AsyncMock()
+        deck._render_touchscreen = AsyncMock()
+
+        change_handler = AsyncMock()
+        vol.on_change(change_handler)
+
+        # Programmatic change (not from dial)
+        vol.set_value(80)
+
+        await deck.refresh()
+        change_handler.assert_awaited_once_with(80.0)
+
+    async def test_no_on_change_when_value_unchanged_via_dial(self, deck):
+        """No on_change callback when dial turn doesn't change value (at max)."""
+        from deckboard.widgets.slider_widget import SliderWidget
+        from deckboard.widgets.volume import VolumeSlider
+
+        p = deck.page("main")
+        sw = SliderWidget(0)
+        vol = VolumeSlider(value=100, max_value=100, step=5)
+        sw.add_slider(vol)
+        p.set_widget(0, sw)
+        deck._active_page = p
+
+        change_handler = AsyncMock()
+        vol.on_change(change_handler)
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock):
+            await deck._dispatch(DialTurnEvent(dial=0, direction=1))
+
+        change_handler.assert_not_awaited()
+
+    async def test_drain_widget_callbacks_helper(self, deck):
+        """_drain_widget_callbacks awaits all pending callbacks in order."""
+        from deckboard.widgets.slider_widget import SliderWidget
+
+        sw = SliderWidget(0)
+        results = []
+
+        async def h1(v: float):
+            results.append(("h1", v))
+
+        async def h2(v: float):
+            results.append(("h2", v))
+
+        sw.queue_pending_callback(h1, (1.0,))
+        sw.queue_pending_callback(h2, (2.0,))
+
+        await deck._drain_widget_callbacks(sw)
+        assert results == [("h1", 1.0), ("h2", 2.0)]
+        # Queue should be empty after drain
+        assert sw.drain_pending_callbacks() == []
+
+
 # ── Deck._render_all_buttons ────────────────────────────────────────────
 
 

--- a/tests/test_touchscreen.py
+++ b/tests/test_touchscreen.py
@@ -141,6 +141,92 @@ class TestWidgetAbstractBase:
         assert img.size == (WIDGET_WIDTH, WIDGET_HEIGHT)
 
 
+class TestWidgetDialDecorators:
+    def test_on_dial_turn(self):
+        w = _ConcreteWidget(0)
+
+        @w.on_dial_turn
+        async def handler(direction: int):
+            pass
+
+        assert w._dial_turn_handler is handler
+
+    def test_on_dial_turn_returns_handler(self):
+        w = _ConcreteWidget(0)
+
+        async def handler(direction: int):
+            pass
+
+        result = w.on_dial_turn(handler)
+        assert result is handler
+
+    def test_on_dial_press(self):
+        w = _ConcreteWidget(0)
+
+        @w.on_dial_press
+        async def handler():
+            pass
+
+        assert w._dial_press_handler is handler
+
+    def test_on_dial_press_returns_handler(self):
+        w = _ConcreteWidget(0)
+
+        async def handler():
+            pass
+
+        result = w.on_dial_press(handler)
+        assert result is handler
+
+    def test_dial_handlers_initially_none(self):
+        w = _ConcreteWidget(0)
+        assert w._dial_turn_handler is None
+        assert w._dial_press_handler is None
+
+
+class TestWidgetPendingCallbacks:
+    def test_initially_empty(self):
+        w = _ConcreteWidget(0)
+        assert w.drain_pending_callbacks() == []
+
+    def test_queue_and_drain(self):
+        w = _ConcreteWidget(0)
+
+        async def handler(value: float):
+            pass
+
+        w.queue_pending_callback(handler, (42.0,))
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (42.0,))
+
+    def test_drain_clears_queue(self):
+        w = _ConcreteWidget(0)
+
+        async def handler(value: float):
+            pass
+
+        w.queue_pending_callback(handler, (1.0,))
+        w.drain_pending_callbacks()
+        assert w.drain_pending_callbacks() == []
+
+    def test_multiple_callbacks_preserved_in_order(self):
+        w = _ConcreteWidget(0)
+
+        async def h1(value: float):
+            pass
+
+        async def h2(value: float):
+            pass
+
+        w.queue_pending_callback(h1, (10.0,))
+        w.queue_pending_callback(h2, (20.0,))
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 2
+        assert callbacks[0] == (h1, (10.0,))
+        assert callbacks[1] == (h2, (20.0,))
+
+
 # ── IconWidget ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_widgets_equalizer_widget.py
+++ b/tests/test_widgets_equalizer_widget.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from deckboard.image import WIDGET_HEIGHT, WIDGET_WIDTH
 from deckboard.widgets.balance import BalanceSlider
@@ -181,3 +181,99 @@ class TestEqualizerWidgetIsSubclassOfTouchPanel:
 
         w = EqualizerWidget(0)
         assert isinstance(w, TouchPanel)
+
+
+class TestEqualizerWidgetOnChangeIntegration:
+    """Integration tests: on_change callbacks with EqualizerWidget sliders."""
+
+    def test_on_change_queued_on_set_value(self):
+        w = EqualizerWidget(0, sub=50)
+        handler = AsyncMock()
+        w.sub.on_change(handler)
+        w.sub.set_value(75)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (75.0,))
+
+    def test_on_change_queued_on_dial_turn(self):
+        w = EqualizerWidget(0, sub=50)
+        handler = AsyncMock()
+        w.sub.on_change(handler)
+        w.handle_dial_turn(3)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (53.0,))
+
+    def test_on_change_fires_for_active_slider_only(self):
+        w = EqualizerWidget(0, sub=50, bass=50)
+        sub_handler = AsyncMock()
+        bass_handler = AsyncMock()
+        w.sub.on_change(sub_handler)
+        w.bass.on_change(bass_handler)
+        w.handle_dial_turn(5)  # sub is active by default
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0][0] is sub_handler
+
+    def test_on_change_follows_active_slider_after_press(self):
+        w = EqualizerWidget(0, sub=50, bass=50)
+        sub_handler = AsyncMock()
+        bass_handler = AsyncMock()
+        w.sub.on_change(sub_handler)
+        w.bass.on_change(bass_handler)
+        w.handle_dial_press()  # switch to bass
+        w.drain_pending_callbacks()  # clear any pending
+        w.handle_dial_turn(2)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0][0] is bass_handler
+        assert callbacks[0][1] == (52.0,)
+
+    def test_on_change_not_queued_when_clamped_at_max(self):
+        w = EqualizerWidget(0, sub=100)
+        handler = AsyncMock()
+        w.sub.on_change(handler)
+        w.handle_dial_turn(1)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_on_change_not_queued_when_clamped_at_min(self):
+        w = EqualizerWidget(0, sub=0)
+        handler = AsyncMock()
+        w.sub.on_change(handler)
+        w.handle_dial_turn(-1)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_multiple_sliders_with_handlers_independent(self):
+        w = EqualizerWidget(0, sub=50, treble=50)
+        sub_handler = AsyncMock()
+        treble_handler = AsyncMock()
+        w.sub.on_change(sub_handler)
+        w.treble.on_change(treble_handler)
+        # Programmatic set_value on both sliders
+        w.sub.set_value(60)
+        w.treble.set_value(70)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 2
+        handlers = [cb[0] for cb in callbacks]
+        assert sub_handler in handlers
+        assert treble_handler in handlers
+
+    def test_balance_slider_on_change(self):
+        w = EqualizerWidget(0, balance=50)
+        handler = AsyncMock()
+        w.balance.on_change(handler)
+        w.balance.set_value(75)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (75.0,))
+
+    def test_drain_clears_pending(self):
+        w = EqualizerWidget(0, sub=50)
+        handler = AsyncMock()
+        w.sub.on_change(handler)
+        w.sub.set_value(60)
+        w.drain_pending_callbacks()
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 0

--- a/tests/test_widgets_slider.py
+++ b/tests/test_widgets_slider.py
@@ -306,3 +306,119 @@ class TestSliderWidgetBackReference:
         s = _ConcreteLargeSlider("X", value=50, step=5)
         s.adjust(1)
         assert s.value == 55
+
+
+# ── on_change callback ──────────────────────────────────────────────────
+
+
+class TestSliderOnChange:
+    def test_handler_initially_none(self):
+        s = _ConcreteLargeSlider("X", value=50)
+        assert s._change_handler is None
+
+    def test_on_change_registers_handler(self):
+        s = _ConcreteLargeSlider("X", value=50)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        assert s._change_handler is handler
+
+    def test_on_change_returns_handler(self):
+        s = _ConcreteLargeSlider("X", value=50)
+
+        async def handler(value: float):
+            pass
+
+        result = s.on_change(handler)
+        assert result is handler
+
+    def test_set_value_queues_callback_on_widget(self):
+        w = SliderWidget(0)
+        s = _ConcreteLargeSlider("X", value=50)
+        w.add_slider(s)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        s.set_value(75)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (75.0,))
+
+    def test_set_value_no_callback_when_value_unchanged(self):
+        w = SliderWidget(0)
+        s = _ConcreteLargeSlider("X", value=50)
+        w.add_slider(s)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        s.set_value(50)  # same value
+        callbacks = w.drain_pending_callbacks()
+        assert callbacks == []
+
+    def test_set_value_no_callback_without_handler(self):
+        w = SliderWidget(0)
+        s = _ConcreteLargeSlider("X", value=50)
+        w.add_slider(s)
+
+        s.set_value(75)
+        callbacks = w.drain_pending_callbacks()
+        assert callbacks == []
+
+    def test_set_value_no_callback_without_widget(self):
+        s = _ConcreteLargeSlider("X", value=50)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        s.set_value(75)  # no widget — should not raise
+        assert s.value == 75
+
+    def test_adjust_queues_callback(self):
+        w = SliderWidget(0)
+        s = _ConcreteLargeSlider("X", value=50, step=5)
+        w.add_slider(s)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        s.adjust(1)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (55.0,))
+
+    def test_adjust_no_callback_when_clamped_at_same_value(self):
+        w = SliderWidget(0)
+        s = _ConcreteLargeSlider("X", value=100, max_value=100, step=5)
+        w.add_slider(s)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        s.adjust(1)  # already at max, value stays 100
+        callbacks = w.drain_pending_callbacks()
+        assert callbacks == []
+
+    def test_multiple_set_value_calls_queue_multiple_callbacks(self):
+        w = SliderWidget(0)
+        s = _ConcreteLargeSlider("X", value=50)
+        w.add_slider(s)
+
+        @s.on_change
+        async def handler(value: float):
+            pass
+
+        s.set_value(60)
+        s.set_value(70)
+        callbacks = w.drain_pending_callbacks()
+        assert len(callbacks) == 2
+        assert callbacks[0] == (handler, (60.0,))
+        assert callbacks[1] == (handler, (70.0,))


### PR DESCRIPTION
## Summary

- Add `on_change` decorator to `Slider` base class — registers an async callback that fires when the slider value actually changes (via dial turn or programmatic `set_value`)
- Add `on_dial_turn` / `on_dial_press` decorators to `Widget` base class — registers async callbacks for dial events scoped to individual widgets
- Add deferred callback queue on `Widget` (`queue_pending_callback` / `drain_pending_callbacks`) so sync `set_value()` can safely enqueue async callbacks
- Update `Deck._dispatch()` to invoke widget-level handlers and drain pending callbacks after dial interactions
- Update `Deck.refresh()` to drain pending callbacks from programmatic `set_value()` calls

## Design decisions

- **Async-only callbacks** — consistent with existing decorator pattern (`@dial.on_turn`, `@button.on_press`)
- **Deferred invocation** — `set_value()` remains synchronous; callbacks are queued and drained by the event loop
- **Dispatch order** — dial handler → widget `on_dial_turn` → `handle_dial_turn` (queues `on_change`) → drain callbacks → refresh

## Testing

- 658 tests passing, 100% code coverage
- New test classes: `TestWidgetDialDecorators`, `TestWidgetPendingCallbacks`, `TestSliderOnChange`, `TestDeckDispatchWidgetCallbacks`, `TestEqualizerWidgetOnChangeIntegration`
- Covers: handler registration, callback queueing, clamping edge cases, dispatch ordering, refresh draining, multi-slider independence