### PR TITLE
Refactor HaMediaCard to emit-only interaction model

### DIFF
--- a/examples/ha_media_card.py
+++ b/examples/ha_media_card.py
@@ -4,12 +4,16 @@
 Shows how ``HaMediaCard`` renders a media player panel with album art,
 artist/title text, playback state, and a volume bar.
 
-Encoder interaction is handled automatically by the card:
+Encoder gestures emit intent callbacks — the card does **not** update
+its own display state.  This example simulates a backend by applying
+the requested changes immediately, but in a real integration you would
+call Home Assistant first and then update the card with the confirmed
+state.
 
-* **Turn** — adjust volume.
-* **Short press** (press and release quickly) — toggle mute/unmute.
-* **Long press** (hold for 2 seconds) — toggle play/pause.  The state
-  changes while the encoder is still held — no need to release first.
+* **Turn** — emits :meth:`on_volume_change` with the requested volume.
+* **Short press** — flips the muted flag and emits :meth:`on_mute_toggle`.
+* **Long press** (hold 2 s) — emits :meth:`on_play_pause_toggle` with
+  the requested playing state.
 
 Layout::
 
@@ -132,11 +136,28 @@ async def main() -> None:
                 f"Muted: {card.muted}"
             )
 
-        # -- Encoder callbacks (for logging / syncing buttons) -------------
+        # -- Encoder callbacks (emit-only: apply confirmed state) ----------
 
         @card.on_volume_change
         async def on_vol(volume: float) -> None:
+            # In a real integration, call HA first, then apply confirmed value.
+            card.set_volume(volume)
             print(f"Volume: {volume:.0f}%")
+            await deck.refresh()
+
+        @card.on_mute_toggle
+        async def on_mute(muted: bool) -> None:
+            print(f"Muted: {muted}")
+            await sync_buttons()
+            await deck.refresh()
+
+        @card.on_play_pause_toggle
+        async def on_play_pause_toggle(playing: bool) -> None:
+            # In a real integration, call HA first, then apply confirmed state.
+            card.set_state("Playing" if playing else "Paused")
+            print(f"State: {card.state}")
+            await sync_buttons()
+            await deck.refresh()
 
         @card.on_encoder_release
         async def on_enc_release() -> None:
@@ -148,9 +169,9 @@ async def main() -> None:
         await deck.set_screen("ha_media")
         print("\nHA Media Card ready!")
         print(f"  Now playing: {PLAYLIST[0][0]} — {PLAYLIST[0][1]}")
-        print("  Turn encoder 3 to adjust volume.")
+        print("  Turn encoder 3 to request volume change.")
         print("  Short press encoder 3 to toggle mute.")
-        print("  Hold encoder 3 for 2s to toggle play/pause.")
+        print("  Hold encoder 3 for 2s to request play/pause.")
         print("  Row 1: Prev, Play/Pause, Next, Mute.")
         print("  Row 2: Shuffle, Repeat, Like, Print status.\n")
 

--- a/src/deckboard/presets/ha_media.py
+++ b/src/deckboard/presets/ha_media.py
@@ -82,14 +82,21 @@ class HaMediaCard(Card):
     transparency gradient, plus artist name, media title, playback
     state, and a thin volume bar at the bottom.
 
-    Encoder interaction:
+    **Emit-only interaction model**
 
-    * **Turn** — adjust volume (0–100).
+    Encoder gestures do **not** modify the card's display state
+    directly.  Instead, each gesture emits a callback that the
+    integration layer should handle — typically by calling the
+    backend and then updating the card with the confirmed state
+    via :meth:`set_volume`, :meth:`set_state`, etc.
+
+    * **Turn** — emits :meth:`on_volume_change` with the *requested*
+      volume.  The card's volume is unchanged.
     * **Short press** (press and release within the hold threshold) —
-      toggle mute/unmute.
-    * **Long press** (hold for :attr:`long_press_seconds`) — toggle
-      play/pause.  The state changes while the encoder is still held,
-      so the user sees the update before releasing.
+      flips :attr:`muted` and emits :meth:`on_mute_toggle`.
+    * **Long press** (hold for :attr:`long_press_seconds`) — emits
+      :meth:`on_play_pause_toggle` with the *requested* playing
+      state.  The card's state is unchanged.
 
     Args:
         index: Card zone index (0–3).
@@ -132,12 +139,14 @@ class HaMediaCard(Card):
         self._title = title
         self._state = state
         self._volume = max(0.0, min(100.0, float(volume)))
+        self._requested_volume: float = self._volume
         self._entity_picture = entity_picture
         self._muted = False
-        self._saved_volume: float = self._volume
         self._playing = state.lower() == "playing"
         self._volume_step: float = 1.0
         self._volume_change_handler: AsyncHandler | None = None
+        self._mute_toggle_handler: AsyncHandler | None = None
+        self._play_pause_toggle_handler: AsyncHandler | None = None
         self._long_press_seconds = max(0.0, float(long_press_seconds))
         self._long_press_task: asyncio.Task[None] | None = None
         self._long_press_fired = False
@@ -161,8 +170,17 @@ class HaMediaCard(Card):
 
     @property
     def volume(self) -> float:
-        """Current volume level (0–100)."""
+        """Current confirmed volume level (0–100)."""
         return self._volume
+
+    @property
+    def requested_volume(self) -> float:
+        """The most recently requested volume from encoder turns.
+
+        This accumulates encoder ticks until the backend confirms the
+        change via :meth:`set_volume`.  Starts equal to :attr:`volume`.
+        """
+        return self._requested_volume
 
     @property
     def volume_normalized(self) -> float:
@@ -216,15 +234,17 @@ class HaMediaCard(Card):
         return self
 
     def set_volume(self, volume: float) -> None:
-        """Set the volume, clamping to 0–100.
+        """Set the confirmed volume, clamping to 0–100.
 
-        Fires the :meth:`on_volume_change` callback if the value changes.
+        This is intended to be called by the integration layer after
+        the backend has acknowledged the volume change.  No callback
+        is emitted.  The :attr:`requested_volume` accumulator is
+        reset to match so that subsequent encoder ticks start from
+        the confirmed value.
         """
-        old = self._volume
         self._volume = max(0.0, min(100.0, float(volume)))
+        self._requested_volume = self._volume
         self._dirty = True
-        if self._volume_change_handler is not None and self._volume != old:
-            self.queue_pending_callback(self._volume_change_handler, (self._volume,))
 
     def set_volume_step(self, step: float) -> HaMediaCard:
         """Set the encoder-turn increment for volume."""
@@ -245,17 +265,56 @@ class HaMediaCard(Card):
     # ── Volume change callback ────────────────────────────────────────
 
     def on_volume_change(self, handler: AsyncHandler) -> AsyncHandler:
-        """Decorator to register a handler for volume changes.
+        """Decorator to register a handler for volume change requests.
 
-        The handler receives the new ``volume`` value (0–100).
+        Fired when the encoder is turned.  The handler receives the
+        *requested* volume (0–100).  The card's actual volume is
+        **not** modified — call :meth:`set_volume` to apply the
+        confirmed value from the backend.
 
         Usage::
 
             @card.on_volume_change
             async def handle(volume: float):
-                print(f"Volume: {volume}")
+                print(f"Requested volume: {volume}")
         """
         self._volume_change_handler = handler
+        return handler
+
+    # ── Mute toggle callback ──────────────────────────────────────────
+
+    def on_mute_toggle(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for mute state changes.
+
+        The handler receives the new ``muted`` value (``True`` or
+        ``False``).
+
+        Usage::
+
+            @card.on_mute_toggle
+            async def handle(muted: bool):
+                print(f"Muted: {muted}")
+        """
+        self._mute_toggle_handler = handler
+        return handler
+
+    # ── Play/pause toggle callback ────────────────────────────────────
+
+    def on_play_pause_toggle(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for play/pause requests.
+
+        The handler receives the *requested* ``playing`` state
+        (``True`` for play, ``False`` for pause).  The card does
+        **not** change its own state — call :meth:`set_state` to
+        apply the confirmed state from the backend.
+
+        Usage::
+
+            @card.on_play_pause_toggle
+            async def handle(playing: bool):
+                print(f"Requested: {'play' if playing else 'pause'}")
+        """
+        self._play_pause_toggle_handler = handler
         return handler
 
     # ── Mute control ──────────────────────────────────────────────────
@@ -263,17 +322,15 @@ class HaMediaCard(Card):
     def toggle_mute(self) -> None:
         """Toggle mute on/off.
 
-        When muting, the current volume is saved and set to 0.
-        When unmuting, the saved volume is restored.
+        Flips the :attr:`muted` flag and queues the
+        :meth:`on_mute_toggle` callback with the new state.  Volume
+        is **not** modified — the caller (or callback handler) is
+        responsible for any volume save/restore logic.
         """
-        if self._muted:
-            self.set_volume(self._saved_volume)
-            self._muted = False
-        else:
-            self._saved_volume = self._volume
-            self.set_volume(0)
-            self._muted = True
+        self._muted = not self._muted
         self._dirty = True
+        if self._mute_toggle_handler is not None:
+            self.queue_pending_callback(self._mute_toggle_handler, (self._muted,))
 
     # ── Play/Pause control ────────────────────────────────────────────
 
@@ -287,8 +344,29 @@ class HaMediaCard(Card):
     # ── Encoder interaction overrides ─────────────────────────────────
 
     def handle_encoder_turn(self, direction: int) -> None:
-        """Adjust volume by *direction* × :attr:`volume_step`."""
-        self.set_volume(self._volume + direction * self._volume_step)
+        """Emit a volume-change request without altering the confirmed volume.
+
+        Successive encoder ticks accumulate on :attr:`requested_volume`
+        so that rapid turns produce increasing/decreasing values rather
+        than repeating the same stale number.  The :meth:`on_volume_change`
+        callback is queued with the accumulated *requested* volume
+        (clamped to 0–100).
+
+        The confirmed :attr:`volume` is **not** modified — call
+        :meth:`set_volume` to apply the backend-confirmed value (which
+        also resets the accumulator).
+        """
+        old_requested = self._requested_volume
+        self._requested_volume = max(
+            0.0, min(100.0, self._requested_volume + direction * self._volume_step)
+        )
+        if (
+            self._volume_change_handler is not None
+            and self._requested_volume != old_requested
+        ):
+            self.queue_pending_callback(
+                self._volume_change_handler, (self._requested_volume,)
+            )
 
     def _cancel_long_press(self) -> None:
         """Cancel a pending long-press timer, if any."""
@@ -297,15 +375,23 @@ class HaMediaCard(Card):
         self._long_press_task = None
 
     async def _long_press_timer(self) -> None:
-        """Sleep for :attr:`long_press_seconds`, then toggle play/pause.
+        """Sleep for :attr:`long_press_seconds`, then emit play/pause.
 
         Runs as an ``asyncio.Task`` started on encoder press.  If the
         encoder is released before the timer fires, the task is
         cancelled and mute/unmute is performed instead.
+
+        The card does **not** change its own playing state — the
+        :meth:`on_play_pause_toggle` callback is queued with the
+        *requested* state so the integration layer can confirm it.
         """
         await asyncio.sleep(self._long_press_seconds)
         self._long_press_fired = True
-        self.toggle_play_pause()
+        requested_playing = not self._playing
+        if self._play_pause_toggle_handler is not None:
+            self.queue_pending_callback(
+                self._play_pause_toggle_handler, (requested_playing,)
+            )
         await self.request_refresh()
 
     async def dispatch_encoder_press(self) -> None:

--- a/src/deckboard/ui/cards/base.py
+++ b/src/deckboard/ui/cards/base.py
@@ -52,7 +52,7 @@ class Card(ABC):
         self._encoder_turn_handler: AsyncHandler | None = None
         self._encoder_press_handler: AsyncHandler | None = None
         self._encoder_release_handler: AsyncHandler | None = None
-        self._pending_callbacks: list[tuple[AsyncHandler, tuple[float]]] = []
+        self._pending_callbacks: list[tuple[AsyncHandler, tuple[object, ...]]] = []
         self._rendered: Image.Image | None = None
         self._dirty = True
         self._request_refresh: AsyncHandler | None = None
@@ -163,7 +163,9 @@ class Card(ABC):
 
     # -- Pending callbacks (deferred async invocation) ---------------------
 
-    def queue_pending_callback(self, handler: AsyncHandler, args: tuple[float]) -> None:
+    def queue_pending_callback(
+        self, handler: AsyncHandler, args: tuple[object, ...]
+    ) -> None:
         """Enqueue a callback for deferred async invocation.
 
         Called by child elements (e.g. sliders) when their value changes
@@ -176,7 +178,7 @@ class Card(ABC):
         """
         self._pending_callbacks.append((handler, args))
 
-    def drain_pending_callbacks(self) -> list[tuple[AsyncHandler, tuple[float]]]:
+    def drain_pending_callbacks(self) -> list[tuple[AsyncHandler, tuple[object, ...]]]:
         """Remove and return all pending callbacks.
 
         Returns:

--- a/tests/test_widgets_ha_media_card.py
+++ b/tests/test_widgets_ha_media_card.py
@@ -44,6 +44,7 @@ class TestHaMediaCardInit:
         assert c.title == "No Media"
         assert c.state == "Idle"
         assert c.volume == 50
+        assert c.requested_volume == 50
         assert c.muted is False
         assert c.playing is False
         assert c.entity_picture is None
@@ -228,26 +229,22 @@ class TestHaMediaCardMutators:
 
 
 class TestHaMediaCardMute:
-    def test_toggle_mute_sets_volume_to_zero(self):
+    def test_toggle_mute_sets_muted_flag(self):
         c = HaMediaCard(0, volume=75)
         c.toggle_mute()
         assert c.muted is True
-        assert c.volume == 0
 
-    def test_toggle_mute_restores_volume(self):
+    def test_toggle_mute_does_not_change_volume(self):
+        c = HaMediaCard(0, volume=75)
+        c.toggle_mute()
+        assert c.volume == 75
+
+    def test_toggle_mute_twice_clears_muted(self):
         c = HaMediaCard(0, volume=75)
         c.toggle_mute()
         c.toggle_mute()
         assert c.muted is False
         assert c.volume == 75
-
-    def test_toggle_mute_saves_current_volume(self):
-        c = HaMediaCard(0, volume=60)
-        c.set_volume(80)
-        c.toggle_mute()
-        assert c.volume == 0
-        c.toggle_mute()
-        assert c.volume == 80
 
     def test_toggle_mute_marks_dirty(self):
         c = HaMediaCard(0, volume=50)
@@ -266,13 +263,13 @@ class TestHaMediaCardMute:
         c = HaMediaCard(0, volume=65)
         c.toggle_mute()
         assert c.muted is True
-        assert c.volume == 0
+        assert c.volume == 65
         c.toggle_mute()
         assert c.muted is False
         assert c.volume == 65
         c.toggle_mute()
         assert c.muted is True
-        assert c.volume == 0
+        assert c.volume == 65
 
     def test_mute_preserves_zero_volume(self):
         c = HaMediaCard(0, volume=0)
@@ -324,43 +321,113 @@ class TestHaMediaCardPlayPause:
 
 
 class TestHaMediaCardEncoderTurn:
-    def test_encoder_turn_adjusts_volume(self):
+    def test_encoder_turn_does_not_change_volume(self):
         c = HaMediaCard(0, volume=50)
         c.handle_encoder_turn(1)
-        assert c.volume == 51
+        assert c.volume == 50
 
-    def test_encoder_turn_negative(self):
+    def test_encoder_turn_accumulates_requested_volume(self):
         c = HaMediaCard(0, volume=50)
+        c.handle_encoder_turn(1)
+        assert c.requested_volume == 51
+        c.handle_encoder_turn(1)
+        assert c.requested_volume == 52
+
+    def test_encoder_turn_emits_requested_volume(self):
+        c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.handle_encoder_turn(1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (51.0,))
+
+    def test_rapid_turns_emit_accumulated_values(self):
+        c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
+        c.handle_encoder_turn(1)
+        c.handle_encoder_turn(1)
+        c.handle_encoder_turn(1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 3
+        assert callbacks[0] == (handler, (51.0,))
+        assert callbacks[1] == (handler, (52.0,))
+        assert callbacks[2] == (handler, (53.0,))
+
+    def test_encoder_turn_negative_emits(self):
+        c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
         c.handle_encoder_turn(-1)
-        assert c.volume == 49
+        callbacks = c.drain_pending_callbacks()
+        assert callbacks[0] == (handler, (49.0,))
 
     def test_encoder_turn_clamps_high(self):
         c = HaMediaCard(0, volume=100)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
         c.handle_encoder_turn(1)
-        assert c.volume == 100
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+        assert c.requested_volume == 100
 
     def test_encoder_turn_clamps_low(self):
         c = HaMediaCard(0, volume=0)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
         c.handle_encoder_turn(-1)
-        assert c.volume == 0
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+        assert c.requested_volume == 0
 
     def test_encoder_turn_custom_step(self):
         c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
         c.set_volume_step(5)
         c.handle_encoder_turn(1)
-        assert c.volume == 55
+        callbacks = c.drain_pending_callbacks()
+        assert callbacks[0] == (handler, (55.0,))
 
-    def test_encoder_turn_marks_dirty(self):
+    def test_encoder_turn_no_handler_no_callback(self):
         c = HaMediaCard(0, volume=50)
-        c.mark_clean()
         c.handle_encoder_turn(1)
-        assert c.is_dirty is True
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+        # requested_volume still accumulates even without handler
+        assert c.requested_volume == 51
 
     def test_encoder_turn_while_muted(self):
         c = HaMediaCard(0, volume=50)
+        handler = AsyncMock()
+        c.on_volume_change(handler)
         c.toggle_mute()
+        c.drain_pending_callbacks()
         c.handle_encoder_turn(5)
-        assert c.volume == 5
+        callbacks = c.drain_pending_callbacks()
+        assert callbacks[0] == (handler, (55.0,))
+        assert c.volume == 50
+
+    def test_set_volume_resets_requested_volume(self):
+        c = HaMediaCard(0, volume=50)
+        c.handle_encoder_turn(3)
+        assert c.requested_volume == 53
+        c.set_volume(53)
+        assert c.requested_volume == 53
+        assert c.volume == 53
+
+    def test_set_volume_resets_accumulator_to_confirmed(self):
+        """Backend may confirm a different value than requested."""
+        c = HaMediaCard(0, volume=50)
+        c.handle_encoder_turn(10)
+        assert c.requested_volume == 60
+        # Backend clamps or adjusts to a different value
+        c.set_volume(55)
+        assert c.requested_volume == 55
+        # Next turn starts from 55
+        c.handle_encoder_turn(1)
+        assert c.requested_volume == 56
 
 
 # ── Encoder short press → mute (async dispatch) ─────────────────────────
@@ -373,7 +440,7 @@ class TestHaMediaCardShortPress:
         c = HaMediaCard(0, volume=75, long_press_seconds=2.0)
         await _short_press(c)
         assert c.muted is True
-        assert c.volume == 0
+        assert c.volume == 75
 
     async def test_short_press_unmutes(self):
         c = HaMediaCard(0, volume=75, long_press_seconds=2.0)
@@ -393,19 +460,23 @@ class TestHaMediaCardShortPress:
 
 
 class TestHaMediaCardLongPress:
-    """Holding the encoder past the threshold toggles play/pause."""
+    """Holding the encoder past the threshold emits play/pause toggle."""
 
-    async def test_long_press_toggles_play_pause(self):
-        # Use a very short threshold so the test runs fast
+    async def test_long_press_emits_play_pause(self):
         c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
         c.set_refresh_callback(AsyncMock())
+        handler = AsyncMock()
+        c.on_play_pause_toggle(handler)
         await c.dispatch_encoder_press()
-        await asyncio.sleep(0.1)  # wait past threshold
+        await asyncio.sleep(0.1)
         assert c._long_press_fired is True
-        assert c.playing is True
-        assert c.state == "Playing"
+        # State is NOT changed — emit only
+        assert c.playing is False
+        assert c.state == "Paused"
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (True,))
         await c.dispatch_encoder_release()
-        # Still playing — release after long press is a no-op for mute
         assert c.muted is False
 
     async def test_long_press_does_not_mute(self):
@@ -417,12 +488,25 @@ class TestHaMediaCardLongPress:
         assert c.muted is False
         assert c.volume == 75
 
-    async def test_long_press_pauses(self):
+    async def test_long_press_does_not_change_state(self):
         c = HaMediaCard(0, state="Playing", long_press_seconds=0.05)
         c.set_refresh_callback(AsyncMock())
         await c.dispatch_encoder_press()
         await asyncio.sleep(0.1)
-        assert c.state == "Paused"
+        assert c.state == "Playing"
+        assert c.playing is True
+        await c.dispatch_encoder_release()
+
+    async def test_long_press_emits_pause_request(self):
+        c = HaMediaCard(0, state="Playing", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        handler = AsyncMock()
+        c.on_play_pause_toggle(handler)
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (False,))
         await c.dispatch_encoder_release()
 
     async def test_long_press_requests_refresh(self):
@@ -460,7 +544,18 @@ class TestHaMediaCardLongPress:
         c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
         await c.dispatch_encoder_press()
         await asyncio.sleep(0.1)
-        assert c.playing is True
+        # State is unchanged — emit only
+        assert c.playing is False
+        await c.dispatch_encoder_release()
+
+    async def test_long_press_no_handler_no_callback(self):
+        """Long press without an on_play_pause_toggle handler is fine."""
+        c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
         await c.dispatch_encoder_release()
 
     async def test_encoder_press_handler_called(self):
@@ -498,7 +593,7 @@ class TestHaMediaCardLongPress:
         await c.dispatch_encoder_press()
         await c.dispatch_encoder_release()
         assert observed["muted"] is True
-        assert observed["volume"] == 0
+        assert observed["volume"] == 60
 
     async def test_release_handler_sees_unmuted_state(self):
         """Second short press: handler must see unmuted state."""
@@ -602,14 +697,14 @@ class TestHaMediaCardRender:
 
 
 class TestHaMediaCardOnVolumeChange:
-    def test_on_volume_change_queued_on_set_volume(self):
+    def test_on_volume_change_not_queued_on_set_volume(self):
+        """set_volume is a confirmed setter — no callback emitted."""
         c = HaMediaCard(0, volume=50)
         handler = AsyncMock()
         c.on_volume_change(handler)
         c.set_volume(75)
         callbacks = c.drain_pending_callbacks()
-        assert len(callbacks) == 1
-        assert callbacks[0] == (handler, (75.0,))
+        assert len(callbacks) == 0
 
     def test_on_volume_change_queued_on_encoder_turn(self):
         c = HaMediaCard(0, volume=50)
@@ -620,16 +715,17 @@ class TestHaMediaCardOnVolumeChange:
         assert len(callbacks) == 1
         assert callbacks[0] == (handler, (53.0,))
 
-    def test_on_volume_change_queued_on_mute(self):
+    def test_on_volume_change_not_queued_on_mute(self):
         c = HaMediaCard(0, volume=75)
         handler = AsyncMock()
         c.on_volume_change(handler)
         c.toggle_mute()
         callbacks = c.drain_pending_callbacks()
-        assert len(callbacks) == 1
-        assert callbacks[0] == (handler, (0.0,))
+        # Only the mute_toggle callback should be present, not volume
+        vol_callbacks = [cb for cb in callbacks if cb[0] is handler]
+        assert len(vol_callbacks) == 0
 
-    def test_on_volume_change_queued_on_unmute(self):
+    def test_on_volume_change_not_queued_on_unmute(self):
         c = HaMediaCard(0, volume=75)
         handler = AsyncMock()
         c.on_volume_change(handler)
@@ -637,8 +733,8 @@ class TestHaMediaCardOnVolumeChange:
         c.drain_pending_callbacks()
         c.toggle_mute()
         callbacks = c.drain_pending_callbacks()
-        assert len(callbacks) == 1
-        assert callbacks[0] == (handler, (75.0,))
+        vol_callbacks = [cb for cb in callbacks if cb[0] is handler]
+        assert len(vol_callbacks) == 0
 
     def test_on_volume_change_not_queued_when_clamped_at_max(self):
         c = HaMediaCard(0, volume=100)
@@ -660,16 +756,126 @@ class TestHaMediaCardOnVolumeChange:
         c = HaMediaCard(0, volume=50)
         handler = AsyncMock()
         c.on_volume_change(handler)
-        c.set_volume(60)
+        c.handle_encoder_turn(10)
         c.drain_pending_callbacks()
         callbacks = c.drain_pending_callbacks()
         assert len(callbacks) == 0
 
     def test_no_handler_no_callback(self):
         c = HaMediaCard(0, volume=50)
-        c.set_volume(60)
+        c.handle_encoder_turn(10)
         callbacks = c.drain_pending_callbacks()
         assert len(callbacks) == 0
+
+
+# ── on_mute_toggle callbacks ─────────────────────────────────────────────
+
+
+class TestHaMediaCardOnMuteToggle:
+    def test_on_mute_toggle_queued_on_mute(self):
+        c = HaMediaCard(0, volume=75)
+        handler = AsyncMock()
+        c.on_mute_toggle(handler)
+        c.toggle_mute()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (True,))
+
+    def test_on_mute_toggle_queued_on_unmute(self):
+        c = HaMediaCard(0, volume=75)
+        handler = AsyncMock()
+        c.on_mute_toggle(handler)
+        c.toggle_mute()
+        c.drain_pending_callbacks()
+        c.toggle_mute()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (False,))
+
+    def test_on_mute_toggle_not_queued_without_handler(self):
+        c = HaMediaCard(0, volume=75)
+        c.toggle_mute()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_on_mute_toggle_returns_handler(self):
+        c = HaMediaCard(0)
+        handler = AsyncMock()
+        result = c.on_mute_toggle(handler)
+        assert result is handler
+
+    async def test_on_mute_toggle_queued_on_short_press(self):
+        c = HaMediaCard(0, volume=75, long_press_seconds=10.0)
+        handler = AsyncMock()
+        c.on_mute_toggle(handler)
+        await _short_press(c)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (True,))
+
+    async def test_on_mute_toggle_not_queued_on_long_press(self):
+        c = HaMediaCard(0, volume=75, long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        handler = AsyncMock()
+        c.on_mute_toggle(handler)
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        await c.dispatch_encoder_release()
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+
+# ── on_play_pause_toggle callbacks ───────────────────────────────────────
+
+
+class TestHaMediaCardOnPlayPauseToggle:
+    def test_on_play_pause_toggle_returns_handler(self):
+        c = HaMediaCard(0)
+        handler = AsyncMock()
+        result = c.on_play_pause_toggle(handler)
+        assert result is handler
+
+    async def test_on_play_pause_toggle_queued_on_long_press_from_paused(self):
+        c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        handler = AsyncMock()
+        c.on_play_pause_toggle(handler)
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (True,))
+        await c.dispatch_encoder_release()
+
+    async def test_on_play_pause_toggle_queued_on_long_press_from_playing(self):
+        c = HaMediaCard(0, state="Playing", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        handler = AsyncMock()
+        c.on_play_pause_toggle(handler)
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        assert callbacks[0] == (handler, (False,))
+        await c.dispatch_encoder_release()
+
+    async def test_on_play_pause_toggle_not_queued_on_short_press(self):
+        c = HaMediaCard(0, state="Paused", long_press_seconds=10.0)
+        handler = AsyncMock()
+        c.on_play_pause_toggle(handler)
+        await _short_press(c)
+        callbacks = c.drain_pending_callbacks()
+        pp_callbacks = [cb for cb in callbacks if cb[0] is handler]
+        assert len(pp_callbacks) == 0
+
+    async def test_on_play_pause_toggle_not_queued_without_handler(self):
+        c = HaMediaCard(0, state="Paused", long_press_seconds=0.05)
+        c.set_refresh_callback(AsyncMock())
+        await c.dispatch_encoder_press()
+        await asyncio.sleep(0.1)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+        await c.dispatch_encoder_release()
 
 
 # ── Gradient mask ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Encoder gestures now emit intent callbacks instead of directly mutating the card display state, fixing erratic GUI behavior caused by optimistic updates that could contradict the backend
- Encoder turn emits `on_volume_change` with accumulated requested volume (new `_requested_volume` accumulator handles rapid turns correctly); `set_volume()` is now a silent confirmed setter that resets the accumulator
- Short press flips `_muted` flag and emits new `on_mute_toggle(bool)` callback -- no longer manipulates volume or `_saved_volume`
- Long press emits new `on_play_pause_toggle(bool)` instead of calling `toggle_play_pause()` -- state unchanged until `set_state()` confirms

## Interaction model

| Gesture | Callback emitted | State changed? |
|---|---|---|
| Encoder turn | `on_volume_change(requested_vol)` | No -- call `set_volume()` to confirm |
| Short press | `on_mute_toggle(muted)` | Yes (flag only) |
| Long press | `on_play_pause_toggle(playing)` | No -- call `set_state()` to confirm |

## Test results

944 tests passed, 100% coverage on `ha_media.py`, 99.90% overall (95% gate).