### PR TITLE
Add min/max setters for sliders and presets

### DIFF
--- a/src/deckboard/presets/audio.py
+++ b/src/deckboard/presets/audio.py
@@ -106,3 +106,23 @@ class EqualizerCard(StackCard):
     def balance(self) -> BalanceSlider:
         """The Balance slider."""
         return self._balance
+
+    # -- Range setters -----------------------------------------------------
+
+    def set_eq_range(self, min_value: float, max_value: float) -> None:
+        """Set the min/max range for all three EQ band sliders.
+
+        Each band's current value is re-clamped to the new range and
+        the card is marked dirty.
+        """
+        self._sub.set_range(min_value, max_value)
+        self._bass.set_range(min_value, max_value)
+        self._treble.set_range(min_value, max_value)
+
+    def set_balance_range(self, min_value: float, max_value: float) -> None:
+        """Set the min/max range for the balance slider.
+
+        The current value is re-clamped to the new range and the card
+        is marked dirty.
+        """
+        self._balance.set_range(min_value, max_value)

--- a/src/deckboard/presets/audio.py
+++ b/src/deckboard/presets/audio.py
@@ -25,6 +25,10 @@ class EqualizerCard(StackCard):
         bass: Initial Bass value.  Defaults to 0.
         treble: Initial Treble value.  Defaults to 0.
         balance: Initial Balance value.  Defaults to 50 (centre).
+        eq_min: Minimum value for all three EQ band sliders.  Defaults to 0.
+        eq_max: Maximum value for all three EQ band sliders.  Defaults to 100.
+        balance_min: Minimum value for the balance slider.  Defaults to 0.
+        balance_max: Maximum value for the balance slider.  Defaults to 100.
 
     Usage::
 
@@ -45,12 +49,36 @@ class EqualizerCard(StackCard):
         bass: float = 0,
         treble: float = 0,
         balance: float = 50,
+        eq_min: float = 0,
+        eq_max: float = 100,
+        balance_min: float = 0,
+        balance_max: float = 100,
     ) -> None:
         super().__init__(index)
-        self._sub = EqualizerSlider("Sub", value=sub)
-        self._bass = EqualizerSlider("Bass", value=bass)
-        self._treble = EqualizerSlider("Treble", value=treble)
-        self._balance = BalanceSlider("Balance", value=balance)
+        self._sub = EqualizerSlider(
+            "Sub",
+            value=sub,
+            min_value=eq_min,
+            max_value=eq_max,
+        )
+        self._bass = EqualizerSlider(
+            "Bass",
+            value=bass,
+            min_value=eq_min,
+            max_value=eq_max,
+        )
+        self._treble = EqualizerSlider(
+            "Treble",
+            value=treble,
+            min_value=eq_min,
+            max_value=eq_max,
+        )
+        self._balance = BalanceSlider(
+            "Balance",
+            value=balance,
+            min_value=balance_min,
+            max_value=balance_max,
+        )
 
         self.add_element(self._sub, default=True)
         self.add_element(self._bass)

--- a/src/deckboard/presets/ha_media.py
+++ b/src/deckboard/presets/ha_media.py
@@ -190,6 +190,8 @@ class HaMediaCard(Card):
         title: str = "No Media",
         state: str = "Idle",
         volume: float = 50,
+        volume_min: float = 0,
+        volume_max: float = 100,
         entity_picture: Image.Image | None = None,
         long_press_seconds: float = 2.0,
     ) -> None:
@@ -197,7 +199,9 @@ class HaMediaCard(Card):
         self._artist = artist
         self._title = title
         self._state = state
-        self._volume = max(0.0, min(100.0, float(volume)))
+        self._volume_min = float(volume_min)
+        self._volume_max = float(volume_max)
+        self._volume = max(self._volume_min, min(self._volume_max, float(volume)))
         self._requested_volume: float = self._volume
         self._entity_picture = entity_picture
         self._muted = False
@@ -229,8 +233,18 @@ class HaMediaCard(Card):
 
     @property
     def volume(self) -> float:
-        """Current confirmed volume level (0–100)."""
+        """Current confirmed volume level."""
         return self._volume
+
+    @property
+    def volume_min(self) -> float:
+        """Minimum volume level."""
+        return self._volume_min
+
+    @property
+    def volume_max(self) -> float:
+        """Maximum volume level."""
+        return self._volume_max
 
     @property
     def requested_volume(self) -> float:
@@ -243,8 +257,11 @@ class HaMediaCard(Card):
 
     @property
     def volume_normalized(self) -> float:
-        """Volume mapped to 0.0 – 1.0."""
-        return self._volume / 100.0
+        """Volume mapped to 0.0 – 1.0 within the min/max range."""
+        span = self._volume_max - self._volume_min
+        if span <= 0:
+            return 0.0
+        return max(0.0, min(1.0, (self._volume - self._volume_min) / span))
 
     @property
     def muted(self) -> bool:
@@ -293,7 +310,7 @@ class HaMediaCard(Card):
         return self
 
     def set_volume(self, volume: float) -> None:
-        """Set the confirmed volume, clamping to 0–100.
+        """Set the confirmed volume, clamping to ``[volume_min, volume_max]``.
 
         This is intended to be called by the integration layer after
         the backend has acknowledged the volume change.  No callback
@@ -301,8 +318,27 @@ class HaMediaCard(Card):
         reset to match so that subsequent encoder ticks start from
         the confirmed value.
         """
-        self._volume = max(0.0, min(100.0, float(volume)))
+        self._volume = max(self._volume_min, min(self._volume_max, float(volume)))
         self._requested_volume = self._volume
+        self._dirty = True
+
+    def set_volume_range(self, min_value: float, max_value: float) -> None:
+        """Set both minimum and maximum volume in one call.
+
+        The confirmed volume and requested volume are re-clamped to
+        the new range and the card is marked dirty when either bound
+        actually changes.
+        """
+        min_value = float(min_value)
+        max_value = float(max_value)
+        if min_value == self._volume_min and max_value == self._volume_max:
+            return
+        self._volume_min = min_value
+        self._volume_max = max_value
+        self._volume = max(self._volume_min, min(self._volume_max, self._volume))
+        self._requested_volume = max(
+            self._volume_min, min(self._volume_max, self._requested_volume)
+        )
         self._dirty = True
 
     def set_volume_step(self, step: float) -> HaMediaCard:
@@ -427,7 +463,10 @@ class HaMediaCard(Card):
         """
         old_requested = self._requested_volume
         self._requested_volume = max(
-            0.0, min(100.0, self._requested_volume + direction * self._volume_step)
+            self._volume_min,
+            min(
+                self._volume_max, self._requested_volume + direction * self._volume_step
+            ),
         )
         if (
             self._volume_change_handler is not None

--- a/src/deckboard/presets/lighting.py
+++ b/src/deckboard/presets/lighting.py
@@ -22,6 +22,10 @@ class LightCard(StackCard):
         index: Card zone index (0–3).
         brightness: Initial brightness value (0–100).  Defaults to 100.
         kelvin: Initial colour temperature in Kelvin.  Defaults to 4000.
+        brightness_min: Minimum brightness.  Defaults to 0.
+        brightness_max: Maximum brightness.  Defaults to 100.
+        kelvin_min: Minimum colour temperature in Kelvin.  Defaults to 2000.
+        kelvin_max: Maximum colour temperature in Kelvin.  Defaults to 6500.
 
     Usage::
 
@@ -38,10 +42,24 @@ class LightCard(StackCard):
         *,
         brightness: float = 100,
         kelvin: float = 4000,
+        brightness_min: float = 0,
+        brightness_max: float = 100,
+        kelvin_min: float = 2000,
+        kelvin_max: float = 6500,
     ) -> None:
         super().__init__(index)
-        self._brightness = BrightnessSlider("Brightness", value=brightness)
-        self._kelvin = KelvinSlider("Kelvin", value=kelvin)
+        self._brightness = BrightnessSlider(
+            "Brightness",
+            value=brightness,
+            min_value=brightness_min,
+            max_value=brightness_max,
+        )
+        self._kelvin = KelvinSlider(
+            "Kelvin",
+            value=kelvin,
+            min_value=kelvin_min,
+            max_value=kelvin_max,
+        )
 
         self.add_element(self._brightness, default=True)
         self.add_element(self._kelvin)

--- a/src/deckboard/presets/lighting.py
+++ b/src/deckboard/presets/lighting.py
@@ -75,3 +75,21 @@ class LightCard(StackCard):
     def kelvin(self) -> KelvinSlider:
         """The Kelvin (colour temperature) slider."""
         return self._kelvin
+
+    # -- Range setters -----------------------------------------------------
+
+    def set_brightness_range(self, min_value: float, max_value: float) -> None:
+        """Set the min/max range for the brightness slider.
+
+        The current value is re-clamped to the new range and the card
+        is marked dirty.
+        """
+        self._brightness.set_range(min_value, max_value)
+
+    def set_kelvin_range(self, min_value: float, max_value: float) -> None:
+        """Set the min/max range for the kelvin slider.
+
+        The current value is re-clamped to the new range and the card
+        is marked dirty.
+        """
+        self._kelvin.set_range(min_value, max_value)

--- a/src/deckboard/presets/media.py
+++ b/src/deckboard/presets/media.py
@@ -75,6 +75,16 @@ class MediaCard(StackCard):
         """Whether the volume is currently muted."""
         return self._muted
 
+    # -- Range setters -----------------------------------------------------
+
+    def set_volume_range(self, min_value: float, max_value: float) -> None:
+        """Set the min/max range for the volume slider.
+
+        The current value is re-clamped to the new range and the card
+        is marked dirty.
+        """
+        self._volume.set_range(min_value, max_value)
+
     # -- Mute control ------------------------------------------------------
 
     def toggle_mute(self) -> None:

--- a/src/deckboard/presets/media.py
+++ b/src/deckboard/presets/media.py
@@ -23,6 +23,8 @@ class MediaCard(StackCard):
         index: Card zone index (0–3).
         title: Initial media title text.  Defaults to ``"No Media"``.
         volume: Initial volume level.  Defaults to 50.
+        volume_min: Minimum volume.  Defaults to 0.
+        volume_max: Maximum volume.  Defaults to 100.
 
     Usage::
 
@@ -39,10 +41,17 @@ class MediaCard(StackCard):
         *,
         title: str = "No Media",
         volume: float = 50,
+        volume_min: float = 0,
+        volume_max: float = 100,
     ) -> None:
         super().__init__(index)
         self._title_text = LargeText(title)
-        self._volume = VolumeSlider("Volume", value=volume)
+        self._volume = VolumeSlider(
+            "Volume",
+            value=volume,
+            min_value=volume_min,
+            max_value=volume_max,
+        )
         self._muted = False
         self._saved_volume: float = volume
 

--- a/src/deckboard/ui/controls/range_control.py
+++ b/src/deckboard/ui/controls/range_control.py
@@ -74,7 +74,8 @@ class RangeControl(Control, ABC):
         self._label = label
         self._min = float(min_value)
         self._max = float(max_value)
-        self._value = float(value) if value is not None else self._min
+        v = float(value) if value is not None else self._min
+        self._value = max(self._min, min(self._max, v))
         self._unit = unit
         self._step = float(step)
         self._change_handler: AsyncHandler | None = None
@@ -130,6 +131,56 @@ class RangeControl(Control, ABC):
         """
         self._change_handler = handler
         return handler
+
+    def set_min_value(self, v: float) -> None:
+        """Set the minimum value.
+
+        If the current value is below the new minimum it is clamped
+        upward.  The parent card is marked dirty when the minimum
+        actually changes.
+        """
+        v = float(v)
+        if v == self._min:
+            return
+        self._min = v
+        self._clamp_value_to_range()
+        if self._card is not None:
+            self._card.mark_dirty()
+
+    def set_max_value(self, v: float) -> None:
+        """Set the maximum value.
+
+        If the current value exceeds the new maximum it is clamped
+        downward.  The parent card is marked dirty when the maximum
+        actually changes.
+        """
+        v = float(v)
+        if v == self._max:
+            return
+        self._max = v
+        self._clamp_value_to_range()
+        if self._card is not None:
+            self._card.mark_dirty()
+
+    def set_range(self, min_value: float, max_value: float) -> None:
+        """Set both minimum and maximum in one call.
+
+        The current value is re-clamped to the new range and the
+        parent card is marked dirty when either bound actually changes.
+        """
+        min_value = float(min_value)
+        max_value = float(max_value)
+        if min_value == self._min and max_value == self._max:
+            return
+        self._min = min_value
+        self._max = max_value
+        self._clamp_value_to_range()
+        if self._card is not None:
+            self._card.mark_dirty()
+
+    def _clamp_value_to_range(self) -> None:
+        """Re-clamp the current value to ``[min, max]``."""
+        self._value = max(self._min, min(self._max, self._value))
 
     def set_value(self, v: float) -> None:
         """Set the value, clamping to ``[min_value, max_value]``.

--- a/tests/test_range_control.py
+++ b/tests/test_range_control.py
@@ -106,6 +106,160 @@ class TestSliderSetValue:
         assert s.value == 90
 
 
+class TestSliderSetMinValue:
+    def test_set_min_value(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_min_value(10)
+        assert s.min_value == 10
+
+    def test_clamps_value_upward(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=5)
+        s.set_min_value(20)
+        assert s.value == 20
+
+    def test_no_clamp_when_value_above_new_min(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_min_value(10)
+        assert s.value == 50
+
+    def test_marks_card_dirty(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_min_value(10)
+        assert w.is_dirty is True
+
+    def test_no_dirty_when_same_value(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_min_value(0)
+        assert w.is_dirty is False
+
+    def test_without_card_does_not_raise(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_min_value(10)
+        assert s.min_value == 10
+
+
+class TestSliderSetMaxValue:
+    def test_set_max_value(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_max_value(80)
+        assert s.max_value == 80
+
+    def test_clamps_value_downward(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=90)
+        s.set_max_value(50)
+        assert s.value == 50
+
+    def test_no_clamp_when_value_below_new_max(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=30)
+        s.set_max_value(80)
+        assert s.value == 30
+
+    def test_marks_card_dirty(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_max_value(80)
+        assert w.is_dirty is True
+
+    def test_no_dirty_when_same_value(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_max_value(100)
+        assert w.is_dirty is False
+
+    def test_without_card_does_not_raise(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_max_value(80)
+        assert s.max_value == 80
+
+
+class TestSliderSetRange:
+    def test_set_range(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_range(10, 90)
+        assert s.min_value == 10
+        assert s.max_value == 90
+
+    def test_clamps_value_to_new_range_low(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=5)
+        s.set_range(20, 80)
+        assert s.value == 20
+
+    def test_clamps_value_to_new_range_high(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=95)
+        s.set_range(20, 80)
+        assert s.value == 80
+
+    def test_no_clamp_when_value_in_range(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_range(10, 90)
+        assert s.value == 50
+
+    def test_marks_card_dirty(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_range(10, 90)
+        assert w.is_dirty is True
+
+    def test_no_dirty_when_same_range(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_range(0, 100)
+        assert w.is_dirty is False
+
+    def test_dirty_when_only_min_changes(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_range(10, 100)
+        assert w.is_dirty is True
+
+    def test_dirty_when_only_max_changes(self):
+        w = StackCard(0)
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        w.add_control(s)
+        w.mark_clean()
+        s.set_range(0, 90)
+        assert w.is_dirty is True
+
+    def test_without_card_does_not_raise(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_range(10, 90)
+        assert s.min_value == 10
+        assert s.max_value == 90
+
+    def test_normalized_updates_after_set_range(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_range(0, 200)
+        assert s.normalized == pytest.approx(0.25)
+
+    def test_set_value_uses_new_range(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50)
+        s.set_range(0, 200)
+        s.set_value(150)
+        assert s.value == 150
+
+    def test_adjust_respects_new_range(self):
+        s = _ConcreteLargeSlider("X", min_value=0, max_value=100, value=50, step=10)
+        s.set_max_value(55)
+        s.adjust(1)
+        assert s.value == 55
+
+
 class TestSliderAdjust:
     def test_positive_direction(self):
         s = _ConcreteLargeSlider("X", value=50, step=5)
@@ -143,7 +297,7 @@ class TestSliderFormatValue:
         assert s.format_value() == "20.5\u00b0C"
 
     def test_kelvin(self):
-        s = _ConcreteLargeSlider("X", value=3000, unit="K")
+        s = _ConcreteLargeSlider("X", value=3000, max_value=6500, unit="K")
         assert s.format_value() == "3000K"
 
     def test_no_unit(self):

--- a/tests/test_widgets_equalizer_widget.py
+++ b/tests/test_widgets_equalizer_widget.py
@@ -50,6 +50,48 @@ class TestEqualizerWidgetInit:
         assert w.active_control is w.sub
 
 
+class TestEqualizerWidgetMinMax:
+    def test_custom_eq_range(self):
+        w = EqualizerCard(0, eq_min=10, eq_max=90)
+        assert w.sub.min_value == 10
+        assert w.sub.max_value == 90
+        assert w.bass.min_value == 10
+        assert w.bass.max_value == 90
+        assert w.treble.min_value == 10
+        assert w.treble.max_value == 90
+
+    def test_custom_balance_range(self):
+        w = EqualizerCard(0, balance_min=20, balance_max=80)
+        assert w.balance.min_value == 20
+        assert w.balance.max_value == 80
+
+    def test_eq_range_clamps_value(self):
+        w = EqualizerCard(0, sub=5, eq_min=10, eq_max=90)
+        assert w.sub.value == 10
+
+    def test_set_min_value_on_slider(self):
+        w = EqualizerCard(0, sub=50)
+        w.sub.set_min_value(30)
+        assert w.sub.min_value == 30
+
+    def test_set_max_value_on_slider(self):
+        w = EqualizerCard(0, sub=50)
+        w.sub.set_max_value(70)
+        assert w.sub.max_value == 70
+
+    def test_set_range_on_slider(self):
+        w = EqualizerCard(0, sub=50)
+        w.sub.set_range(20, 80)
+        assert w.sub.min_value == 20
+        assert w.sub.max_value == 80
+
+    def test_set_range_marks_dirty(self):
+        w = EqualizerCard(0, sub=50)
+        w.mark_clean()
+        w.sub.set_range(10, 90)
+        assert w.is_dirty is True
+
+
 class TestEqualizerWidgetAccessors:
     def test_sub_set_value(self):
         w = EqualizerCard(0)

--- a/tests/test_widgets_equalizer_widget.py
+++ b/tests/test_widgets_equalizer_widget.py
@@ -91,6 +91,46 @@ class TestEqualizerWidgetMinMax:
         w.sub.set_range(10, 90)
         assert w.is_dirty is True
 
+    def test_set_eq_range(self):
+        w = EqualizerCard(0, sub=50, bass=50, treble=50)
+        w.set_eq_range(10, 90)
+        assert w.sub.min_value == 10
+        assert w.sub.max_value == 90
+        assert w.bass.min_value == 10
+        assert w.bass.max_value == 90
+        assert w.treble.min_value == 10
+        assert w.treble.max_value == 90
+
+    def test_set_eq_range_clamps_values(self):
+        w = EqualizerCard(0, sub=5, bass=95, treble=50)
+        w.set_eq_range(20, 80)
+        assert w.sub.value == 20
+        assert w.bass.value == 80
+        assert w.treble.value == 50
+
+    def test_set_eq_range_marks_dirty(self):
+        w = EqualizerCard(0, sub=50)
+        w.mark_clean()
+        w.set_eq_range(10, 90)
+        assert w.is_dirty is True
+
+    def test_set_balance_range(self):
+        w = EqualizerCard(0, balance=50)
+        w.set_balance_range(20, 80)
+        assert w.balance.min_value == 20
+        assert w.balance.max_value == 80
+
+    def test_set_balance_range_clamps_value(self):
+        w = EqualizerCard(0, balance=90)
+        w.set_balance_range(20, 80)
+        assert w.balance.value == 80
+
+    def test_set_balance_range_marks_dirty(self):
+        w = EqualizerCard(0, balance=50)
+        w.mark_clean()
+        w.set_balance_range(20, 80)
+        assert w.is_dirty is True
+
 
 class TestEqualizerWidgetAccessors:
     def test_sub_set_value(self):

--- a/tests/test_widgets_ha_media_card.py
+++ b/tests/test_widgets_ha_media_card.py
@@ -102,6 +102,25 @@ class TestHaMediaCardInit:
         c = HaMediaCard(0, long_press_seconds=-5)
         assert c.long_press_seconds == 0.0
 
+    def test_volume_min_max_defaults(self):
+        c = HaMediaCard(0)
+        assert c.volume_min == 0
+        assert c.volume_max == 100
+
+    def test_custom_volume_range(self):
+        c = HaMediaCard(0, volume=50, volume_min=10, volume_max=80)
+        assert c.volume_min == 10
+        assert c.volume_max == 80
+        assert c.volume == 50
+
+    def test_volume_clamped_to_custom_range_high(self):
+        c = HaMediaCard(0, volume=100, volume_min=10, volume_max=80)
+        assert c.volume == 80
+
+    def test_volume_clamped_to_custom_range_low(self):
+        c = HaMediaCard(0, volume=5, volume_min=10, volume_max=80)
+        assert c.volume == 10
+
 
 # ── Accessors ────────────────────────────────────────────────────────────
 
@@ -231,6 +250,65 @@ class TestHaMediaCardMutators:
         c = HaMediaCard(0)
         c.set_long_press_seconds(-1)
         assert c.long_press_seconds == 0.0
+
+
+# ── Volume range setters ─────────────────────────────────────────────────
+
+
+class TestHaMediaCardVolumeRange:
+    def test_set_volume_range(self):
+        c = HaMediaCard(0, volume=50)
+        c.set_volume_range(10, 90)
+        assert c.volume_min == 10
+        assert c.volume_max == 90
+
+    def test_set_volume_range_clamps_volume(self):
+        c = HaMediaCard(0, volume=100)
+        c.set_volume_range(10, 80)
+        assert c.volume == 80
+
+    def test_set_volume_range_clamps_volume_low(self):
+        c = HaMediaCard(0, volume=5)
+        c.set_volume_range(10, 80)
+        assert c.volume == 10
+
+    def test_set_volume_range_clamps_requested_volume(self):
+        c = HaMediaCard(0, volume=50)
+        c.handle_encoder_turn(40)  # requested_volume = 90
+        c.set_volume_range(10, 80)
+        assert c.requested_volume == 80
+
+    def test_set_volume_range_marks_dirty(self):
+        c = HaMediaCard(0, volume=50)
+        c.mark_clean()
+        c.set_volume_range(10, 90)
+        assert c.is_dirty is True
+
+    def test_set_volume_range_no_dirty_when_same(self):
+        c = HaMediaCard(0, volume=50)
+        c.mark_clean()
+        c.set_volume_range(0, 100)
+        assert c.is_dirty is False
+
+    def test_set_volume_clamps_to_new_range(self):
+        c = HaMediaCard(0, volume=50)
+        c.set_volume_range(20, 80)
+        c.set_volume(100)
+        assert c.volume == 80
+
+    def test_encoder_turn_clamps_to_new_range(self):
+        c = HaMediaCard(0, volume=75)
+        c.set_volume_range(0, 80)
+        c.handle_encoder_turn(10)
+        assert c.requested_volume == 80
+
+    def test_volume_normalized_custom_range(self):
+        c = HaMediaCard(0, volume=50, volume_min=0, volume_max=200)
+        assert c.volume_normalized == 0.25
+
+    def test_volume_normalized_zero_span(self):
+        c = HaMediaCard(0, volume=50, volume_min=50, volume_max=50)
+        assert c.volume_normalized == 0.0
 
 
 # ── Mute control (direct method calls) ───────────────────────────────────

--- a/tests/test_widgets_light_widget.py
+++ b/tests/test_widgets_light_widget.py
@@ -42,6 +42,44 @@ class TestLightWidgetInit:
         assert w.active_control is w.brightness
 
 
+class TestLightWidgetMinMax:
+    def test_custom_brightness_range(self):
+        w = LightCard(0, brightness_min=10, brightness_max=90)
+        assert w.brightness.min_value == 10
+        assert w.brightness.max_value == 90
+
+    def test_custom_kelvin_range(self):
+        w = LightCard(0, kelvin_min=2700, kelvin_max=5000)
+        assert w.kelvin.min_value == 2700
+        assert w.kelvin.max_value == 5000
+
+    def test_brightness_range_clamps_value(self):
+        w = LightCard(0, brightness=100, brightness_max=80)
+        assert w.brightness.value == 80
+
+    def test_kelvin_range_clamps_value(self):
+        w = LightCard(0, kelvin=6000, kelvin_max=5000)
+        assert w.kelvin.value == 5000
+
+    def test_set_range_on_brightness(self):
+        w = LightCard(0, brightness=50)
+        w.brightness.set_range(10, 90)
+        assert w.brightness.min_value == 10
+        assert w.brightness.max_value == 90
+
+    def test_set_range_on_kelvin(self):
+        w = LightCard(0, kelvin=4000)
+        w.kelvin.set_range(3000, 5500)
+        assert w.kelvin.min_value == 3000
+        assert w.kelvin.max_value == 5500
+
+    def test_set_range_marks_dirty(self):
+        w = LightCard(0, brightness=50)
+        w.mark_clean()
+        w.brightness.set_range(10, 90)
+        assert w.is_dirty is True
+
+
 class TestLightWidgetAccessors:
     def test_brightness_set_value(self):
         w = LightCard(0)

--- a/tests/test_widgets_light_widget.py
+++ b/tests/test_widgets_light_widget.py
@@ -79,6 +79,40 @@ class TestLightWidgetMinMax:
         w.brightness.set_range(10, 90)
         assert w.is_dirty is True
 
+    def test_set_brightness_range(self):
+        w = LightCard(0, brightness=50)
+        w.set_brightness_range(10, 90)
+        assert w.brightness.min_value == 10
+        assert w.brightness.max_value == 90
+
+    def test_set_brightness_range_clamps_value(self):
+        w = LightCard(0, brightness=100)
+        w.set_brightness_range(10, 80)
+        assert w.brightness.value == 80
+
+    def test_set_brightness_range_marks_dirty(self):
+        w = LightCard(0, brightness=50)
+        w.mark_clean()
+        w.set_brightness_range(10, 90)
+        assert w.is_dirty is True
+
+    def test_set_kelvin_range(self):
+        w = LightCard(0, kelvin=4000)
+        w.set_kelvin_range(3000, 5500)
+        assert w.kelvin.min_value == 3000
+        assert w.kelvin.max_value == 5500
+
+    def test_set_kelvin_range_clamps_value(self):
+        w = LightCard(0, kelvin=6000)
+        w.set_kelvin_range(3000, 5000)
+        assert w.kelvin.value == 5000
+
+    def test_set_kelvin_range_marks_dirty(self):
+        w = LightCard(0, kelvin=4000)
+        w.mark_clean()
+        w.set_kelvin_range(3000, 5500)
+        assert w.is_dirty is True
+
 
 class TestLightWidgetAccessors:
     def test_brightness_set_value(self):

--- a/tests/test_widgets_media_widget.py
+++ b/tests/test_widgets_media_widget.py
@@ -42,6 +42,35 @@ class TestMediaWidgetInit:
         assert w.active_control is w.volume
 
 
+class TestMediaWidgetMinMax:
+    def test_custom_volume_range(self):
+        w = MediaCard(0, volume_min=10, volume_max=80)
+        assert w.volume.min_value == 10
+        assert w.volume.max_value == 80
+
+    def test_volume_range_clamps_value(self):
+        w = MediaCard(0, volume=100, volume_max=80)
+        assert w.volume.value == 80
+
+    def test_set_range_on_volume(self):
+        w = MediaCard(0, volume=50)
+        w.volume.set_range(10, 90)
+        assert w.volume.min_value == 10
+        assert w.volume.max_value == 90
+
+    def test_set_range_marks_dirty(self):
+        w = MediaCard(0, volume=50)
+        w.mark_clean()
+        w.volume.set_range(10, 90)
+        assert w.is_dirty is True
+
+    def test_mute_respects_min_value(self):
+        """When volume_min > 0, muting sets to volume_min."""
+        w = MediaCard(0, volume=50, volume_min=10)
+        w.toggle_mute()
+        assert w.volume.value == 10  # clamped to min
+
+
 class TestMediaWidgetAccessors:
     def test_title_text_set_text(self):
         w = MediaCard(0)

--- a/tests/test_widgets_media_widget.py
+++ b/tests/test_widgets_media_widget.py
@@ -70,6 +70,23 @@ class TestMediaWidgetMinMax:
         w.toggle_mute()
         assert w.volume.value == 10  # clamped to min
 
+    def test_set_volume_range(self):
+        w = MediaCard(0, volume=50)
+        w.set_volume_range(10, 90)
+        assert w.volume.min_value == 10
+        assert w.volume.max_value == 90
+
+    def test_set_volume_range_clamps_value(self):
+        w = MediaCard(0, volume=100)
+        w.set_volume_range(10, 80)
+        assert w.volume.value == 80
+
+    def test_set_volume_range_marks_dirty(self):
+        w = MediaCard(0, volume=50)
+        w.mark_clean()
+        w.set_volume_range(10, 90)
+        assert w.is_dirty is True
+
 
 class TestMediaWidgetAccessors:
     def test_title_text_set_text(self):


### PR DESCRIPTION
## Summary

- Add set_min_value(), set_max_value(), and set_range() methods to RangeControl for runtime adjustment of slider bounds
- Clamp initial value in RangeControl.__init__() to [min, max] (previously unclamped)
- Add eq_min/eq_max/balance_min/balance_max constructor params to EqualizerCard
- Add brightness_min/brightness_max/kelvin_min/kelvin_max constructor params to LightCard
- Add volume_min/volume_max constructor params to MediaCard

All setters re-clamp the current value to the new range and propagate dirty state to the parent card. No-ops when the value has not changed.

## Test results

All 1006 tests pass. Coverage: 99.90% (well above the 95% gate).