### PR TITLE
Add --background option to preview tool for custom touchstrip background colour

### DIFF
--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -3,11 +3,13 @@
 Run with::
 
     python -m deckboard.tools.preview \\
-        --card0 my_card.svg --key0 my_key.svg
+        --card0 my_card.svg --key0 my_key.svg \\
+        --background "#1a2b3c"
 
 Only the specified slots are updated; unspecified keys and cards are
-left blank (black).  SVGs are scaled to fit the target area while
-preserving aspect ratio and centred on a black background.
+left blank (black unless ``--background`` is given).  SVGs are scaled to
+fit the target area while preserving aspect ratio and centred on the
+background colour.
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ import io
 import logging
 import os
 import platform
+import re
 import signal
 import subprocess
 import sys
@@ -44,6 +47,23 @@ from deckboard.render.metrics import (
 logger = logging.getLogger(__name__)
 
 _KEY_COUNT = 8
+
+_HEX_RE = re.compile(r"^#?([0-9a-fA-F]{6})$")
+
+
+def parse_hex_color(value: str) -> str:
+    """Validate and normalise a hex colour string to ``#RRGGBB``.
+
+    Accepts ``RRGGBB`` or ``#RRGGBB`` (case-insensitive).  Raises
+    :class:`argparse.ArgumentTypeError` for invalid values so that
+    ``argparse`` can produce a user-friendly error message.
+    """
+    m = _HEX_RE.match(value)
+    if m is None:
+        raise argparse.ArgumentTypeError(
+            f"invalid hex colour: {value!r} (expected '#RRGGBB' or 'RRGGBB')"
+        )
+    return f"#{m.group(1).lower()}"
 
 
 # -- SVG loading -------------------------------------------------------------
@@ -144,9 +164,16 @@ def compose_key_image(svg_img: Image.Image) -> bytes:
     return _encode_jpeg(canvas)
 
 
-def compose_card_image(svg_img: Image.Image) -> Image.Image:
-    """Place *svg_img* centred on a panel-sized black card canvas."""
-    canvas = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), "black")
+def compose_card_image(
+    svg_img: Image.Image,
+    background: str = "black",
+) -> Image.Image:
+    """Place *svg_img* centred on a panel-sized card canvas.
+
+    *background* sets the canvas fill colour (any PIL-compatible colour
+    string, e.g. ``"black"`` or ``"#1a2b3c"``).
+    """
+    canvas = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), background)
     x = (PANEL_WIDTH - svg_img.width) // 2
     y = (PANEL_HEIGHT - svg_img.height) // 2
     if svg_img.mode == "RGBA":
@@ -156,9 +183,16 @@ def compose_card_image(svg_img: Image.Image) -> Image.Image:
     return canvas
 
 
-def compose_touchstrip(card_images: list[Image.Image | None]) -> bytes:
-    """Compose up to 4 card images into a single 800x100 touchscreen JPEG."""
-    img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+def compose_touchstrip(
+    card_images: list[Image.Image | None],
+    background: str = "black",
+) -> bytes:
+    """Compose up to 4 card images into a single 800x100 touchscreen JPEG.
+
+    *background* fills the entire 800x100 canvas — including the margin
+    and gap areas outside card panels.
+    """
+    img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), background)
     for index, card_image in enumerate(card_images):
         if index >= PANEL_COUNT:
             break
@@ -200,6 +234,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=80,
         metavar="PCT",
         help="Screen brightness 0-100 (default: 80)",
+    )
+    parser.add_argument(
+        "--background",
+        type=parse_hex_color,
+        default=None,
+        metavar="HEX",
+        help="Background colour for the touchstrip in hex (e.g. '#1a2b3c' or '1a2b3c')",
     )
     parser.add_argument(
         "-v",
@@ -310,6 +351,7 @@ def render_preview(
 
     Returns a ``(key_images, touchstrip_bytes)`` tuple.
     """
+    background: str = getattr(args, "background", None) or "black"
     key_images: dict[int, bytes] = {}
     card_images: list[Image.Image | None] = [None] * PANEL_COUNT
 
@@ -332,12 +374,12 @@ def render_preview(
                 print(f"ERROR: Card SVG not found: {svg_path}", file=sys.stderr)  # noqa: T201
                 sys.exit(1)
             img = load_svg(svg_path, PANEL_WIDTH, PANEL_HEIGHT)
-            card_images[i] = compose_card_image(img)
+            card_images[i] = compose_card_image(img, background=background)
             logger.info(
                 "Rendered card %d from %s (%dx%d)", i, svg_path, img.width, img.height
             )
 
-    touchstrip_bytes = compose_touchstrip(card_images)
+    touchstrip_bytes = compose_touchstrip(card_images, background=background)
     return key_images, touchstrip_bytes
 
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -36,6 +36,7 @@ from deckboard.tools.preview import (
     load_svg,
     main,
     parse_args,
+    parse_hex_color,
     render_preview,
 )
 
@@ -80,6 +81,49 @@ def wide_svg(tmp_path: Path) -> Path:
     p = tmp_path / "wide.svg"
     p.write_bytes(svg)
     return p
+
+
+# -- parse_hex_color ---------------------------------------------------------
+
+
+class TestParseHexColor:
+    def test_hash_prefix(self):
+        assert parse_hex_color("#1a2b3c") == "#1a2b3c"
+
+    def test_no_hash_prefix(self):
+        assert parse_hex_color("ff00aa") == "#ff00aa"
+
+    def test_uppercase_normalised(self):
+        assert parse_hex_color("#AABBCC") == "#aabbcc"
+
+    def test_mixed_case(self):
+        assert parse_hex_color("AaBbCc") == "#aabbcc"
+
+    def test_all_zeros(self):
+        assert parse_hex_color("000000") == "#000000"
+
+    def test_all_f(self):
+        assert parse_hex_color("FFFFFF") == "#ffffff"
+
+    def test_invalid_too_short(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid hex colour"):
+            parse_hex_color("#abc")
+
+    def test_invalid_too_long(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid hex colour"):
+            parse_hex_color("#1234567")
+
+    def test_invalid_chars(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid hex colour"):
+            parse_hex_color("#gghhii")
+
+    def test_empty_string(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid hex colour"):
+            parse_hex_color("")
+
+    def test_hash_only(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid hex colour"):
+            parse_hex_color("#")
 
 
 # -- load_svg ----------------------------------------------------------------
@@ -172,6 +216,20 @@ class TestComposeCardImage:
         result = compose_card_image(svg_img)
         assert result.size == (PANEL_WIDTH, PANEL_HEIGHT)
 
+    def test_custom_background_colour(self):
+        """A card with no SVG coverage should show the custom background."""
+        svg_img = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+        result = compose_card_image(svg_img, background="#ff0000")
+        # A corner pixel (outside the tiny transparent SVG) should be red.
+        px = result.getpixel((0, 0))
+        assert px == (255, 0, 0)
+
+    def test_default_background_is_black(self):
+        svg_img = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+        result = compose_card_image(svg_img)
+        px = result.getpixel((0, 0))
+        assert px == (0, 0, 0)
+
 
 # -- compose_touchstrip ------------------------------------------------------
 
@@ -209,6 +267,35 @@ class TestComposeTouchstrip:
         result = compose_touchstrip(cards)
         decoded = Image.open(io.BytesIO(result))
         assert decoded.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
+
+    def test_custom_background_fills_margins(self):
+        """The background colour should fill areas outside card panels."""
+        cards: list[Image.Image | None] = [None] * PANEL_COUNT
+        result = compose_touchstrip(cards, background="#00ff00")
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        # Top-left corner is in the margin area — should be green.
+        px = decoded.getpixel((0, 0))
+        assert px[1] > 200  # green channel high
+        assert px[0] < 30  # red channel low
+        assert px[2] < 30  # blue channel low
+
+    def test_custom_background_between_panels(self):
+        """The background colour should fill the gap between card panels."""
+        # Use None cards so the entire canvas is background colour.
+        cards: list[Image.Image | None] = [None, None, None, None]
+        result = compose_touchstrip(cards, background="#0000ff")
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        # The gap area between where card 0 and card 1 would be.
+        gap_x = MARGIN_LEFT + PANEL_WIDTH + PANEL_GAP // 2
+        px = decoded.getpixel((gap_x, TOUCHSCREEN_HEIGHT // 2))
+        assert px[2] > 200  # blue channel high
+
+    def test_default_background_is_black(self):
+        cards: list[Image.Image | None] = [None] * PANEL_COUNT
+        result = compose_touchstrip(cards)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        px = decoded.getpixel((0, 0))
+        assert all(c < 10 for c in px)
 
 
 # -- build_parser / parse_args -----------------------------------------------
@@ -266,6 +353,22 @@ class TestParser:
         parser = build_parser()
         assert isinstance(parser, argparse.ArgumentParser)
 
+    def test_background_default_none(self):
+        args = parse_args([])
+        assert args.background is None
+
+    def test_background_with_hash(self):
+        args = parse_args(["--background", "#1a2b3c"])
+        assert args.background == "#1a2b3c"
+
+    def test_background_without_hash(self):
+        args = parse_args(["--background", "ff00aa"])
+        assert args.background == "#ff00aa"
+
+    def test_background_invalid_exits(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--background", "nope"])
+
 
 # -- render_preview ----------------------------------------------------------
 
@@ -320,6 +423,22 @@ class TestRenderPreview:
             render_preview(args)
         assert "Card SVG not found" in capsys.readouterr().err
 
+    def test_background_applies_to_touchstrip(self, wide_svg: Path):
+        """When --background is given, the touchstrip uses that colour."""
+        args = parse_args(["--card0", str(wide_svg), "--background", "#00ff00"])
+        _, touchstrip = render_preview(args)
+        decoded = Image.open(io.BytesIO(touchstrip)).convert("RGB")
+        # Top-left corner is margin area — should be green.
+        px = decoded.getpixel((0, 0))
+        assert px[1] > 200
+
+    def test_no_background_defaults_black(self):
+        args = parse_args([])
+        _, touchstrip = render_preview(args)
+        decoded = Image.open(io.BytesIO(touchstrip)).convert("RGB")
+        px = decoded.getpixel((0, 0))
+        assert all(c < 10 for c in px)
+
 
 # -- main / push_to_device ---------------------------------------------------
 
@@ -350,6 +469,19 @@ class TestMain:
     def test_main_verbose(self, mock_push: AsyncMock):
         main(["-v"])
         mock_push.assert_awaited_once()
+
+    @patch("deckboard.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_with_background(self, mock_push: AsyncMock):
+        main(["--background", "#aabbcc"])
+        mock_push.assert_awaited_once()
+        _, touchstrip, _ = mock_push.call_args[0]
+        # The touchstrip should contain the background colour.
+        decoded = Image.open(io.BytesIO(touchstrip)).convert("RGB")
+        px = decoded.getpixel((0, 0))
+        # #aabbcc = (170, 187, 204) — allow for JPEG compression.
+        assert px[0] > 150  # R
+        assert px[1] > 160  # G
+        assert px[2] > 180  # B
 
 
 class TestPushToDevice:


### PR DESCRIPTION
## Summary

- Add a `--background` CLI flag to `deckboard.tools.preview` that accepts a hex colour (`#RRGGBB` or `RRGGBB`) to set the background of the entire 800×100 touchstrip canvas, including margin and gap areas outside card panels
- Card canvases also use the same background colour so there are no black rectangles inside the strip
- Add `parse_hex_color()` validation helper with normalisation to lowercase `#rrggbb`
- Defaults to black when omitted, preserving existing behaviour
- 28 new tests covering hex validation, card/touchstrip background rendering, CLI parsing, and end-to-end integration

## Usage

```bash
python -m deckboard.tools.preview     --card0 my_card.svg --key0 my_key.svg     --background "#1a2b3c"
```