### PR TITLE
Add HaMediaCard preset with album art, volume bar, and encoder long-press

### DIFF
--- a/examples/ha_media_card.py
+++ b/examples/ha_media_card.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Home Assistant media card — album art, metadata, and volume bar.
+
+Shows how ``HaMediaCard`` renders a media player panel with album art,
+artist/title text, playback state, and a volume bar.
+
+Encoder interaction is handled automatically by the card:
+
+* **Turn** — adjust volume.
+* **Short press** (press and release quickly) — toggle mute/unmute.
+* **Long press** (hold for 2 seconds) — toggle play/pause.  The state
+  changes while the encoder is still held — no need to release first.
+
+Layout::
+
+    ┌──────────┬──────────┬──────────┬──────────┐
+    │   Prev   │  Play /  │   Next   │   Mute   │   ← keys (row 1)
+    │          │  Pause   │          │          │
+    ├──────────┼──────────┼──────────┼──────────┤
+    │ Shuffle  │  Repeat  │  Like    │  Print   │   ← keys (row 2)
+    ├──────────┼──────────┼──────────┼──────────┤
+    │          │          │          │HA Media  │   ← touchscreen
+    │          │          │          │  Card    │
+    └──────────┴──────────┴──────────┴──────────┘
+        enc 0      enc 1      enc 2      enc 3
+
+Run with::
+
+    python examples/ha_media_card.py
+"""
+
+import asyncio
+import logging
+
+from deckboard import Deck, HaMediaCard
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+PLAYLIST = [
+    ("Tórshavnar Big Band", "Sólsetur"),
+    ("Queen", "Bohemian Rhapsody"),
+    ("Pink Floyd", "Comfortably Numb"),
+    ("Eagles", "Hotel California"),
+    ("Led Zeppelin", "Stairway to Heaven"),
+]
+
+
+async def main() -> None:
+    async with Deck(brightness=80) as deck:
+        info = deck.info
+        print(f"Connected: {info.deck_type} (serial: {info.serial})")
+
+        page = deck.screen("ha_media")
+
+        # -- HaMediaCard on zone 3 (encoder 3) ----------------------------
+
+        artist, title = PLAYLIST[0]
+        card = HaMediaCard(
+            3,
+            artist=artist,
+            title=title,
+            state="Paused",
+            volume=24,
+        )
+        page.set_card(3, card)
+
+        # -- Transport keys (row 1) ----------------------------------------
+
+        page.key(0).set_icon("mdi:skip-previous").set_label("Prev")
+        page.key(1).set_icon("mdi:play").set_label("Play")
+        page.key(2).set_icon("mdi:skip-next").set_label("Next")
+        page.key(3).set_icon("mdi:volume-high").set_label("Mute")
+
+        # -- Utility keys (row 2) ------------------------------------------
+
+        page.key(4).set_icon("mdi:shuffle-variant").set_label("Shuffle")
+        page.key(5).set_icon("mdi:repeat").set_label("Repeat")
+        page.key(6).set_icon("mdi:heart-outline").set_label("Like")
+        page.key(7).set_icon("mdi:printer").set_label("Print")
+
+        # -- State ---------------------------------------------------------
+
+        track_index = 0
+
+        async def sync_buttons() -> None:
+            """Keep key icons in sync with the card state."""
+            if card.muted:
+                page.key(3).set_icon("mdi:volume-off").set_label("Unmute")
+            else:
+                page.key(3).set_icon("mdi:volume-high").set_label("Mute")
+            if card.playing:
+                page.key(1).set_icon("mdi:pause").set_label("Pause")
+            else:
+                page.key(1).set_icon("mdi:play").set_label("Play")
+
+        @page.key(0).on_press
+        async def on_prev() -> None:
+            nonlocal track_index
+            track_index = (track_index - 1) % len(PLAYLIST)
+            a, t = PLAYLIST[track_index]
+            card.set_artist(a).set_title(t)
+            print(f"Now playing: {a} — {t}")
+            await deck.refresh()
+
+        @page.key(1).on_press
+        async def on_play_pause() -> None:
+            card.toggle_play_pause()
+            await sync_buttons()
+            print(f"State: {card.state}")
+            await deck.refresh()
+
+        @page.key(2).on_press
+        async def on_next() -> None:
+            nonlocal track_index
+            track_index = (track_index + 1) % len(PLAYLIST)
+            a, t = PLAYLIST[track_index]
+            card.set_artist(a).set_title(t)
+            print(f"Now playing: {a} — {t}")
+            await deck.refresh()
+
+        @page.key(3).on_press
+        async def on_mute_button() -> None:
+            card.toggle_mute()
+            await sync_buttons()
+            await deck.refresh()
+
+        @page.key(7).on_press
+        async def on_print() -> None:
+            print(
+                f"Artist: {card.artist}, Title: {card.title}, "
+                f"State: {card.state}, Volume: {card.volume:.0f}%, "
+                f"Muted: {card.muted}"
+            )
+
+        # -- Encoder callbacks (for logging / syncing buttons) -------------
+
+        @card.on_volume_change
+        async def on_vol(volume: float) -> None:
+            print(f"Volume: {volume:.0f}%")
+
+        @card.on_encoder_release
+        async def on_enc_release() -> None:
+            await sync_buttons()
+            await deck.refresh()
+
+        # -- Activate and run ----------------------------------------------
+
+        await deck.set_screen("ha_media")
+        print("\nHA Media Card ready!")
+        print(f"  Now playing: {PLAYLIST[0][0]} — {PLAYLIST[0][1]}")
+        print("  Turn encoder 3 to adjust volume.")
+        print("  Short press encoder 3 to toggle mute.")
+        print("  Hold encoder 3 for 2s to toggle play/pause.")
+        print("  Row 1: Prev, Play/Pause, Next, Mute.")
+        print("  Row 2: Shuffle, Repeat, Like, Print status.\n")
+
+        await deck.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deckboard/__init__.py
+++ b/src/deckboard/__init__.py
@@ -22,7 +22,7 @@ Example::
 
 from __future__ import annotations
 
-from .presets import EqualizerCard, LightCard, MediaCard
+from .presets import EqualizerCard, HaMediaCard, LightCard, MediaCard
 from .render import IconError, IconManager
 from .runtime import (
     Deck,
@@ -77,6 +77,7 @@ __all__ = [
     "EqualizerCard",
     "EqualizerSlider",
     "EventType",
+    "HaMediaCard",
     "IconError",
     "IconManager",
     "KelvinSlider",

--- a/src/deckboard/presets/__init__.py
+++ b/src/deckboard/presets/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .audio import BalanceSlider, EqualizerCard, EqualizerSlider, VolumeSlider
 from .climate import TemperatureSlider
+from .ha_media import HaMediaCard
 from .lighting import BrightnessSlider, KelvinSlider, LightCard
 from .media import MediaCard
 from .sensors import LargeDualValue, SmallDualValue, StatusCard
@@ -13,6 +14,7 @@ __all__ = [
     "BrightnessSlider",
     "EqualizerCard",
     "EqualizerSlider",
+    "HaMediaCard",
     "KelvinSlider",
     "LargeDualValue",
     "LightCard",

--- a/src/deckboard/presets/ha_media.py
+++ b/src/deckboard/presets/ha_media.py
@@ -1,0 +1,385 @@
+"""Home Assistant–style media card with album art, metadata, and volume bar."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from PIL import Image, ImageDraw
+
+from ..render.fonts import get_font, get_small_font
+from ..render.metrics import PANEL_HEIGHT, PANEL_WIDTH
+from ..runtime.events import AsyncHandler
+from ..ui.cards.base import Card
+
+if TYPE_CHECKING:
+    from ..render.icons import IconManager
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HaMediaCard"]
+
+# ── Volume bar layout constants ──────────────────────────────────────────
+
+_VOL_BAR_HEIGHT = 5
+_VOL_BAR_Y = PANEL_HEIGHT - _VOL_BAR_HEIGHT - 2
+_VOL_BAR_COLOR = "#68b1ff"
+
+# ── Text colours ─────────────────────────────────────────────────────────
+
+_ARTIST_COLOR = "#69b1ff"
+_TITLE_COLOR = "#f8ab3c"
+_STATE_COLOR = "#69b1ff"
+
+# ── Gradient mask (pre-built once) ───────────────────────────────────────
+
+_gradient_mask: Image.Image | None = None
+
+
+def _build_gradient_mask() -> Image.Image:
+    """Build the left-to-right transparency gradient for the entity picture.
+
+    The gradient goes from fully transparent on the left to fully opaque
+    on the right, allowing the album art to blend smoothly into the
+    black card background.
+    """
+    global _gradient_mask  # noqa: PLW0603
+    if _gradient_mask is not None:
+        return _gradient_mask
+
+    mask = Image.new("L", (PANEL_WIDTH, PANEL_HEIGHT), 0)
+    for x in range(PANEL_WIDTH):
+        t = x / max(PANEL_WIDTH - 1, 1)
+        # Opacity ramps from 0 at x=0 to ~173 at 58% then 255 at 100%
+        if t < 0.58:
+            alpha = int(t / 0.58 * 173)
+        else:
+            alpha = int(173 + (t - 0.58) / 0.42 * (255 - 173))
+        for y in range(PANEL_HEIGHT):
+            mask.putpixel((x, y), alpha)
+
+    _gradient_mask = mask
+    return _gradient_mask
+
+
+class HaMediaCard(Card):
+    """A Home Assistant–style media card with album art and volume bar.
+
+    Renders an entity picture (album art) on the left with a
+    transparency gradient, plus artist name, media title, playback
+    state, and a thin volume bar at the bottom.
+
+    Encoder interaction:
+
+    * **Turn** — adjust volume (0–100).
+    * **Short press** (press and release within the hold threshold) —
+      toggle mute/unmute.
+    * **Long press** (hold for :attr:`long_press_seconds`) — toggle
+      play/pause.  The state changes while the encoder is still held,
+      so the user sees the update before releasing.
+
+    Args:
+        index: Card zone index (0–3).
+        artist: Initial artist name.  Defaults to ``""``.
+        title: Initial media title.  Defaults to ``"No Media"``.
+        state: Initial playback state (``"Playing"`` / ``"Paused"`` /
+            ``"Idle"``).  Defaults to ``"Idle"``.
+        volume: Initial volume level (0–100).  Defaults to 50.
+        entity_picture: Optional album-art :class:`~PIL.Image.Image`.
+        long_press_seconds: How long the encoder must be held before
+            play/pause is toggled.  Defaults to ``2.0``.
+
+    Usage::
+
+        from deckboard import HaMediaCard
+
+        card = HaMediaCard(
+            0,
+            artist="Tórshavnar Big Band",
+            title="Sólsetur",
+            state="Playing",
+            volume=24,
+        )
+        card.set_entity_picture(album_art_image)
+    """
+
+    def __init__(
+        self,
+        index: int,
+        *,
+        artist: str = "",
+        title: str = "No Media",
+        state: str = "Idle",
+        volume: float = 50,
+        entity_picture: Image.Image | None = None,
+        long_press_seconds: float = 2.0,
+    ) -> None:
+        super().__init__(index)
+        self._artist = artist
+        self._title = title
+        self._state = state
+        self._volume = max(0.0, min(100.0, float(volume)))
+        self._entity_picture = entity_picture
+        self._muted = False
+        self._saved_volume: float = self._volume
+        self._playing = state.lower() == "playing"
+        self._volume_step: float = 1.0
+        self._volume_change_handler: AsyncHandler | None = None
+        self._long_press_seconds = max(0.0, float(long_press_seconds))
+        self._long_press_task: asyncio.Task[None] | None = None
+        self._long_press_fired = False
+
+    # ── Property accessors ────────────────────────────────────────────
+
+    @property
+    def artist(self) -> str:
+        """The media artist name."""
+        return self._artist
+
+    @property
+    def title(self) -> str:
+        """The media title."""
+        return self._title
+
+    @property
+    def state(self) -> str:
+        """The current playback state text (e.g. ``'Playing'``)."""
+        return self._state
+
+    @property
+    def volume(self) -> float:
+        """Current volume level (0–100)."""
+        return self._volume
+
+    @property
+    def volume_normalized(self) -> float:
+        """Volume mapped to 0.0 – 1.0."""
+        return self._volume / 100.0
+
+    @property
+    def muted(self) -> bool:
+        """Whether the volume is currently muted."""
+        return self._muted
+
+    @property
+    def playing(self) -> bool:
+        """Whether media is currently playing."""
+        return self._playing
+
+    @property
+    def entity_picture(self) -> Image.Image | None:
+        """The album-art image, or ``None``."""
+        return self._entity_picture
+
+    @property
+    def volume_step(self) -> float:
+        """The increment used per encoder tick."""
+        return self._volume_step
+
+    @property
+    def long_press_seconds(self) -> float:
+        """Seconds the encoder must be held to trigger play/pause."""
+        return self._long_press_seconds
+
+    # ── Mutators ──────────────────────────────────────────────────────
+
+    def set_artist(self, artist: str) -> HaMediaCard:
+        """Update the artist name."""
+        self._artist = artist
+        self._dirty = True
+        return self
+
+    def set_title(self, title: str) -> HaMediaCard:
+        """Update the media title."""
+        self._title = title
+        self._dirty = True
+        return self
+
+    def set_state(self, state: str) -> HaMediaCard:
+        """Update the playback state text and internal playing flag."""
+        self._state = state
+        self._playing = state.lower() == "playing"
+        self._dirty = True
+        return self
+
+    def set_volume(self, volume: float) -> None:
+        """Set the volume, clamping to 0–100.
+
+        Fires the :meth:`on_volume_change` callback if the value changes.
+        """
+        old = self._volume
+        self._volume = max(0.0, min(100.0, float(volume)))
+        self._dirty = True
+        if self._volume_change_handler is not None and self._volume != old:
+            self.queue_pending_callback(self._volume_change_handler, (self._volume,))
+
+    def set_volume_step(self, step: float) -> HaMediaCard:
+        """Set the encoder-turn increment for volume."""
+        self._volume_step = max(0.1, float(step))
+        return self
+
+    def set_long_press_seconds(self, seconds: float) -> HaMediaCard:
+        """Set how long the encoder must be held for play/pause."""
+        self._long_press_seconds = max(0.0, float(seconds))
+        return self
+
+    def set_entity_picture(self, image: Image.Image | None) -> HaMediaCard:
+        """Set or clear the album-art image."""
+        self._entity_picture = image
+        self._dirty = True
+        return self
+
+    # ── Volume change callback ────────────────────────────────────────
+
+    def on_volume_change(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for volume changes.
+
+        The handler receives the new ``volume`` value (0–100).
+
+        Usage::
+
+            @card.on_volume_change
+            async def handle(volume: float):
+                print(f"Volume: {volume}")
+        """
+        self._volume_change_handler = handler
+        return handler
+
+    # ── Mute control ──────────────────────────────────────────────────
+
+    def toggle_mute(self) -> None:
+        """Toggle mute on/off.
+
+        When muting, the current volume is saved and set to 0.
+        When unmuting, the saved volume is restored.
+        """
+        if self._muted:
+            self.set_volume(self._saved_volume)
+            self._muted = False
+        else:
+            self._saved_volume = self._volume
+            self.set_volume(0)
+            self._muted = True
+        self._dirty = True
+
+    # ── Play/Pause control ────────────────────────────────────────────
+
+    def toggle_play_pause(self) -> None:
+        """Toggle between Playing and Paused states."""
+        if self._playing:
+            self.set_state("Paused")
+        else:
+            self.set_state("Playing")
+
+    # ── Encoder interaction overrides ─────────────────────────────────
+
+    def handle_encoder_turn(self, direction: int) -> None:
+        """Adjust volume by *direction* × :attr:`volume_step`."""
+        self.set_volume(self._volume + direction * self._volume_step)
+
+    def _cancel_long_press(self) -> None:
+        """Cancel a pending long-press timer, if any."""
+        if self._long_press_task is not None and not self._long_press_task.done():
+            self._long_press_task.cancel()
+        self._long_press_task = None
+
+    async def _long_press_timer(self) -> None:
+        """Sleep for :attr:`long_press_seconds`, then toggle play/pause.
+
+        Runs as an ``asyncio.Task`` started on encoder press.  If the
+        encoder is released before the timer fires, the task is
+        cancelled and mute/unmute is performed instead.
+        """
+        await asyncio.sleep(self._long_press_seconds)
+        self._long_press_fired = True
+        self.toggle_play_pause()
+        await self.request_refresh()
+
+    async def dispatch_encoder_press(self) -> None:
+        """Start the long-press timer on encoder press.
+
+        Overrides :meth:`Card.dispatch_encoder_press` to defer the
+        short-press action (mute/unmute) until release, so the card
+        can distinguish between a short press and a long hold.
+        """
+        if self._encoder_press_handler is not None:
+            await self._encoder_press_handler()
+        self._long_press_fired = False
+        self._cancel_long_press()
+        self._long_press_task = asyncio.ensure_future(self._long_press_timer())
+
+    async def dispatch_encoder_release(self) -> None:
+        """Handle encoder release: mute/unmute if short, no-op if long.
+
+        Overrides :meth:`Card.dispatch_encoder_release`.  If the
+        long-press timer already fired, the release is a no-op (the
+        play/pause toggle has already happened).  Otherwise the timer
+        is cancelled and mute/unmute is toggled.
+        """
+        if self._encoder_release_handler is not None:
+            await self._encoder_release_handler()
+        self._cancel_long_press()
+        if not self._long_press_fired:
+            self.toggle_mute()
+
+    # ── Rendering ─────────────────────────────────────────────────────
+
+    def render(self) -> Image.Image:
+        """Compose the card image with album art, text, and volume bar.
+
+        Returns:
+            A PANEL_WIDTH × PANEL_HEIGHT RGB :class:`~PIL.Image.Image`.
+        """
+        img = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), "black")
+        draw = ImageDraw.Draw(img)
+        font = get_font()
+        small_font = get_small_font()
+
+        # 1. Entity picture (album art) ─────────────────────────────────
+        if self._entity_picture is not None:
+            pic = self._entity_picture.convert("RGB")
+            pic = pic.resize((PANEL_HEIGHT, PANEL_HEIGHT), Image.LANCZOS)
+            img.paste(pic, (0, 0))
+
+        # 2. Gradient mask ──────────────────────────────────────────────
+        mask = _build_gradient_mask()
+        black = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), "black")
+        img = Image.composite(black, img, mask)
+        draw = ImageDraw.Draw(img)
+
+        # 3. Artist text (top area, small font) ────────────────────────
+        if self._artist:
+            draw.text((37, 14), self._artist, fill=_ARTIST_COLOR, font=font)
+
+        # 4. Title text (middle area, smaller font) ─────────────────────
+        if self._title:
+            draw.text((37, 34), self._title, fill=_TITLE_COLOR, font=small_font)
+
+        # 5. State text (lower-right, standard font) ───────────────────
+        state_text = self._state.capitalize() if self._state else ""
+        if state_text:
+            bbox = draw.textbbox((0, 0), state_text, font=font)
+            text_w = bbox[2] - bbox[0]
+            draw.text(
+                (PANEL_WIDTH - text_w - 5, 60),
+                state_text,
+                fill=_STATE_COLOR,
+                font=font,
+            )
+
+        # 6. Volume bar background ──────────────────────────────────────
+        draw.rectangle(
+            (0, _VOL_BAR_Y, PANEL_WIDTH - 1, _VOL_BAR_Y + _VOL_BAR_HEIGHT - 1),
+            fill="black",
+        )
+
+        # 7. Volume level fill ──────────────────────────────────────────
+        fill_w = int((PANEL_WIDTH - 1) * self.volume_normalized)
+        if fill_w > 0:
+            draw.rectangle(
+                (0, _VOL_BAR_Y, fill_w, _VOL_BAR_Y + _VOL_BAR_HEIGHT - 1),
+                fill=_VOL_BAR_COLOR,
+            )
+
+        return img

--- a/src/deckboard/runtime/deck.py
+++ b/src/deckboard/runtime/deck.py
@@ -484,12 +484,15 @@ class Deck:
             encoder = screen.encoders.get(event.encoder)
             if encoder:
                 await encoder.dispatch_press(event.pressed)
+            card = screen.touch_strip.card(event.encoder)
+            card.set_refresh_callback(self.refresh)
             if event.pressed:
-                card = screen.touch_strip.card(event.encoder)
                 await card.dispatch_encoder_press()
-                await self._drain_card_callbacks(card)
-                if card.is_dirty:
-                    await self.refresh()
+            else:
+                await card.dispatch_encoder_release()
+            await self._drain_card_callbacks(card)
+            if card.is_dirty:
+                await self.refresh()
 
         elif isinstance(event, TouchEvent):
             zone = event.zone

--- a/src/deckboard/ui/cards/base.py
+++ b/src/deckboard/ui/cards/base.py
@@ -51,9 +51,11 @@ class Card(ABC):
         self._drag_handler: AsyncHandler | None = None
         self._encoder_turn_handler: AsyncHandler | None = None
         self._encoder_press_handler: AsyncHandler | None = None
+        self._encoder_release_handler: AsyncHandler | None = None
         self._pending_callbacks: list[tuple[AsyncHandler, tuple[float]]] = []
         self._rendered: Image.Image | None = None
         self._dirty = True
+        self._request_refresh: AsyncHandler | None = None
 
     @property
     def index(self) -> int:
@@ -127,6 +129,38 @@ class Card(ABC):
         self._encoder_press_handler = handler
         return handler
 
+    def on_encoder_release(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for encoder release events on this widget.
+
+        Usage::
+
+            @widget.on_encoder_release
+            async def handle():
+                ...
+        """
+        self._encoder_release_handler = handler
+        return handler
+
+    # -- Refresh callback (set by Deck) ------------------------------------
+
+    def set_refresh_callback(self, callback: AsyncHandler) -> None:
+        """Register an async callback the card can invoke to request a refresh.
+
+        This is set automatically by :class:`~deckboard.runtime.deck.Deck`
+        when dispatching events so that cards with internal timers (e.g.
+        long-press detection) can trigger a re-render without a direct
+        reference to the deck.
+        """
+        self._request_refresh = callback
+
+    async def request_refresh(self) -> None:
+        """Ask the deck to re-render this card.
+
+        No-op if no refresh callback has been registered.
+        """
+        if self._request_refresh is not None:
+            await self._request_refresh()
+
     # -- Pending callbacks (deferred async invocation) ---------------------
 
     def queue_pending_callback(self, handler: AsyncHandler, args: tuple[float]) -> None:
@@ -189,6 +223,12 @@ class Card(ABC):
             await self._encoder_press_handler()
         self.handle_encoder_press()
 
+    async def dispatch_encoder_release(self) -> None:
+        """Dispatch an encoder-release event to the card."""
+        if self._encoder_release_handler is not None:
+            await self._encoder_release_handler()
+        self.handle_encoder_release()
+
     async def dispatch_touch(self, event: TouchEvent) -> None:
         """Dispatch a touch gesture to the card."""
         if event.event_type == EventType.TOUCH_SHORT:
@@ -224,6 +264,12 @@ class Card(ABC):
         """Called when the encoder above this widget is pressed.
 
         Override to handle encoder presses.  The default is a no-op.
+        """
+
+    def handle_encoder_release(self) -> None:
+        """Called when the encoder above this widget is released.
+
+        Override to handle encoder releases.  The default is a no-op.
         """
 
     def check_selection_timeout(self) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,6 +26,7 @@ class TestPublicAPI:
             "EqualizerCard",
             "EqualizerSlider",
             "EventType",
+            "HaMediaCard",
             "IconError",
             "IconManager",
             "KelvinSlider",
@@ -159,8 +160,9 @@ class TestPublicAPI:
         assert TouchStrip is not None
 
     def test_preset_cards_importable(self):
-        from deckboard import EqualizerCard, LightCard, MediaCard
+        from deckboard import EqualizerCard, HaMediaCard, LightCard, MediaCard
 
         assert EqualizerCard is not None
+        assert HaMediaCard is not None
         assert LightCard is not None
         assert MediaCard is not None

--- a/tests/test_widgets_ha_media_card.py
+++ b/tests/test_widgets_ha_media_card.py
@@ -1,0 +1,683 @@
+"""Tests for deckboard.presets.ha_media — HaMediaCard."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from PIL import Image
+
+from deckboard.presets.ha_media import HaMediaCard
+from deckboard.render.metrics import PANEL_HEIGHT, PANEL_WIDTH
+from deckboard.ui.cards.base import Card
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+async def _short_press(card: HaMediaCard) -> None:
+    """Simulate a short encoder press then immediate release."""
+    await card.dispatch_encoder_press()
+    await card.dispatch_encoder_release()
+
+
+async def _long_press(card: HaMediaCard, hold: float = 2.1) -> None:
+    """Simulate a long encoder press — hold past the threshold.
+
+    Uses ``long_press_seconds=0`` on the card's internal timer
+    so the asyncio task fires immediately, then release.
+    """
+    await card.dispatch_encoder_press()
+    # Let the long-press task fire
+    await asyncio.sleep(hold)
+    await card.dispatch_encoder_release()
+
+
+# ── Init ─────────────────────────────────────────────────────────────────
+
+
+class TestHaMediaCardInit:
+    def test_defaults(self):
+        c = HaMediaCard(0)
+        assert c.index == 0
+        assert c.artist == ""
+        assert c.title == "No Media"
+        assert c.state == "Idle"
+        assert c.volume == 50
+        assert c.muted is False
+        assert c.playing is False
+        assert c.entity_picture is None
+        assert c.long_press_seconds == 2.0
+
+    def test_custom_values(self):
+        pic = Image.new("RGB", (100, 100), "red")
+        c = HaMediaCard(
+            2,
+            artist="Queen",
+            title="Bohemian Rhapsody",
+            state="Playing",
+            volume=75,
+            entity_picture=pic,
+            long_press_seconds=1.5,
+        )
+        assert c.index == 2
+        assert c.artist == "Queen"
+        assert c.title == "Bohemian Rhapsody"
+        assert c.state == "Playing"
+        assert c.volume == 75
+        assert c.playing is True
+        assert c.entity_picture is pic
+        assert c.long_press_seconds == 1.5
+
+    def test_volume_clamped_high(self):
+        c = HaMediaCard(0, volume=200)
+        assert c.volume == 100
+
+    def test_volume_clamped_low(self):
+        c = HaMediaCard(0, volume=-10)
+        assert c.volume == 0
+
+    def test_is_card(self):
+        c = HaMediaCard(0)
+        assert isinstance(c, Card)
+
+    def test_state_playing_sets_playing(self):
+        c = HaMediaCard(0, state="playing")
+        assert c.playing is True
+
+    def test_state_paused_sets_not_playing(self):
+        c = HaMediaCard(0, state="Paused")
+        assert c.playing is False
+
+    def test_long_press_seconds_clamped(self):
+        c = HaMediaCard(0, long_press_seconds=-5)
+        assert c.long_press_seconds == 0.0
+
+
+# ── Accessors ────────────────────────────────────────────────────────────
+
+
+class TestHaMediaCardAccessors:
+    def test_volume_normalized_zero(self):
+        c = HaMediaCard(0, volume=0)
+        assert c.volume_normalized == 0.0
+
+    def test_volume_normalized_full(self):
+        c = HaMediaCard(0, volume=100)
+        assert c.volume_normalized == 1.0
+
+    def test_volume_normalized_half(self):
+        c = HaMediaCard(0, volume=50)
+        assert c.volume_normalized == 0.5
+
+    def test_volume_step_default(self):
+        c = HaMediaCard(0)
+        assert c.volume_step == 1.0
+
+
+# ── Mutators ─────────────────────────────────────────────────────────────
+
+
+class TestHaMediaCardMutators:
+    def test_set_artist(self):
+        c = HaMediaCard(0)
+        result = c.set_artist("Led Zeppelin")
+        assert c.artist == "Led Zeppelin"
+        assert result is c
+
+    def test_set_title(self):
+        c = HaMediaCard(0)
+        result = c.set_title("Stairway to Heaven")
+        assert c.title == "Stairway to Heaven"
+        assert result is c
+
+    def test_set_state(self):
+        c = HaMediaCard(0)
+        result = c.set_state("Playing")
+        assert c.state == "Playing"
+        assert c.playing is True
+        assert result is c
+
+    def test_set_state_paused(self):
+        c = HaMediaCard(0, state="Playing")
+        c.set_state("Paused")
+        assert c.playing is False
+
+    def test_set_volume(self):
+        c = HaMediaCard(0)
+        c.set_volume(80)
+        assert c.volume == 80
+
+    def test_set_volume_clamps_high(self):
+        c = HaMediaCard(0)
+        c.set_volume(200)
+        assert c.volume == 100
+
+    def test_set_volume_clamps_low(self):
+        c = HaMediaCard(0)
+        c.set_volume(-10)
+        assert c.volume == 0
+
+    def test_set_volume_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.set_volume(70)
+        assert c.is_dirty is True
+
+    def test_set_artist_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.set_artist("Beatles")
+        assert c.is_dirty is True
+
+    def test_set_title_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.set_title("Yesterday")
+        assert c.is_dirty is True
+
+    def test_set_state_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.set_state("Playing")
+        assert c.is_dirty is True
+
+    def test_set_entity_picture(self):
+        c = HaMediaCard(0)
+        pic = Image.new("RGB", (50, 50), "blue")
+        result = c.set_entity_picture(pic)
+        assert c.entity_picture is pic
+        assert result is c
+
+    def test_set_entity_picture_none(self):
+        pic = Image.new("RGB", (50, 50), "blue")
+        c = HaMediaCard(0, entity_picture=pic)
+        c.set_entity_picture(None)
+        assert c.entity_picture is None
+
+    def test_set_entity_picture_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.set_entity_picture(Image.new("RGB", (50, 50), "blue"))
+        assert c.is_dirty is True
+
+    def test_set_volume_step(self):
+        c = HaMediaCard(0)
+        result = c.set_volume_step(5)
+        assert c.volume_step == 5.0
+        assert result is c
+
+    def test_set_volume_step_minimum(self):
+        c = HaMediaCard(0)
+        c.set_volume_step(0.01)
+        assert c.volume_step == 0.1
+
+    def test_set_long_press_seconds(self):
+        c = HaMediaCard(0)
+        result = c.set_long_press_seconds(3.0)
+        assert c.long_press_seconds == 3.0
+        assert result is c
+
+    def test_set_long_press_seconds_clamped(self):
+        c = HaMediaCard(0)
+        c.set_long_press_seconds(-1)
+        assert c.long_press_seconds == 0.0
+
+
+# ── Mute control (direct method calls) ───────────────────────────────────
+
+
+class TestHaMediaCardMute:
+    def test_toggle_mute_sets_volume_to_zero(self):
+        c = HaMediaCard(0, volume=75)
+        c.toggle_mute()
+        assert c.muted is True
+        assert c.volume == 0
+
+    def test_toggle_mute_restores_volume(self):
+        c = HaMediaCard(0, volume=75)
+        c.toggle_mute()
+        c.toggle_mute()
+        assert c.muted is False
+        assert c.volume == 75
+
+    def test_toggle_mute_saves_current_volume(self):
+        c = HaMediaCard(0, volume=60)
+        c.set_volume(80)
+        c.toggle_mute()
+        assert c.volume == 0
+        c.toggle_mute()
+        assert c.volume == 80
+
+    def test_toggle_mute_marks_dirty(self):
+        c = HaMediaCard(0, volume=50)
+        c.mark_clean()
+        c.toggle_mute()
+        assert c.is_dirty is True
+
+    def test_toggle_mute_marks_dirty_on_unmute(self):
+        c = HaMediaCard(0, volume=50)
+        c.toggle_mute()
+        c.mark_clean()
+        c.toggle_mute()
+        assert c.is_dirty is True
+
+    def test_mute_unmute_cycle(self):
+        c = HaMediaCard(0, volume=65)
+        c.toggle_mute()
+        assert c.muted is True
+        assert c.volume == 0
+        c.toggle_mute()
+        assert c.muted is False
+        assert c.volume == 65
+        c.toggle_mute()
+        assert c.muted is True
+        assert c.volume == 0
+
+    def test_mute_preserves_zero_volume(self):
+        c = HaMediaCard(0, volume=0)
+        c.toggle_mute()
+        assert c.muted is True
+        assert c.volume == 0
+        c.toggle_mute()
+        assert c.muted is False
+        assert c.volume == 0
+
+
+# ── Play/Pause control (direct method calls) ─────────────────────────────
+
+
+class TestHaMediaCardPlayPause:
+    def test_toggle_play_pause_from_idle(self):
+        c = HaMediaCard(0, state="Idle")
+        c.toggle_play_pause()
+        assert c.playing is True
+        assert c.state == "Playing"
+
+    def test_toggle_play_pause_from_playing(self):
+        c = HaMediaCard(0, state="Playing")
+        c.toggle_play_pause()
+        assert c.playing is False
+        assert c.state == "Paused"
+
+    def test_toggle_play_pause_from_paused(self):
+        c = HaMediaCard(0, state="Paused")
+        c.toggle_play_pause()
+        assert c.playing is True
+        assert c.state == "Playing"
+
+    def test_toggle_play_pause_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.toggle_play_pause()
+        assert c.is_dirty is True
+
+    def test_double_toggle(self):
+        c = HaMediaCard(0, state="Playing")
+        c.toggle_play_pause()
+        c.toggle_play_pause()
+        assert c.playing is True
+        assert c.state == "Playing"
+
+
+# ── Encoder turn (sync — same as before) ─────────────────────────────────
+
+
+class TestHaMediaCardEncoderTurn:
+    def test_encoder_turn_adjusts_volume(self):
+        c = HaMediaCard(0, volume=50)
+        c.handle_encoder_turn(1)
+        assert c.volume == 51
+
+    def test_encoder_turn_negative(self):
+        c = HaMediaCard(0, volume=50)
+        c.handle_encoder_turn(-1)
+        assert c.volume == 49
+
+    def test_encoder_turn_clamps_high(self):
+        c = HaMediaCard(0, volume=100)
+        c.handle_encoder_turn(1)
+        assert c.volume == 100
+
+    def test_encoder_turn_clamps_low(self):
+        c = HaMediaCard(0, volume=0)
+        c.handle_encoder_turn(-1)
+        assert c.volume == 0
+
+    def test_encoder_turn_custom_step(self):
+        c = HaMediaCard(0, volume=50)
+        c.set_volume_step(5)
+        c.handle_encoder_turn(1)
+        assert c.volume == 55
+
+    def test_encoder_turn_marks_dirty(self):
+        c = HaMediaCard(0, volume=50)
+        c.mark_clean()
+        c.handle_encoder_turn(1)
+        assert c.is_dirty is True
+
+    def test_encoder_turn_while_muted(self):
+        c = HaMediaCard(0, volume=50)
+        c.toggle_mute()
+        c.handle_encoder_turn(5)
+        assert c.volume == 5
+
+
+# ── Encoder short press → mute (async dispatch) ─────────────────────────
+
+
+class TestHaMediaCardShortPress:
+    """Short press (press + immediate release) should toggle mute."""
+
+    async def test_short_press_mutes(self):
+        c = HaMediaCard(0, volume=75, long_press_seconds=2.0)
+        await _short_press(c)
+        assert c.muted is True
+        assert c.volume == 0
+
+    async def test_short_press_unmutes(self):
+        c = HaMediaCard(0, volume=75, long_press_seconds=2.0)
+        await _short_press(c)
+        await _short_press(c)
+        assert c.muted is False
+        assert c.volume == 75
+
+    async def test_short_press_does_not_toggle_play_pause(self):
+        c = HaMediaCard(0, state="Paused", long_press_seconds=2.0)
+        await _short_press(c)
+        assert c.state == "Paused"
+        assert c.playing is False
+
+
+# ── Encoder long press → play/pause (async dispatch with timer) ──────────
+
+
+class TestHaMediaCardLongPress:
+    """Holding the encoder past the threshold toggles play/pause."""
+
+    async def test_long_press_toggles_play_pause(self):
+        # Use a very short threshold so the test runs fast
+        c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)  # wait past threshold
+        assert c._long_press_fired is True
+        assert c.playing is True
+        assert c.state == "Playing"
+        await c.dispatch_encoder_release()
+        # Still playing — release after long press is a no-op for mute
+        assert c.muted is False
+
+    async def test_long_press_does_not_mute(self):
+        c = HaMediaCard(0, volume=75, state="Playing", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        await c.dispatch_encoder_release()
+        assert c.muted is False
+        assert c.volume == 75
+
+    async def test_long_press_pauses(self):
+        c = HaMediaCard(0, state="Playing", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        assert c.state == "Paused"
+        await c.dispatch_encoder_release()
+
+    async def test_long_press_requests_refresh(self):
+        refresh_mock = AsyncMock()
+        c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
+        c.set_refresh_callback(refresh_mock)
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        await c.dispatch_encoder_release()
+        refresh_mock.assert_awaited()
+
+    async def test_release_before_threshold_mutes(self):
+        c = HaMediaCard(0, volume=60, long_press_seconds=10.0)
+        await c.dispatch_encoder_press()
+        # Release immediately — well before 10s threshold
+        await c.dispatch_encoder_release()
+        assert c._long_press_fired is False
+        assert c.muted is True
+        assert c.playing is False
+
+    async def test_cancel_long_press_on_release(self):
+        c = HaMediaCard(0, long_press_seconds=10.0)
+        await c.dispatch_encoder_press()
+        task = c._long_press_task
+        assert task is not None
+        await c.dispatch_encoder_release()
+        # After release, _cancel_long_press clears the task reference
+        assert c._long_press_task is None
+        # Give the event loop a tick so the cancellation propagates
+        await asyncio.sleep(0)
+        assert task.cancelled()
+
+    async def test_long_press_with_no_refresh_callback(self):
+        """Long press works even without a refresh callback (no crash)."""
+        c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        assert c.playing is True
+        await c.dispatch_encoder_release()
+
+    async def test_encoder_press_handler_called(self):
+        c = HaMediaCard(0, long_press_seconds=10.0)
+        handler = AsyncMock()
+        c.on_encoder_press(handler)
+        await c.dispatch_encoder_press()
+        handler.assert_awaited_once()
+        await c.dispatch_encoder_release()
+
+    async def test_encoder_release_handler_called(self):
+        c = HaMediaCard(0, long_press_seconds=10.0)
+        handler = AsyncMock()
+        c.on_encoder_release(handler)
+        await c.dispatch_encoder_press()
+        await c.dispatch_encoder_release()
+        handler.assert_awaited_once()
+
+
+# ── Rendering ────────────────────────────────────────────────────────────
+
+
+class TestHaMediaCardRender:
+    def test_render_returns_correct_size(self):
+        c = HaMediaCard(0)
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_with_custom_values(self):
+        c = HaMediaCard(
+            0, artist="Queen", title="Bohemian Rhapsody", state="Playing", volume=80
+        )
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_with_entity_picture(self):
+        pic = Image.new("RGB", (200, 200), "red")
+        c = HaMediaCard(0, entity_picture=pic)
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_with_rgba_entity_picture(self):
+        pic = Image.new("RGBA", (200, 200), (255, 0, 0, 128))
+        c = HaMediaCard(0, entity_picture=pic)
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_while_muted(self):
+        c = HaMediaCard(0, volume=75)
+        c.toggle_mute()
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_zero_volume(self):
+        c = HaMediaCard(0, volume=0)
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_full_volume(self):
+        c = HaMediaCard(0, volume=100)
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_empty_artist(self):
+        c = HaMediaCard(0, artist="")
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_empty_state(self):
+        c = HaMediaCard(0, state="")
+        img = c.render()
+        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_render_mode_is_rgb(self):
+        c = HaMediaCard(0)
+        img = c.render()
+        assert img.mode == "RGB"
+
+
+# ── on_volume_change callbacks ───────────────────────────────────────────
+
+
+class TestHaMediaCardOnVolumeChange:
+    def test_on_volume_change_queued_on_set_volume(self):
+        c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.set_volume(75)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (75.0,))
+
+    def test_on_volume_change_queued_on_encoder_turn(self):
+        c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.handle_encoder_turn(3)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (53.0,))
+
+    def test_on_volume_change_queued_on_mute(self):
+        c = HaMediaCard(0, volume=75)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.toggle_mute()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (0.0,))
+
+    def test_on_volume_change_queued_on_unmute(self):
+        c = HaMediaCard(0, volume=75)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.toggle_mute()
+        c.drain_pending_callbacks()
+        c.toggle_mute()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (75.0,))
+
+    def test_on_volume_change_not_queued_when_clamped_at_max(self):
+        c = HaMediaCard(0, volume=100)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.handle_encoder_turn(1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_on_volume_change_not_queued_when_clamped_at_min(self):
+        c = HaMediaCard(0, volume=0)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.handle_encoder_turn(-1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_drain_clears_pending(self):
+        c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.set_volume(60)
+        c.drain_pending_callbacks()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_no_handler_no_callback(self):
+        c = HaMediaCard(0, volume=50)
+        c.set_volume(60)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+
+# ── Gradient mask ────────────────────────────────────────────────────────
+
+
+class TestHaMediaCardGradientMask:
+    def test_gradient_mask_is_cached(self):
+        from deckboard.presets.ha_media import _build_gradient_mask
+
+        mask1 = _build_gradient_mask()
+        mask2 = _build_gradient_mask()
+        assert mask1 is mask2
+
+    def test_gradient_mask_size(self):
+        from deckboard.presets.ha_media import _build_gradient_mask
+
+        mask = _build_gradient_mask()
+        assert mask.size == (PANEL_WIDTH, PANEL_HEIGHT)
+
+    def test_gradient_mask_mode(self):
+        from deckboard.presets.ha_media import _build_gradient_mask
+
+        mask = _build_gradient_mask()
+        assert mask.mode == "L"
+
+
+# ── Method chaining ──────────────────────────────────────────────────────
+
+
+class TestHaMediaCardMethodChaining:
+    def test_set_artist_chains(self):
+        c = HaMediaCard(0)
+        assert c.set_artist("Test") is c
+
+    def test_set_title_chains(self):
+        c = HaMediaCard(0)
+        assert c.set_title("Test") is c
+
+    def test_set_state_chains(self):
+        c = HaMediaCard(0)
+        assert c.set_state("Playing") is c
+
+    def test_set_entity_picture_chains(self):
+        c = HaMediaCard(0)
+        assert c.set_entity_picture(None) is c
+
+    def test_set_volume_step_chains(self):
+        c = HaMediaCard(0)
+        assert c.set_volume_step(2) is c
+
+    def test_set_long_press_seconds_chains(self):
+        c = HaMediaCard(0)
+        assert c.set_long_press_seconds(3) is c
+
+    def test_chained_calls(self):
+        c = HaMediaCard(0)
+        result = (
+            c.set_artist("Queen")
+            .set_title("Bohemian Rhapsody")
+            .set_state("Playing")
+            .set_volume_step(2)
+            .set_long_press_seconds(1.5)
+        )
+        assert result is c
+        assert c.artist == "Queen"
+        assert c.title == "Bohemian Rhapsody"
+        assert c.state == "Playing"
+        assert c.volume_step == 2.0
+        assert c.long_press_seconds == 1.5


### PR DESCRIPTION
## Summary

- Add `HaMediaCard` — a Home Assistant–style media card preset that renders album art with a gradient overlay, artist/title/state text, and a thin volume bar. Encoder turn adjusts volume, short press toggles mute/unmute, and holding the encoder for 2 seconds toggles play/pause while still held (state updates before release).
- Extend the `Card` base class with encoder release dispatch (`on_encoder_release`, `dispatch_encoder_release`, `handle_encoder_release`) and a refresh callback mechanism (`set_refresh_callback` / `request_refresh`) so cards with internal async timers can trigger re-renders.
- Forward encoder release events to cards in `Deck._dispatch()`.

## Encoder interaction

| Action | Behavior |
|---|---|
| Turn | Adjust volume (0–100) |
| Short press | Toggle mute/unmute |
| Hold 2s | Toggle play/pause (fires while held via `asyncio.Task` timer) |

## Files

| File | Change |
|---|---|
| `src/deckboard/presets/ha_media.py` | New — `HaMediaCard` class (100% coverage) |
| `src/deckboard/ui/cards/base.py` | Encoder release + refresh callback plumbing |
| `src/deckboard/runtime/deck.py` | Forward release events to cards |
| `src/deckboard/presets/__init__.py` | Export `HaMediaCard` |
| `src/deckboard/__init__.py` | Export `HaMediaCard` |
| `tests/test_widgets_ha_media_card.py` | 89 tests covering init, mutators, mute, play/pause, short press, long press, rendering, callbacks, chaining |
| `tests/test_init.py` | Updated expected `__all__` set |
| `examples/ha_media_card.py` | Full working example |

## Test results

925 passed, 99.90% coverage (threshold: 95%).