### PR TITLE
Fix HaMediaCard encoder mute toggle reverting immediately

### DIFF
--- a/src/deckboard/presets/ha_media.py
+++ b/src/deckboard/presets/ha_media.py
@@ -314,12 +314,16 @@ class HaMediaCard(Card):
         Overrides :meth:`Card.dispatch_encoder_press` to defer the
         short-press action (mute/unmute) until release, so the card
         can distinguish between a short press and a long hold.
+
+        The internal state change (starting the timer) happens *before*
+        the user handler so that any callback registered via
+        :meth:`~Card.on_encoder_press` sees up-to-date state.
         """
-        if self._encoder_press_handler is not None:
-            await self._encoder_press_handler()
         self._long_press_fired = False
         self._cancel_long_press()
         self._long_press_task = asyncio.ensure_future(self._long_press_timer())
+        if self._encoder_press_handler is not None:
+            await self._encoder_press_handler()
 
     async def dispatch_encoder_release(self) -> None:
         """Handle encoder release: mute/unmute if short, no-op if long.
@@ -328,12 +332,16 @@ class HaMediaCard(Card):
         long-press timer already fired, the release is a no-op (the
         play/pause toggle has already happened).  Otherwise the timer
         is cancelled and mute/unmute is toggled.
+
+        The internal state change (toggle mute) happens *before* the
+        user handler so that any callback registered via
+        :meth:`~Card.on_encoder_release` sees up-to-date state.
         """
-        if self._encoder_release_handler is not None:
-            await self._encoder_release_handler()
         self._cancel_long_press()
         if not self._long_press_fired:
             self.toggle_mute()
+        if self._encoder_release_handler is not None:
+            await self._encoder_release_handler()
 
     # ── Rendering ─────────────────────────────────────────────────────
 

--- a/tests/test_widgets_ha_media_card.py
+++ b/tests/test_widgets_ha_media_card.py
@@ -479,6 +479,64 @@ class TestHaMediaCardLongPress:
         await c.dispatch_encoder_release()
         handler.assert_awaited_once()
 
+    async def test_release_handler_sees_muted_state(self):
+        """The on_encoder_release handler must see the post-toggle state.
+
+        This is the core of the mute/unmute ordering fix: toggle_mute()
+        must run *before* the user's release handler so that sync logic
+        (e.g. updating key icons) reads the correct muted state.
+        """
+        observed: dict[str, bool | float] = {}
+
+        c = HaMediaCard(0, volume=60, long_press_seconds=10.0)
+
+        @c.on_encoder_release
+        async def capture_state() -> None:
+            observed["muted"] = c.muted
+            observed["volume"] = c.volume
+
+        await c.dispatch_encoder_press()
+        await c.dispatch_encoder_release()
+        assert observed["muted"] is True
+        assert observed["volume"] == 0
+
+    async def test_release_handler_sees_unmuted_state(self):
+        """Second short press: handler must see unmuted state."""
+        observed: dict[str, bool | float] = {}
+
+        c = HaMediaCard(0, volume=60, long_press_seconds=10.0)
+
+        @c.on_encoder_release
+        async def capture_state() -> None:
+            observed["muted"] = c.muted
+            observed["volume"] = c.volume
+
+        # First short press → mute
+        await c.dispatch_encoder_press()
+        await c.dispatch_encoder_release()
+        assert observed["muted"] is True
+
+        # Second short press → unmute
+        await c.dispatch_encoder_press()
+        await c.dispatch_encoder_release()
+        assert observed["muted"] is False
+        assert observed["volume"] == 60
+
+    async def test_press_handler_runs_after_timer_starts(self):
+        """The on_encoder_press handler runs after the long-press timer
+        has been started, so the task exists when the handler fires."""
+        observed: dict[str, object] = {}
+
+        c = HaMediaCard(0, long_press_seconds=10.0)
+
+        @c.on_encoder_press
+        async def capture_state() -> None:
+            observed["task_exists"] = c._long_press_task is not None
+
+        await c.dispatch_encoder_press()
+        assert observed["task_exists"] is True
+        await c.dispatch_encoder_release()
+
 
 # ── Rendering ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Bug:** Short-pressing the encoder to mute would appear to mute for a fraction of a second, then immediately revert to unmuted.
- **Root cause:** In `HaMediaCard.dispatch_encoder_release()`, the user`s `on_encoder_release` handler was called *before* `toggle_mute()`. Any state-syncing logic in the handler (e.g. `sync_buttons()` updating key icons) would read stale pre-toggle state and render the wrong icons, making it look like the mute was immediately undone.
- **Fix:** Reorder both `dispatch_encoder_press()` and `dispatch_encoder_release()` so internal state changes (timer start / mute toggle) happen *before* user handlers, ensuring callbacks observe the correct post-action state.

## Changes

- `src/deckboard/presets/ha_media.py` -- swap handler/state-change ordering in `dispatch_encoder_press()` and `dispatch_encoder_release()`
- `tests/test_widgets_ha_media_card.py` -- add 3 tests verifying handlers see post-toggle state

All 926 tests pass, coverage 99.90%.