### PR TITLE
Refactor touchscreen debug grid to 4x4 within margin boundaries

### DIFF
--- a/src/deckboard/render/debug_grid.py
+++ b/src/deckboard/render/debug_grid.py
@@ -13,9 +13,9 @@ from .metrics import (
     TOUCHSCREEN_WIDTH,
 )
 
-# Grid density: 10 columns x 10 rows for the full 800x100 touchscreen.
-_GRID_COLS = 10
-_GRID_ROWS = 10
+# Grid density: 4 columns x 4 rows within the usable (margin-bounded) area.
+_GRID_COLS = 4
+_GRID_ROWS = 4
 
 # Colours — margin lines are brighter so they stand out.
 _MARGIN_COLOR = (120, 120, 120)  # lighter grey for margin boundaries
@@ -23,11 +23,12 @@ _GRID_COLOR = (50, 50, 50)  # subtle dark grey for inner grid lines
 
 
 def draw_touchscreen_grid(img: Image.Image) -> Image.Image:
-    """Draw a 10x10 debug grid on a touchscreen-sized image.
+    """Draw a 4x4 debug grid within the margin boundaries of a touchscreen image.
 
     Margin boundaries (top/bottom/left/right) are drawn with a
     brighter line so they are easy to distinguish from the evenly
-    spaced inner grid lines.
+    spaced inner grid lines.  All grid lines run only between the
+    margin boundaries, not edge-to-edge.
 
     Args:
         img: An 800x100 RGB :class:`~PIL.Image.Image`.
@@ -40,42 +41,33 @@ def draw_touchscreen_grid(img: Image.Image) -> Image.Image:
     draw = ImageDraw.Draw(overlay)
     w, h = overlay.size
 
-    col_step = w / _GRID_COLS
-    row_step = h / _GRID_ROWS
+    # Margin boundary positions
+    left = MARGIN_LEFT
+    right = w - MARGIN_RIGHT - 1
+    top = MARGIN_TOP
+    bottom = h - MARGIN_BOTTOM - 1
 
-    # Inner vertical grid lines
+    usable_w = right - left
+    usable_h = bottom - top
+
+    col_step = usable_w / _GRID_COLS
+    row_step = usable_h / _GRID_ROWS
+
+    # Inner vertical grid lines (margin-to-margin)
     for i in range(1, _GRID_COLS):
-        x = round(i * col_step)
-        draw.line([(x, 0), (x, h - 1)], fill=_GRID_COLOR)
+        x = round(left + i * col_step)
+        draw.line([(x, top), (x, bottom)], fill=_GRID_COLOR)
 
-    # Inner horizontal grid lines
+    # Inner horizontal grid lines (margin-to-margin)
     for i in range(1, _GRID_ROWS):
-        y = round(i * row_step)
-        draw.line([(0, y), (w - 1, y)], fill=_GRID_COLOR)
+        y = round(top + i * row_step)
+        draw.line([(left, y), (right, y)], fill=_GRID_COLOR)
 
     # Margin boundary lines (brighter)
-    # Left margin
-    draw.line(
-        [(MARGIN_LEFT, 0), (MARGIN_LEFT, h - 1)],
-        fill=_MARGIN_COLOR,
-    )
-    # Right margin
-    right_x = w - MARGIN_RIGHT - 1
-    draw.line(
-        [(right_x, 0), (right_x, h - 1)],
-        fill=_MARGIN_COLOR,
-    )
-    # Top margin
-    draw.line(
-        [(0, MARGIN_TOP), (w - 1, MARGIN_TOP)],
-        fill=_MARGIN_COLOR,
-    )
-    # Bottom margin
-    bottom_y = h - MARGIN_BOTTOM - 1
-    draw.line(
-        [(0, bottom_y), (w - 1, bottom_y)],
-        fill=_MARGIN_COLOR,
-    )
+    draw.line([(left, top), (left, bottom)], fill=_MARGIN_COLOR)
+    draw.line([(right, top), (right, bottom)], fill=_MARGIN_COLOR)
+    draw.line([(left, top), (right, top)], fill=_MARGIN_COLOR)
+    draw.line([(left, bottom), (right, bottom)], fill=_MARGIN_COLOR)
 
     return overlay
 

--- a/tests/test_debug_grid.py
+++ b/tests/test_debug_grid.py
@@ -63,37 +63,82 @@ class TestDrawTouchscreenGrid:
         img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
         result = draw_touchscreen_grid(img)
 
-        # Left margin line at x=MARGIN_LEFT
-        assert result.getpixel((MARGIN_LEFT, TOUCHSCREEN_HEIGHT // 2)) == _MARGIN_COLOR
+        left = MARGIN_LEFT
+        right = TOUCHSCREEN_WIDTH - MARGIN_RIGHT - 1
+        top = MARGIN_TOP
+        bottom = TOUCHSCREEN_HEIGHT - MARGIN_BOTTOM - 1
+        mid_x = (left + right) // 2
+        mid_y = (top + bottom) // 2
 
-        # Top margin line at y=MARGIN_TOP
-        assert result.getpixel((TOUCHSCREEN_WIDTH // 2, MARGIN_TOP)) == _MARGIN_COLOR
+        # Left margin line
+        assert result.getpixel((left, mid_y)) == _MARGIN_COLOR
+        # Right margin line
+        assert result.getpixel((right, mid_y)) == _MARGIN_COLOR
+        # Top margin line
+        assert result.getpixel((mid_x, top)) == _MARGIN_COLOR
+        # Bottom margin line
+        assert result.getpixel((mid_x, bottom)) == _MARGIN_COLOR
 
-        # Right margin line at x = W - MARGIN_RIGHT - 1
-        right_x = TOUCHSCREEN_WIDTH - MARGIN_RIGHT - 1
-        assert result.getpixel((right_x, TOUCHSCREEN_HEIGHT // 2)) == _MARGIN_COLOR
-
-        # Bottom margin line at y = H - MARGIN_BOTTOM - 1
-        bottom_y = TOUCHSCREEN_HEIGHT - MARGIN_BOTTOM - 1
-        assert result.getpixel((TOUCHSCREEN_WIDTH // 2, bottom_y)) == _MARGIN_COLOR
-
-    def test_inner_grid_pixels_present(self):
-        """Inner grid lines should appear at expected positions."""
+    def test_margin_lines_stay_within_bounds(self):
+        """Margin lines should not extend beyond the margin rectangle."""
         img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
         result = draw_touchscreen_grid(img)
 
-        # Vertical grid line at column 5 (midpoint)
-        col_step = TOUCHSCREEN_WIDTH / _GRID_COLS
-        x = round(5 * col_step)
-        pixel = result.getpixel((x, TOUCHSCREEN_HEIGHT // 2))
-        # This pixel should be a grid or margin colour (not black)
+        # Pixels outside the margin rectangle should remain black
+        # Above the top margin on the left margin column
+        assert result.getpixel((MARGIN_LEFT, 0)) == (0, 0, 0)
+        # Below the bottom margin on the left margin column
+        assert result.getpixel((MARGIN_LEFT, TOUCHSCREEN_HEIGHT - 1)) == (0, 0, 0)
+        # Left of the left margin on the top margin row
+        assert result.getpixel((0, MARGIN_TOP)) == (0, 0, 0)
+        # Right of the right margin on the top margin row
+        assert result.getpixel((TOUCHSCREEN_WIDTH - 1, MARGIN_TOP)) == (0, 0, 0)
+
+    def test_inner_grid_pixels_present(self):
+        """Inner grid lines should appear within the usable area."""
+        img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        result = draw_touchscreen_grid(img)
+
+        left = MARGIN_LEFT
+        right = TOUCHSCREEN_WIDTH - MARGIN_RIGHT - 1
+        top = MARGIN_TOP
+        bottom = TOUCHSCREEN_HEIGHT - MARGIN_BOTTOM - 1
+        usable_w = right - left
+        usable_h = bottom - top
+
+        # Vertical grid line at column 2 (midpoint of 4 columns)
+        col_step = usable_w / _GRID_COLS
+        x = round(left + 2 * col_step)
+        mid_y = (top + bottom) // 2
+        pixel = result.getpixel((x, mid_y))
         assert pixel != (0, 0, 0)
 
-        # Horizontal grid line at row 5 (midpoint)
-        row_step = TOUCHSCREEN_HEIGHT / _GRID_ROWS
-        y = round(5 * row_step)
-        pixel = result.getpixel((TOUCHSCREEN_WIDTH // 2, y))
+        # Horizontal grid line at row 2 (midpoint of 4 rows)
+        row_step = usable_h / _GRID_ROWS
+        y = round(top + 2 * row_step)
+        mid_x = (left + right) // 2
+        pixel = result.getpixel((mid_x, y))
         assert pixel != (0, 0, 0)
+
+    def test_inner_grid_lines_stay_within_margins(self):
+        """Inner grid lines should not extend beyond the margin rectangle."""
+        img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        result = draw_touchscreen_grid(img)
+
+        left = MARGIN_LEFT
+        right = TOUCHSCREEN_WIDTH - MARGIN_RIGHT - 1
+        top = MARGIN_TOP
+        bottom = TOUCHSCREEN_HEIGHT - MARGIN_BOTTOM - 1
+        usable_w = right - left
+
+        # Pick a vertical inner grid line
+        col_step = usable_w / _GRID_COLS
+        x = round(left + 1 * col_step)
+
+        # The pixel above the top margin on that column should be black
+        assert result.getpixel((x, 0)) == (0, 0, 0)
+        # The pixel below the bottom margin on that column should be black
+        assert result.getpixel((x, TOUCHSCREEN_HEIGHT - 1)) == (0, 0, 0)
 
     def test_works_with_non_black_background(self):
         """Grid draws over arbitrary backgrounds without error."""


### PR DESCRIPTION
## Summary
- Changed the touchscreen debug grid from 10x10 (full-image) to 4x4 (margin-bounded)
- Grid lines and margin boundary lines now run only within the usable area between margins, not edge-to-edge
- Added new tests verifying that no grid pixels bleed outside the margin rectangle