### PR TITLE
Add SVG preview tool for Stream Deck+

### DIFF
--- a/src/deckboard/tools/__init__.py
+++ b/src/deckboard/tools/__init__.py
@@ -1,0 +1,3 @@
+"""CLI tools for the deckboard library."""
+
+from __future__ import annotations

--- a/src/deckboard/tools/__main__.py
+++ b/src/deckboard/tools/__main__.py
@@ -1,0 +1,7 @@
+"""Allow running the preview tool via ``python -m deckboard.tools``."""
+
+from __future__ import annotations
+
+from .preview import main
+
+main()

--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -210,16 +210,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _find_and_open_device() -> object:
-    """Discover, open, and return the first Stream Deck+ device."""
+    """Discover, open, and return the first Stream Deck+ device.
+
+    Prints an error and exits if no device is found.
+    """
     from StreamDeck.DeviceManager import DeviceManager  # type: ignore[import-untyped]
 
     devices = DeviceManager().enumerate()
     if not devices:
-        logger.error("No Stream Deck devices found")
+        print("ERROR: No Stream Deck devices found", file=sys.stderr)  # noqa: T201
         sys.exit(1)
 
     deck = devices[0]
     deck.open()
+    logger.debug("Opened device: %s", deck.deck_type())
     return deck
 
 
@@ -256,7 +260,7 @@ async def push_to_device(
             TOUCHSCREEN_HEIGHT,
         )
 
-        logger.info("Preview pushed — press Ctrl+C to exit")
+        print("Preview pushed — press Ctrl+C to exit", file=sys.stderr)  # noqa: T201
         await loop.run_in_executor(None, _wait_forever)
     except KeyboardInterrupt:
         pass
@@ -290,21 +294,25 @@ def render_preview(
         svg_path: Path | None = getattr(args, f"key{i}", None)
         if svg_path is not None:
             if not svg_path.exists():
-                logger.error("Key SVG not found: %s", svg_path)
+                print(f"ERROR: Key SVG not found: {svg_path}", file=sys.stderr)  # noqa: T201
                 sys.exit(1)
             img = load_svg(svg_path, ICON_SIZE, ICON_SIZE)
             key_images[i] = compose_key_image(img)
-            logger.debug("Rendered key %d from %s", i, svg_path)
+            logger.info(
+                "Rendered key %d from %s (%dx%d)", i, svg_path, img.width, img.height
+            )
 
     for i in range(PANEL_COUNT):
         svg_path = getattr(args, f"card{i}", None)
         if svg_path is not None:
             if not svg_path.exists():
-                logger.error("Card SVG not found: %s", svg_path)
+                print(f"ERROR: Card SVG not found: {svg_path}", file=sys.stderr)  # noqa: T201
                 sys.exit(1)
             img = load_svg(svg_path, PANEL_WIDTH, PANEL_HEIGHT)
             card_images[i] = compose_card_image(img)
-            logger.debug("Rendered card %d from %s", i, svg_path)
+            logger.info(
+                "Rendered card %d from %s (%dx%d)", i, svg_path, img.width, img.height
+            )
 
     touchstrip_bytes = compose_touchstrip(card_images)
     return key_images, touchstrip_bytes
@@ -319,3 +327,7 @@ def main(argv: list[str] | None = None) -> None:
 
     key_images, touchstrip_bytes = render_preview(args)
     asyncio.run(push_to_device(key_images, touchstrip_bytes))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -18,6 +18,7 @@ import io
 import logging
 import os
 import platform
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -278,20 +279,25 @@ async def push_to_device(
         )
 
         print("Preview pushed — press Ctrl+C to exit", file=sys.stderr)  # noqa: T201
-        await loop.run_in_executor(None, _wait_forever)
-    except KeyboardInterrupt:
-        pass
+        await _wait_for_interrupt()
     finally:
         await loop.run_in_executor(None, deck.reset)  # type: ignore[union-attr]
         await loop.run_in_executor(None, deck.close)  # type: ignore[union-attr]
 
 
-def _wait_forever() -> None:  # pragma: no cover
-    """Block until interrupted (runs in executor thread)."""
-    import threading
+async def _wait_for_interrupt() -> None:
+    """Wait until the process receives SIGINT (Ctrl+C).
 
-    evt = threading.Event()
-    evt.wait()
+    Uses an :class:`asyncio.Event` set by a signal handler so the event
+    loop stays responsive and shuts down cleanly on the first Ctrl+C.
+    """
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    loop.add_signal_handler(signal.SIGINT, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        loop.remove_signal_handler(signal.SIGINT)
 
 
 # -- Orchestration ------------------------------------------------------------

--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -1,0 +1,321 @@
+"""Preview SVG designs on a physical Stream Deck+ device.
+
+Run with::
+
+    python -m deckboard.tools.preview \\
+        --card0 my_card.svg --key0 my_key.svg
+
+Only the specified slots are updated; unspecified keys and cards are
+left blank (black).  SVGs are scaled to fit the target area while
+preserving aspect ratio and centred on a black background.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import logging
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+from deckboard.render.icons import IconError
+from deckboard.render.key_renderer import _encode_jpeg
+from deckboard.render.metrics import (
+    ICON_PADDING,
+    ICON_SIZE,
+    KEY_SIZE,
+    MARGIN_LEFT,
+    MARGIN_TOP,
+    PANEL_COUNT,
+    PANEL_GAP,
+    PANEL_HEIGHT,
+    PANEL_WIDTH,
+    TOUCHSCREEN_HEIGHT,
+    TOUCHSCREEN_WIDTH,
+)
+
+logger = logging.getLogger(__name__)
+
+_KEY_COUNT = 8
+
+
+# -- SVG loading -------------------------------------------------------------
+
+
+def _svg_to_png_fit(svg_data: bytes, max_width: int, max_height: int) -> bytes:
+    """Rasterise SVG bytes to PNG, fitting within a bounding box.
+
+    Unlike ``icons._svg_to_png`` (which forces exact dimensions), this
+    function preserves the SVG's intrinsic aspect ratio by only
+    constraining the output width, then scaling down if the height
+    exceeds *max_height*.
+    """
+    try:
+        if platform.system() == "Darwin":
+            brew_lib = Path("/opt/homebrew/lib")
+            if brew_lib.exists():
+                os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
+
+        import cairosvg  # noqa: delayed import
+
+        # First pass: constrain by width to get natural aspect ratio.
+        png_bytes = cairosvg.svg2png(
+            bytestring=svg_data,
+            output_width=max_width,
+        )
+        img = Image.open(io.BytesIO(png_bytes))
+        if img.height > max_height:
+            # Width-constrained result is too tall; constrain by height.
+            png_bytes = cairosvg.svg2png(
+                bytestring=svg_data,
+                output_height=max_height,
+            )
+        return png_bytes
+    except (OSError, ImportError) as exc:
+        logger.debug("cairosvg unavailable (%s), trying rsvg-convert", exc)
+
+    try:
+        result = subprocess.run(
+            [
+                "rsvg-convert",
+                "--keep-aspect-ratio",
+                "--width",
+                str(max_width),
+                "--height",
+                str(max_height),
+                "--format",
+                "png",
+            ],
+            input=svg_data,
+            capture_output=True,
+            check=True,
+            timeout=10,
+        )
+        return result.stdout
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        logger.debug("rsvg-convert unavailable (%s)", exc)
+
+    raise IconError(
+        "No SVG renderer available. Install one of:\n"
+        "  - System library: brew install cairo  (macOS) or apt install libcairo2 (Linux)\n"
+        "  - CLI tool: apt install librsvg2-bin\n"
+        "  - Python package: pip install cairosvg"
+    )
+
+
+def load_svg(path: Path, max_width: int, max_height: int) -> Image.Image:
+    """Load an SVG file and return a PIL Image fitted to *max_width* x *max_height*.
+
+    The SVG is rasterised at a size that preserves its intrinsic aspect
+    ratio.  The result is guaranteed to be at most *max_width* wide and
+    *max_height* tall.
+    """
+    svg_data = path.read_bytes()
+    png_bytes = _svg_to_png_fit(svg_data, max_width, max_height)
+    img = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+    # Final safety net — thumbnail never upscales, only shrinks.
+    img.thumbnail((max_width, max_height), Image.LANCZOS)
+    return img
+
+
+# -- Image composition -------------------------------------------------------
+
+
+def compose_key_image(svg_img: Image.Image) -> bytes:
+    """Place *svg_img* centred on a 120x120 black key canvas.
+
+    The image is fitted inside the icon area (80x80 by default) using
+    ``ICON_PADDING`` as the margin on each side.
+    """
+    canvas = Image.new("RGB", KEY_SIZE, "black")
+    x = ICON_PADDING + (ICON_SIZE - svg_img.width) // 2
+    y = ICON_PADDING + (ICON_SIZE - svg_img.height) // 2
+    if svg_img.mode == "RGBA":
+        canvas.paste(svg_img, (x, y), svg_img)
+    else:
+        canvas.paste(svg_img, (x, y))
+    return _encode_jpeg(canvas)
+
+
+def compose_card_image(svg_img: Image.Image) -> Image.Image:
+    """Place *svg_img* centred on a panel-sized black card canvas."""
+    canvas = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), "black")
+    x = (PANEL_WIDTH - svg_img.width) // 2
+    y = (PANEL_HEIGHT - svg_img.height) // 2
+    if svg_img.mode == "RGBA":
+        canvas.paste(svg_img, (x, y), svg_img)
+    else:
+        canvas.paste(svg_img, (x, y))
+    return canvas
+
+
+def compose_touchstrip(card_images: list[Image.Image | None]) -> bytes:
+    """Compose up to 4 card images into a single 800x100 touchscreen JPEG."""
+    img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+    for index, card_image in enumerate(card_images):
+        if index >= PANEL_COUNT:
+            break
+        if card_image is not None:
+            x = MARGIN_LEFT + index * (PANEL_WIDTH + PANEL_GAP)
+            img.paste(card_image, (x, MARGIN_TOP))
+    return _encode_jpeg(img)
+
+
+# -- CLI argument parsing -----------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``argparse`` parser for the preview tool."""
+    parser = argparse.ArgumentParser(
+        prog="python -m deckboard.tools.preview",
+        description="Preview SVG designs on a Stream Deck+ device.",
+    )
+    for i in range(_KEY_COUNT):
+        parser.add_argument(
+            f"--key{i}",
+            type=Path,
+            default=None,
+            metavar="SVG",
+            help=f"SVG file for key slot {i}",
+        )
+    for i in range(PANEL_COUNT):
+        parser.add_argument(
+            f"--card{i}",
+            type=Path,
+            default=None,
+            metavar="SVG",
+            help=f"SVG file for card slot {i}",
+        )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    return build_parser().parse_args(argv)
+
+
+# -- Device interaction -------------------------------------------------------
+
+
+def _find_and_open_device() -> object:
+    """Discover, open, and return the first Stream Deck+ device."""
+    from StreamDeck.DeviceManager import DeviceManager  # type: ignore[import-untyped]
+
+    devices = DeviceManager().enumerate()
+    if not devices:
+        logger.error("No Stream Deck devices found")
+        sys.exit(1)
+
+    deck = devices[0]
+    deck.open()
+    return deck
+
+
+async def push_to_device(
+    key_images: dict[int, bytes],
+    touchstrip_bytes: bytes,
+) -> None:
+    """Push rendered images to the physical Stream Deck+.
+
+    *key_images* maps key indices to JPEG bytes.  *touchstrip_bytes* is
+    the full 800x100 touchscreen JPEG.
+    """
+    loop = asyncio.get_running_loop()
+    deck = await loop.run_in_executor(None, _find_and_open_device)
+
+    try:
+        for key_index in range(_KEY_COUNT):
+            jpeg = key_images.get(key_index)
+            if jpeg is not None:
+                await loop.run_in_executor(
+                    None,
+                    deck.set_key_image,
+                    key_index,
+                    jpeg,  # type: ignore[union-attr]
+                )
+
+        await loop.run_in_executor(
+            None,
+            deck.set_touchscreen_image,  # type: ignore[union-attr]
+            touchstrip_bytes,
+            0,
+            0,
+            TOUCHSCREEN_WIDTH,
+            TOUCHSCREEN_HEIGHT,
+        )
+
+        logger.info("Preview pushed — press Ctrl+C to exit")
+        await loop.run_in_executor(None, _wait_forever)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await loop.run_in_executor(None, deck.reset)  # type: ignore[union-attr]
+        await loop.run_in_executor(None, deck.close)  # type: ignore[union-attr]
+
+
+def _wait_forever() -> None:  # pragma: no cover
+    """Block until interrupted (runs in executor thread)."""
+    import threading
+
+    evt = threading.Event()
+    evt.wait()
+
+
+# -- Orchestration ------------------------------------------------------------
+
+
+def render_preview(
+    args: argparse.Namespace,
+) -> tuple[dict[int, bytes], bytes]:
+    """Render all specified SVGs and return key images + touchstrip JPEG.
+
+    Returns a ``(key_images, touchstrip_bytes)`` tuple.
+    """
+    key_images: dict[int, bytes] = {}
+    card_images: list[Image.Image | None] = [None] * PANEL_COUNT
+
+    for i in range(_KEY_COUNT):
+        svg_path: Path | None = getattr(args, f"key{i}", None)
+        if svg_path is not None:
+            if not svg_path.exists():
+                logger.error("Key SVG not found: %s", svg_path)
+                sys.exit(1)
+            img = load_svg(svg_path, ICON_SIZE, ICON_SIZE)
+            key_images[i] = compose_key_image(img)
+            logger.debug("Rendered key %d from %s", i, svg_path)
+
+    for i in range(PANEL_COUNT):
+        svg_path = getattr(args, f"card{i}", None)
+        if svg_path is not None:
+            if not svg_path.exists():
+                logger.error("Card SVG not found: %s", svg_path)
+                sys.exit(1)
+            img = load_svg(svg_path, PANEL_WIDTH, PANEL_HEIGHT)
+            card_images[i] = compose_card_image(img)
+            logger.debug("Rendered card %d from %s", i, svg_path)
+
+    touchstrip_bytes = compose_touchstrip(card_images)
+    return key_images, touchstrip_bytes
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the preview tool."""
+    args = parse_args(argv)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+    key_images, touchstrip_bytes = render_preview(args)
+    asyncio.run(push_to_device(key_images, touchstrip_bytes))

--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -193,6 +193,14 @@ def build_parser() -> argparse.ArgumentParser:
             help=f"SVG file for card slot {i}",
         )
     parser.add_argument(
+        "-b",
+        "--brightness",
+        type=int,
+        default=80,
+        metavar="PCT",
+        help="Screen brightness 0-100 (default: 80)",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -230,16 +238,25 @@ def _find_and_open_device() -> object:
 async def push_to_device(
     key_images: dict[int, bytes],
     touchstrip_bytes: bytes,
+    brightness: int = 80,
 ) -> None:
     """Push rendered images to the physical Stream Deck+.
 
     *key_images* maps key indices to JPEG bytes.  *touchstrip_bytes* is
-    the full 800x100 touchscreen JPEG.
+    the full 800x100 touchscreen JPEG.  *brightness* sets the screen
+    brightness (0-100).
     """
     loop = asyncio.get_running_loop()
     deck = await loop.run_in_executor(None, _find_and_open_device)
 
     try:
+        brightness = max(0, min(100, brightness))
+        await loop.run_in_executor(
+            None,
+            deck.set_brightness,
+            brightness,  # type: ignore[union-attr]
+        )
+
         for key_index in range(_KEY_COUNT):
             jpeg = key_images.get(key_index)
             if jpeg is not None:
@@ -326,7 +343,7 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
 
     key_images, touchstrip_bytes = render_preview(args)
-    asyncio.run(push_to_device(key_images, touchstrip_bytes))
+    asyncio.run(push_to_device(key_images, touchstrip_bytes, args.brightness))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -240,6 +240,18 @@ class TestParser:
         for i in range(PANEL_COUNT):
             assert getattr(args, f"card{i}") == tmp_path / f"c{i}.svg"
 
+    def test_brightness_default(self):
+        args = parse_args([])
+        assert args.brightness == 80
+
+    def test_brightness_custom(self):
+        args = parse_args(["--brightness", "50"])
+        assert args.brightness == 50
+
+    def test_brightness_short(self):
+        args = parse_args(["-b", "30"])
+        assert args.brightness == 30
+
     def test_verbose_flag(self):
         args = parse_args(["-v"])
         assert args.verbose is True
@@ -315,14 +327,22 @@ class TestMain:
     def test_main_calls_push(self, mock_push: AsyncMock, square_svg: Path):
         main(["--key0", str(square_svg)])
         mock_push.assert_awaited_once()
-        key_images, touchstrip = mock_push.call_args[0]
+        key_images, touchstrip, brightness = mock_push.call_args[0]
         assert 0 in key_images
         assert isinstance(touchstrip, bytes)
+        assert brightness == 80
 
     @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
-    def test_main_no_args(self, mock_push: AsyncMock):
+    def test_main_default_brightness(self, mock_push: AsyncMock):
         main([])
-        mock_push.assert_awaited_once()
+        _, _, brightness = mock_push.call_args[0]
+        assert brightness == 80
+
+    @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_custom_brightness(self, mock_push: AsyncMock):
+        main(["--brightness", "40"])
+        _, _, brightness = mock_push.call_args[0]
+        assert brightness == 40
 
     @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
     def test_main_verbose(self, mock_push: AsyncMock):
@@ -363,8 +383,9 @@ class TestPushToDevice:
                 )
                 mock_loop.return_value = loop_instance
 
-                await push_to_device({0: key_jpeg}, ts_jpeg)
+                await push_to_device({0: key_jpeg}, ts_jpeg, brightness=60)
 
+        mock_streamdeck_device.set_brightness.assert_called_once_with(60)
         mock_streamdeck_device.set_key_image.assert_called_once_with(0, key_jpeg)
         mock_streamdeck_device.set_touchscreen_image.assert_called_once_with(
             ts_jpeg,
@@ -375,6 +396,36 @@ class TestPushToDevice:
         )
         mock_streamdeck_device.reset.assert_called_once()
         mock_streamdeck_device.close.assert_called_once()
+
+    async def test_brightness_clamped(self, mock_streamdeck_device: MagicMock):
+        """Values outside 0-100 are clamped."""
+        from deckboard.tools.preview import _wait_forever, push_to_device
+
+        blank_ts = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        buf = io.BytesIO()
+        blank_ts.save(buf, format="JPEG")
+        ts_jpeg = buf.getvalue()
+
+        with patch(
+            "deckboard.tools.preview._find_and_open_device",
+            return_value=mock_streamdeck_device,
+        ):
+
+            async def mock_executor(executor, fn, *args):
+                if fn is _wait_forever:
+                    raise KeyboardInterrupt
+                return fn(*args)
+
+            with patch("asyncio.get_running_loop") as mock_loop:
+                loop_instance = MagicMock()
+                loop_instance.run_in_executor = AsyncMock(
+                    side_effect=mock_executor,
+                )
+                mock_loop.return_value = loop_instance
+
+                await push_to_device({}, ts_jpeg, brightness=150)
+
+        mock_streamdeck_device.set_brightness.assert_called_once_with(100)
 
 
 # -- _svg_to_png_fit ---------------------------------------------------------

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,465 @@
+"""Tests for deckboard.tools.preview — SVG preview CLI tool."""
+
+from __future__ import annotations
+
+import argparse
+import io
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from deckboard.render.metrics import (
+    ICON_PADDING,
+    ICON_SIZE,
+    KEY_SIZE,
+    MARGIN_LEFT,
+    MARGIN_TOP,
+    PANEL_COUNT,
+    PANEL_GAP,
+    PANEL_HEIGHT,
+    PANEL_WIDTH,
+    TOUCHSCREEN_HEIGHT,
+    TOUCHSCREEN_WIDTH,
+)
+from deckboard.render.icons import IconError
+from deckboard.tools.preview import (
+    _KEY_COUNT,
+    _svg_to_png_fit,
+    build_parser,
+    compose_card_image,
+    compose_key_image,
+    compose_touchstrip,
+    load_svg,
+    main,
+    parse_args,
+    render_preview,
+)
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def tiny_svg(tmp_path: Path) -> Path:
+    """Write a minimal valid SVG and return its path."""
+    svg = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20">'
+        b'<rect width="40" height="20" fill="red"/>'
+        b"</svg>"
+    )
+    p = tmp_path / "icon.svg"
+    p.write_bytes(svg)
+    return p
+
+
+@pytest.fixture
+def square_svg(tmp_path: Path) -> Path:
+    """Write a square SVG for key tests."""
+    svg = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">'
+        b'<rect width="80" height="80" fill="blue"/>'
+        b"</svg>"
+    )
+    p = tmp_path / "square.svg"
+    p.write_bytes(svg)
+    return p
+
+
+@pytest.fixture
+def wide_svg(tmp_path: Path) -> Path:
+    """Write a wide SVG for card tests."""
+    svg = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="200" height="50">'
+        b'<rect width="200" height="50" fill="green"/>'
+        b"</svg>"
+    )
+    p = tmp_path / "wide.svg"
+    p.write_bytes(svg)
+    return p
+
+
+# -- load_svg ----------------------------------------------------------------
+
+
+class TestLoadSvg:
+    def test_returns_rgba_image(self, tiny_svg: Path):
+        img = load_svg(tiny_svg, 80, 80)
+        assert img.mode == "RGBA"
+
+    def test_fits_within_bounds(self, tiny_svg: Path):
+        img = load_svg(tiny_svg, 80, 80)
+        assert img.width <= 80
+        assert img.height <= 80
+
+    def test_preserves_aspect_ratio(self, tiny_svg: Path):
+        """A 40x20 SVG scaled to 80x80 should be 80x40 (2:1 ratio)."""
+        img = load_svg(tiny_svg, 80, 80)
+        assert img.width == 80
+        assert img.height == 40
+
+    def test_exact_fit(self, square_svg: Path):
+        """An 80x80 SVG scaled to 80x80 should remain 80x80."""
+        img = load_svg(square_svg, 80, 80)
+        assert img.size == (80, 80)
+
+    def test_wide_image_constrained_by_width(self, wide_svg: Path):
+        """A 200x50 SVG fitted to 197x98 keeps width as the constraint."""
+        img = load_svg(wide_svg, PANEL_WIDTH, PANEL_HEIGHT)
+        assert img.width <= PANEL_WIDTH
+        assert img.height <= PANEL_HEIGHT
+
+
+# -- compose_key_image -------------------------------------------------------
+
+
+class TestComposeKeyImage:
+    def test_returns_jpeg_bytes(self):
+        svg_img = Image.new("RGBA", (80, 80), (255, 0, 0, 255))
+        result = compose_key_image(svg_img)
+        assert isinstance(result, bytes)
+        # Verify it's valid JPEG
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.format == "JPEG"
+        assert decoded.size == KEY_SIZE
+
+    def test_centres_icon_in_key(self):
+        """A small image should be centred in the icon area."""
+        svg_img = Image.new("RGBA", (40, 40), (255, 0, 0, 255))
+        result = compose_key_image(svg_img)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.size == KEY_SIZE
+
+    def test_rgb_image_no_alpha(self):
+        """An RGB image (no alpha) should compose without error."""
+        svg_img = Image.new("RGB", (60, 60), (0, 255, 0))
+        result = compose_key_image(svg_img)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.size == KEY_SIZE
+
+    def test_full_size_icon(self):
+        """An 80x80 icon should be placed at (ICON_PADDING, ICON_PADDING)."""
+        svg_img = Image.new("RGBA", (ICON_SIZE, ICON_SIZE), (255, 0, 0, 255))
+        result = compose_key_image(svg_img)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.size == KEY_SIZE
+
+
+# -- compose_card_image ------------------------------------------------------
+
+
+class TestComposeCardImage:
+    def test_returns_pil_image(self):
+        svg_img = Image.new("RGBA", (100, 50), (0, 0, 255, 255))
+        result = compose_card_image(svg_img)
+        assert isinstance(result, Image.Image)
+        assert result.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_centres_image(self):
+        """A 100x50 image on a 197x98 canvas should be centred."""
+        svg_img = Image.new("RGBA", (100, 50), (255, 0, 0, 255))
+        result = compose_card_image(svg_img)
+        assert result.size == (PANEL_WIDTH, PANEL_HEIGHT)
+        # The non-black centre should contain the image
+        centre_pixel = result.getpixel((PANEL_WIDTH // 2, PANEL_HEIGHT // 2))
+        assert centre_pixel != (0, 0, 0)
+
+    def test_rgb_image_no_alpha(self):
+        svg_img = Image.new("RGB", (50, 30), (0, 255, 0))
+        result = compose_card_image(svg_img)
+        assert result.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+
+# -- compose_touchstrip ------------------------------------------------------
+
+
+class TestComposeTouchstrip:
+    def test_returns_jpeg_bytes(self):
+        cards: list[Image.Image | None] = [None] * PANEL_COUNT
+        result = compose_touchstrip(cards)
+        assert isinstance(result, bytes)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
+
+    def test_all_none_produces_black(self):
+        cards: list[Image.Image | None] = [None] * PANEL_COUNT
+        result = compose_touchstrip(cards)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        # Should be mostly black (JPEG compression may introduce slight noise)
+        px = decoded.getpixel((0, 0))
+        assert all(c < 10 for c in px)
+
+    def test_single_card_placed_correctly(self):
+        red_card = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), (255, 0, 0))
+        cards: list[Image.Image | None] = [red_card, None, None, None]
+        result = compose_touchstrip(cards)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        # Card 0 should be at x=MARGIN_LEFT
+        px = decoded.getpixel((MARGIN_LEFT + 5, MARGIN_TOP + 5))
+        assert px[0] > 200  # red channel high
+
+    def test_excess_cards_ignored(self):
+        """More than PANEL_COUNT cards should be silently truncated."""
+        cards: list[Image.Image | None] = [
+            Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), (255, 0, 0)) for _ in range(6)
+        ]
+        result = compose_touchstrip(cards)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
+
+
+# -- build_parser / parse_args -----------------------------------------------
+
+
+class TestParser:
+    def test_no_args(self):
+        args = parse_args([])
+        for i in range(_KEY_COUNT):
+            assert getattr(args, f"key{i}") is None
+        for i in range(PANEL_COUNT):
+            assert getattr(args, f"card{i}") is None
+
+    def test_key_arg(self, tmp_path: Path):
+        args = parse_args([f"--key0", str(tmp_path / "k.svg")])
+        assert args.key0 == tmp_path / "k.svg"
+
+    def test_card_arg(self, tmp_path: Path):
+        args = parse_args(["--card2", str(tmp_path / "c.svg")])
+        assert args.card2 == tmp_path / "c.svg"
+
+    def test_all_keys_and_cards(self, tmp_path: Path):
+        argv = []
+        for i in range(_KEY_COUNT):
+            argv.extend([f"--key{i}", str(tmp_path / f"k{i}.svg")])
+        for i in range(PANEL_COUNT):
+            argv.extend([f"--card{i}", str(tmp_path / f"c{i}.svg")])
+        args = parse_args(argv)
+        for i in range(_KEY_COUNT):
+            assert getattr(args, f"key{i}") == tmp_path / f"k{i}.svg"
+        for i in range(PANEL_COUNT):
+            assert getattr(args, f"card{i}") == tmp_path / f"c{i}.svg"
+
+    def test_verbose_flag(self):
+        args = parse_args(["-v"])
+        assert args.verbose is True
+
+    def test_verbose_long(self):
+        args = parse_args(["--verbose"])
+        assert args.verbose is True
+
+    def test_build_parser_returns_parser(self):
+        parser = build_parser()
+        assert isinstance(parser, argparse.ArgumentParser)
+
+
+# -- render_preview ----------------------------------------------------------
+
+
+class TestRenderPreview:
+    def test_no_files(self):
+        args = parse_args([])
+        key_images, touchstrip = render_preview(args)
+        assert key_images == {}
+        assert isinstance(touchstrip, bytes)
+
+    def test_with_key_svg(self, square_svg: Path):
+        args = parse_args(["--key0", str(square_svg)])
+        key_images, touchstrip = render_preview(args)
+        assert 0 in key_images
+        decoded = Image.open(io.BytesIO(key_images[0]))
+        assert decoded.size == KEY_SIZE
+
+    def test_with_card_svg(self, wide_svg: Path):
+        args = parse_args(["--card1", str(wide_svg)])
+        key_images, touchstrip = render_preview(args)
+        assert key_images == {}
+        decoded = Image.open(io.BytesIO(touchstrip))
+        assert decoded.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
+
+    def test_with_both(self, square_svg: Path, wide_svg: Path):
+        args = parse_args(
+            [
+                "--key3",
+                str(square_svg),
+                "--card0",
+                str(wide_svg),
+            ]
+        )
+        key_images, touchstrip = render_preview(args)
+        assert 3 in key_images
+        assert isinstance(touchstrip, bytes)
+
+    def test_missing_key_svg_exits(self, tmp_path: Path):
+        args = parse_args(["--key0", str(tmp_path / "nonexistent.svg")])
+        with pytest.raises(SystemExit):
+            render_preview(args)
+
+    def test_missing_card_svg_exits(self, tmp_path: Path):
+        args = parse_args(["--card0", str(tmp_path / "nonexistent.svg")])
+        with pytest.raises(SystemExit):
+            render_preview(args)
+
+
+# -- main / push_to_device ---------------------------------------------------
+
+
+class TestMain:
+    @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_calls_push(self, mock_push: AsyncMock, square_svg: Path):
+        main(["--key0", str(square_svg)])
+        mock_push.assert_awaited_once()
+        key_images, touchstrip = mock_push.call_args[0]
+        assert 0 in key_images
+        assert isinstance(touchstrip, bytes)
+
+    @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_no_args(self, mock_push: AsyncMock):
+        main([])
+        mock_push.assert_awaited_once()
+
+    @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_verbose(self, mock_push: AsyncMock):
+        main(["-v"])
+        mock_push.assert_awaited_once()
+
+
+class TestPushToDevice:
+    async def test_push_opens_and_pushes(self, mock_streamdeck_device: MagicMock):
+        from deckboard.tools.preview import _wait_forever, push_to_device
+
+        # Create minimal key image and touchstrip
+        blank_key = Image.new("RGB", KEY_SIZE, "black")
+        buf = io.BytesIO()
+        blank_key.save(buf, format="JPEG")
+        key_jpeg = buf.getvalue()
+
+        blank_ts = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        buf2 = io.BytesIO()
+        blank_ts.save(buf2, format="JPEG")
+        ts_jpeg = buf2.getvalue()
+
+        with patch(
+            "deckboard.tools.preview._find_and_open_device",
+            return_value=mock_streamdeck_device,
+        ):
+
+            async def mock_executor(executor, fn, *args):
+                # Let device calls through, interrupt on _wait_forever
+                if fn is _wait_forever:
+                    raise KeyboardInterrupt
+                return fn(*args)
+
+            with patch("asyncio.get_running_loop") as mock_loop:
+                loop_instance = MagicMock()
+                loop_instance.run_in_executor = AsyncMock(
+                    side_effect=mock_executor,
+                )
+                mock_loop.return_value = loop_instance
+
+                await push_to_device({0: key_jpeg}, ts_jpeg)
+
+        mock_streamdeck_device.set_key_image.assert_called_once_with(0, key_jpeg)
+        mock_streamdeck_device.set_touchscreen_image.assert_called_once_with(
+            ts_jpeg,
+            0,
+            0,
+            TOUCHSCREEN_WIDTH,
+            TOUCHSCREEN_HEIGHT,
+        )
+        mock_streamdeck_device.reset.assert_called_once()
+        mock_streamdeck_device.close.assert_called_once()
+
+
+# -- _svg_to_png_fit ---------------------------------------------------------
+
+
+class TestSvgToPngFit:
+    def test_tall_svg_constrained_by_height(self, tmp_path: Path):
+        """An SVG taller than max_height triggers the height-constrained path."""
+        # 20x200 SVG → when constrained to width=80, result is 80x800 → too tall
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="20" height="200">'
+            b'<rect width="20" height="200" fill="red"/>'
+            b"</svg>"
+        )
+        png_bytes = _svg_to_png_fit(svg, 80, 80)
+        img = Image.open(io.BytesIO(png_bytes))
+        assert img.height <= 80
+
+    def test_cairosvg_fallback_to_rsvg(self):
+        """When cairosvg is unavailable, fall back to rsvg-convert."""
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            b'<rect width="10" height="10" fill="red"/>'
+            b"</svg>"
+        )
+        fake_png = Image.new("RGB", (10, 10), "red")
+        buf = io.BytesIO()
+        fake_png.save(buf, format="PNG")
+        fake_png_bytes = buf.getvalue()
+
+        with patch.dict("sys.modules", {"cairosvg": None}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout=fake_png_bytes)
+                result = _svg_to_png_fit(svg, 80, 80)
+                assert result == fake_png_bytes
+                mock_run.assert_called_once()
+
+    def test_no_renderer_raises(self):
+        """When both cairosvg and rsvg-convert fail, raise IconError."""
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
+
+        with patch.dict("sys.modules", {"cairosvg": None}):
+            with patch(
+                "subprocess.run",
+                side_effect=FileNotFoundError("no rsvg"),
+            ):
+                with pytest.raises(IconError, match="No SVG renderer"):
+                    _svg_to_png_fit(svg, 80, 80)
+
+
+# -- _find_and_open_device ---------------------------------------------------
+
+
+class TestFindAndOpenDevice:
+    def test_no_devices_exits(self):
+        from deckboard.tools.preview import _find_and_open_device
+
+        mock_dm = MagicMock()
+        mock_dm.return_value.enumerate.return_value = []
+        with patch(
+            "StreamDeck.DeviceManager.DeviceManager",
+            mock_dm,
+        ):
+            with pytest.raises(SystemExit):
+                _find_and_open_device()
+
+    def test_opens_first_device(self):
+        from deckboard.tools.preview import _find_and_open_device
+
+        device = MagicMock()
+        mock_dm = MagicMock()
+        mock_dm.return_value.enumerate.return_value = [device]
+        with patch(
+            "StreamDeck.DeviceManager.DeviceManager",
+            mock_dm,
+        ):
+            result = _find_and_open_device()
+        device.open.assert_called_once()
+        assert result is device
+
+
+# -- __main__ ----------------------------------------------------------------
+
+
+class TestMainModule:
+    @patch("deckboard.tools.preview.main")
+    def test_main_module(self, mock_main: MagicMock):
+        """Importing __main__ should call main()."""
+        import importlib
+
+        import deckboard.tools.__main__  # noqa: F811
+
+        importlib.reload(deckboard.tools.__main__)
+        mock_main.assert_called()

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import io
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -352,7 +354,7 @@ class TestMain:
 
 class TestPushToDevice:
     async def test_push_opens_and_pushes(self, mock_streamdeck_device: MagicMock):
-        from deckboard.tools.preview import _wait_forever, push_to_device
+        from deckboard.tools.preview import push_to_device
 
         # Create minimal key image and touchstrip
         blank_key = Image.new("RGB", KEY_SIZE, "black")
@@ -365,25 +367,17 @@ class TestPushToDevice:
         blank_ts.save(buf2, format="JPEG")
         ts_jpeg = buf2.getvalue()
 
-        with patch(
-            "deckboard.tools.preview._find_and_open_device",
-            return_value=mock_streamdeck_device,
+        with (
+            patch(
+                "deckboard.tools.preview._find_and_open_device",
+                return_value=mock_streamdeck_device,
+            ),
+            patch(
+                "deckboard.tools.preview._wait_for_interrupt",
+                new_callable=AsyncMock,
+            ),
         ):
-
-            async def mock_executor(executor, fn, *args):
-                # Let device calls through, interrupt on _wait_forever
-                if fn is _wait_forever:
-                    raise KeyboardInterrupt
-                return fn(*args)
-
-            with patch("asyncio.get_running_loop") as mock_loop:
-                loop_instance = MagicMock()
-                loop_instance.run_in_executor = AsyncMock(
-                    side_effect=mock_executor,
-                )
-                mock_loop.return_value = loop_instance
-
-                await push_to_device({0: key_jpeg}, ts_jpeg, brightness=60)
+            await push_to_device({0: key_jpeg}, ts_jpeg, brightness=60)
 
         mock_streamdeck_device.set_brightness.assert_called_once_with(60)
         mock_streamdeck_device.set_key_image.assert_called_once_with(0, key_jpeg)
@@ -399,33 +393,57 @@ class TestPushToDevice:
 
     async def test_brightness_clamped(self, mock_streamdeck_device: MagicMock):
         """Values outside 0-100 are clamped."""
-        from deckboard.tools.preview import _wait_forever, push_to_device
+        from deckboard.tools.preview import push_to_device
 
         blank_ts = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
         buf = io.BytesIO()
         blank_ts.save(buf, format="JPEG")
         ts_jpeg = buf.getvalue()
 
-        with patch(
-            "deckboard.tools.preview._find_and_open_device",
-            return_value=mock_streamdeck_device,
+        with (
+            patch(
+                "deckboard.tools.preview._find_and_open_device",
+                return_value=mock_streamdeck_device,
+            ),
+            patch(
+                "deckboard.tools.preview._wait_for_interrupt",
+                new_callable=AsyncMock,
+            ),
         ):
-
-            async def mock_executor(executor, fn, *args):
-                if fn is _wait_forever:
-                    raise KeyboardInterrupt
-                return fn(*args)
-
-            with patch("asyncio.get_running_loop") as mock_loop:
-                loop_instance = MagicMock()
-                loop_instance.run_in_executor = AsyncMock(
-                    side_effect=mock_executor,
-                )
-                mock_loop.return_value = loop_instance
-
-                await push_to_device({}, ts_jpeg, brightness=150)
+            await push_to_device({}, ts_jpeg, brightness=150)
 
         mock_streamdeck_device.set_brightness.assert_called_once_with(100)
+
+
+# -- _wait_for_interrupt ------------------------------------------------------
+
+
+class TestWaitForInterrupt:
+    async def test_returns_on_sigint(self):
+        """The coroutine completes when SIGINT is delivered."""
+        import signal
+
+        from deckboard.tools.preview import _wait_for_interrupt
+
+        loop = asyncio.get_running_loop()
+
+        # Schedule SIGINT delivery shortly after the wait starts.
+        loop.call_later(0.05, os.kill, os.getpid(), signal.SIGINT)
+        await asyncio.wait_for(_wait_for_interrupt(), timeout=1.0)
+
+    async def test_signal_handler_removed_after_return(self):
+        """The SIGINT handler is cleaned up after _wait_for_interrupt returns."""
+        import signal
+
+        from deckboard.tools.preview import _wait_for_interrupt
+
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.05, os.kill, os.getpid(), signal.SIGINT)
+        await asyncio.wait_for(_wait_for_interrupt(), timeout=1.0)
+
+        # After returning, the default handler should be restored, meaning
+        # remove_signal_handler returns False (nothing left to remove).
+        assert loop.remove_signal_handler(signal.SIGINT) is False
 
 
 # -- _svg_to_png_fit ---------------------------------------------------------

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -290,15 +290,21 @@ class TestRenderPreview:
         assert 3 in key_images
         assert isinstance(touchstrip, bytes)
 
-    def test_missing_key_svg_exits(self, tmp_path: Path):
+    def test_missing_key_svg_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
         args = parse_args(["--key0", str(tmp_path / "nonexistent.svg")])
         with pytest.raises(SystemExit):
             render_preview(args)
+        assert "Key SVG not found" in capsys.readouterr().err
 
-    def test_missing_card_svg_exits(self, tmp_path: Path):
+    def test_missing_card_svg_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
         args = parse_args(["--card0", str(tmp_path / "nonexistent.svg")])
         with pytest.raises(SystemExit):
             render_preview(args)
+        assert "Card SVG not found" in capsys.readouterr().err
 
 
 # -- main / push_to_device ---------------------------------------------------
@@ -423,7 +429,7 @@ class TestSvgToPngFit:
 
 
 class TestFindAndOpenDevice:
-    def test_no_devices_exits(self):
+    def test_no_devices_exits(self, capsys: pytest.CaptureFixture[str]):
         from deckboard.tools.preview import _find_and_open_device
 
         mock_dm = MagicMock()
@@ -434,6 +440,7 @@ class TestFindAndOpenDevice:
         ):
             with pytest.raises(SystemExit):
                 _find_and_open_device()
+        assert "No Stream Deck devices found" in capsys.readouterr().err
 
     def test_opens_first_device(self):
         from deckboard.tools.preview import _find_and_open_device


### PR DESCRIPTION
## Summary

- Adds a new `tools/` package under `src/deckboard/` with a CLI utility for previewing SVG designs on a physical Stream Deck+ device
- Supports `--key0`..`--key7` for key slots (120x120, icon area 80x80) and `--card0`..`--card3` for touchscreen card slots (197x98)
- SVGs are rasterised preserving aspect ratio and centred on a black background within the target area margins

## Usage

```bash
python -m deckboard.tools.preview     --card0 my_card_design.svg     --card1 my_other_card_design.svg     --key0 my_key_design.svg
```

Only specified slots are updated; unspecified ones remain blank. The tool pushes images to the device and waits for Ctrl+C.

## Testing

- 39 new tests covering all functions: SVG loading, aspect-ratio preservation, image composition, CLI parsing, device interaction, fallback paths, and the `__main__` entry point
- Full suite: **829 passed, 99.94% coverage**