### PR TITLE
Add background color support for touchstrip canvas

### DIFF
--- a/src/deckboard/render/touch_renderer.py
+++ b/src/deckboard/render/touch_renderer.py
@@ -21,14 +21,16 @@ from .metrics import (
 def compose_touchstrip(
     cards: list[Image.Image | None],
     debug_grid: bool = False,
+    background: str = "black",
 ) -> bytes:
     """Compose 4 card images into a single touchscreen JPEG.
 
     Args:
         cards: Up to 4 card images (or ``None`` for blank slots).
         debug_grid: When ``True``, overlay a 32x4 alignment grid.
+        background: Fill colour for the 800x100 canvas (margins and gaps).
     """
-    img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+    img = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), background)
 
     for index, card_image in enumerate(cards):
         if index >= PANEL_COUNT:
@@ -43,6 +45,11 @@ def compose_touchstrip(
     return _encode_jpeg(img)
 
 
-def render_blank_touchscreen(debug_grid: bool = False) -> bytes:
+def render_blank_touchscreen(
+    debug_grid: bool = False,
+    background: str = "black",
+) -> bytes:
     """Render a blank touch-strip image."""
-    return compose_touchstrip([None] * PANEL_COUNT, debug_grid=debug_grid)
+    return compose_touchstrip(
+        [None] * PANEL_COUNT, debug_grid=debug_grid, background=background
+    )

--- a/src/deckboard/runtime/deck.py
+++ b/src/deckboard/runtime/deck.py
@@ -390,7 +390,11 @@ class Deck:
             card.set_rendered(img)
             card_images.append(img)
 
-        touchstrip_bytes = compose_touchstrip(card_images, debug_grid=self._debug_grid)
+        touchstrip_bytes = compose_touchstrip(
+            card_images,
+            debug_grid=self._debug_grid,
+            background=screen.touch_strip.background_color,
+        )
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(

--- a/src/deckboard/ui/screen.py
+++ b/src/deckboard/ui/screen.py
@@ -114,5 +114,14 @@ class Screen:
         return self._touch_strip
 
     @property
+    def touchstrip_background(self) -> str:
+        """The fill colour for the touchscreen canvas (margins and gaps)."""
+        return self._touch_strip.background_color
+
+    @touchstrip_background.setter
+    def touchstrip_background(self, value: str) -> None:
+        self._touch_strip.background_color = value
+
+    @property
     def cards(self) -> list[Card]:
         return self._touch_strip.cards

--- a/src/deckboard/ui/touch_strip.py
+++ b/src/deckboard/ui/touch_strip.py
@@ -8,10 +8,29 @@ from .cards.blank import BlankCard
 
 
 class TouchStrip:
-    """Manage the 4 card zones on the Stream Deck+ touch strip."""
+    """Manage the 4 card zones on the Stream Deck+ touch strip.
 
-    def __init__(self) -> None:
+    The *background_color* fills the entire 800x100 canvas — including
+    the margin and gap areas outside card panels.  Each :class:`Screen`
+    owns its own ``TouchStrip``, so different screens can use different
+    background colours.
+    """
+
+    def __init__(self, background_color: str = "black") -> None:
         self._cards: list[Card] = [BlankCard(i) for i in range(PANEL_COUNT)]
+        self._background_color = background_color
+
+    @property
+    def background_color(self) -> str:
+        """The fill colour for the touchscreen canvas (margins and gaps)."""
+        return self._background_color
+
+    @background_color.setter
+    def background_color(self, value: str) -> None:
+        if self._background_color != value:
+            self._background_color = value
+            for card in self._cards:
+                card.mark_dirty()
 
     def card(self, index: int) -> Card:
         """Get a card zone by index (0-3)."""

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -220,6 +220,26 @@ class TestComposeTouchscreen:
         img = _decode_jpeg(result)
         assert img.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
 
+    def test_custom_background_color(self):
+        """Background colour fills the canvas margins and gaps."""
+        result = compose_touchstrip([None] * 4, background="#ff0000")
+        img = _decode_jpeg(result)
+        assert img.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
+        # Top-left corner (0,0) is in the margin area — should be red-ish
+        r, g, b = img.getpixel((0, 0))
+        assert r > 200  # JPEG compression may shift values slightly
+        assert g < 50
+        assert b < 50
+
+    def test_default_background_is_black(self):
+        """Without a background argument the canvas is black."""
+        result = compose_touchstrip([None] * 4)
+        img = _decode_jpeg(result)
+        r, g, b = img.getpixel((0, 0))
+        assert r < 10
+        assert g < 10
+        assert b < 10
+
 
 # ── render_blank_key ────────────────────────────────────────────────────
 
@@ -258,6 +278,14 @@ class TestRenderBlankTouchscreen:
         result = render_blank_touchscreen(debug_grid=True)
         img = _decode_jpeg(result)
         assert img.size == (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT)
+
+    def test_custom_background(self):
+        result = render_blank_touchscreen(background="#00ff00")
+        img = _decode_jpeg(result)
+        r, g, b = img.getpixel((0, 0))
+        assert g > 200
+        assert r < 50
+        assert b < 50
 
 
 # ── _encode_jpeg ────────────────────────────────────────────────────────

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -119,6 +119,25 @@ class TestPageCard:
             page.card(4)
 
 
+class TestPageTouchstripBackground:
+    def test_default_is_black(self, page: Screen):
+        assert page.touchstrip_background == "black"
+
+    def test_getter_delegates_to_touch_strip(self, page: Screen):
+        page.touch_strip.background_color = "#abcdef"
+        assert page.touchstrip_background == "#abcdef"
+
+    def test_setter_delegates_to_touch_strip(self, page: Screen):
+        page.touchstrip_background = "#123456"
+        assert page.touch_strip.background_color == "#123456"
+
+    def test_setter_marks_cards_dirty(self, page: Screen):
+        for card in page.cards:
+            card.mark_clean()
+        page.touchstrip_background = "#ff0000"
+        assert page.touch_strip.any_dirty is True
+
+
 class TestPageSetCard:
     def test_set_card_replaces(self, page: Screen):
         from tests.test_touch_strip import _ConcreteWidget

--- a/tests/test_touch_strip.py
+++ b/tests/test_touch_strip.py
@@ -438,6 +438,34 @@ class TestTouchStripSetCard:
             touchscreen.set_card(0, "not a card")  # type: ignore[arg-type]
 
 
+class TestTouchStripBackgroundColor:
+    def test_default_is_black(self, touchscreen: TouchStrip):
+        assert touchscreen.background_color == "black"
+
+    def test_constructor_accepts_background_color(self):
+        ts = TouchStrip(background_color="#1a1a2e")
+        assert ts.background_color == "#1a1a2e"
+
+    def test_setter_updates_value(self, touchscreen: TouchStrip):
+        touchscreen.background_color = "#ff0000"
+        assert touchscreen.background_color == "#ff0000"
+
+    def test_setter_marks_all_cards_dirty(self, touchscreen: TouchStrip):
+        for card in touchscreen.cards:
+            card.mark_clean()
+        assert touchscreen.any_dirty is False
+        touchscreen.background_color = "#00ff00"
+        assert touchscreen.any_dirty is True
+        for card in touchscreen.cards:
+            assert card.is_dirty is True
+
+    def test_setter_same_value_does_not_mark_dirty(self, touchscreen: TouchStrip):
+        for card in touchscreen.cards:
+            card.mark_clean()
+        touchscreen.background_color = "black"  # same as default
+        assert touchscreen.any_dirty is False
+
+
 class TestTouchStripAnyDirty:
     def test_initially_dirty(self, touchscreen: TouchStrip):
         assert touchscreen.any_dirty is True


### PR DESCRIPTION
## Summary

- **TouchStrip** gains a `background_color` property (default `"black"`). Changing it marks all cards dirty so the strip re-renders on next refresh.
- **compose_touchstrip()** and **render_blank_touchscreen()** accept a `background` parameter instead of hardcoding black.
- **Deck._render_touchscreen()** passes the active screen`s `touch_strip.background_color` through to the compositor.
- **Screen** exposes a `touchstrip_background` convenience property that delegates to its TouchStrip.

## Usage

```python
main = deck.screen("main")
main.touch_strip.background_color = "#1a1a2e"

# Or via the Screen convenience property:
main.touchstrip_background = "#1a1a2e"
```

Each screen owns its own TouchStrip, so different screens automatically get independent background colours.

## Tests

662 tests pass, 99.18% coverage (threshold: 95%).