### PR TITLE
Refactor: replace lazy imports with eager imports in ui/elements

### DIFF
--- a/src/deckboard/ui/elements/__init__.py
+++ b/src/deckboard/ui/elements/__init__.py
@@ -3,20 +3,7 @@
 from __future__ import annotations
 
 from .base import Element
+from .dual_value import LargeDualValue, SmallDualValue
+from .text import LargeText, SmallText
 
-__all__ = ["Element", "LargeDualValue", "SmallDualValue", "LargeText", "SmallText"]
-
-
-def __getattr__(name: str):
-    if name in {"LargeText", "SmallText"}:
-        from .text import LargeText, SmallText
-
-        return {"LargeText": LargeText, "SmallText": SmallText}[name]
-    if name in {"LargeDualValue", "SmallDualValue"}:
-        from .dual_value import LargeDualValue, SmallDualValue
-
-        return {
-            "LargeDualValue": LargeDualValue,
-            "SmallDualValue": SmallDualValue,
-        }[name]
-    raise AttributeError(name)
+__all__ = ["Element", "LargeDualValue", "LargeText", "SmallDualValue", "SmallText"]


### PR DESCRIPTION
## Summary
- Replaces the module-level `__getattr__` lazy-import pattern in `src/deckboard/ui/elements/__init__.py` with eager imports at the top of the file.
- Aligns with the eager import style already used in `ui/controls/__init__.py` for consistency across the codebase.
- All 790 tests pass with 99.94% coverage.