### PR TITLE
Add set_muted() silent confirmed setter to HaMediaCard

### DIFF
--- a/src/deckboard/presets/ha_media.py
+++ b/src/deckboard/presets/ha_media.py
@@ -319,6 +319,16 @@ class HaMediaCard(Card):
 
     # ── Mute control ──────────────────────────────────────────────────
 
+    def set_muted(self, muted: bool) -> None:
+        """Set the confirmed mute state.
+
+        This is intended to be called by the integration layer to sync
+        the mute state from the backend (e.g. on initial load or after
+        a confirmed toggle).  No callback is emitted.
+        """
+        self._muted = bool(muted)
+        self._dirty = True
+
     def toggle_mute(self) -> None:
         """Toggle mute on/off.
 

--- a/tests/test_widgets_ha_media_card.py
+++ b/tests/test_widgets_ha_media_card.py
@@ -280,6 +280,36 @@ class TestHaMediaCardMute:
         assert c.muted is False
         assert c.volume == 0
 
+    def test_set_muted_true(self):
+        c = HaMediaCard(0)
+        c.set_muted(True)
+        assert c.muted is True
+
+    def test_set_muted_false(self):
+        c = HaMediaCard(0)
+        c.toggle_mute()
+        c.set_muted(False)
+        assert c.muted is False
+
+    def test_set_muted_marks_dirty(self):
+        c = HaMediaCard(0)
+        c.mark_clean()
+        c.set_muted(True)
+        assert c.is_dirty is True
+
+    def test_set_muted_does_not_emit_callback(self):
+        c = HaMediaCard(0)
+        handler = AsyncMock()
+        c.on_mute_toggle(handler)
+        c.set_muted(True)
+        callbacks = c.drain_pending_callbacks()
+        assert len(callbacks) == 0
+
+    def test_set_muted_does_not_change_volume(self):
+        c = HaMediaCard(0, volume=75)
+        c.set_muted(True)
+        assert c.volume == 75
+
 
 # ── Play/Pause control (direct method calls) ─────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `set_muted(bool)` as a silent confirmed setter, consistent with `set_volume()` and `set_state()`
- Allows the integration layer to sync mute state from the backend (initial load, confirmed toggle) without emitting callbacks
- 949 tests passed, 100% coverage on `ha_media.py`, 99.90% overall