### PR TITLE
Make BlankCard transparent by returning None from render()

### DIFF
--- a/src/deckboard/ui/cards/base.py
+++ b/src/deckboard/ui/cards/base.py
@@ -206,7 +206,7 @@ class Card(ABC):
     def rendered(self) -> Image.Image | None:
         return self._rendered
 
-    def set_rendered(self, img: Image.Image) -> None:
+    def set_rendered(self, img: Image.Image | None) -> None:
         self._rendered = img
         self._dirty = False
 
@@ -247,11 +247,15 @@ class Card(ABC):
     # -- Rendering (abstract) ----------------------------------------------
 
     @abstractmethod
-    def render(self) -> Image.Image:
+    def render(self) -> Image.Image | None:
         """Render this card as a PANEL_WIDTH x PANEL_HEIGHT PIL Image.
 
+        Return ``None`` to let the touchstrip background colour show
+        through (used by :class:`~deckboard.ui.cards.blank.BlankCard`).
+
         Returns:
-            A PANEL_WIDTH x PANEL_HEIGHT RGB :class:`~PIL.Image.Image`.
+            A PANEL_WIDTH x PANEL_HEIGHT RGB :class:`~PIL.Image.Image`,
+            or ``None`` for a transparent/empty slot.
         """
 
     # -- Encoder interaction hooks (default no-ops) ------------------------

--- a/src/deckboard/ui/cards/blank.py
+++ b/src/deckboard/ui/cards/blank.py
@@ -1,19 +1,18 @@
-"""BlankCard: a minimal card that renders an empty black panel."""
+"""BlankCard: a transparent placeholder card for empty touch-strip slots."""
 
 from __future__ import annotations
 
-from PIL import Image
-
-from ...render.metrics import PANEL_HEIGHT, PANEL_WIDTH
 from .base import Card
 
 
 class BlankCard(Card):
-    """A card that renders a plain black rectangle.
+    """A card that renders nothing, letting the touchstrip background show through.
 
     Used as the default placeholder in :class:`~deckboard.ui.touch_strip.TouchStrip`
-    before the user assigns real cards.
+    before the user assigns real cards.  Returns ``None`` from :meth:`render`
+    so the compositor skips the slot and the
+    :attr:`~deckboard.ui.touch_strip.TouchStrip.background_color` is visible.
     """
 
-    def render(self) -> Image.Image:
-        return Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT), "black")
+    def render(self) -> None:
+        return None

--- a/tests/test_touch_strip.py
+++ b/tests/test_touch_strip.py
@@ -60,6 +60,12 @@ class TestWidgetAbstractBase:
         assert w.rendered is img
         assert w.is_dirty is False
 
+    def test_set_rendered_none(self):
+        w = _ConcreteWidget(0)
+        w.set_rendered(None)
+        assert w.rendered is None
+        assert w.is_dirty is False
+
     def test_on_tap(self):
         w = _ConcreteWidget(0)
 
@@ -363,11 +369,9 @@ class TestBlankCard:
         b = BlankCard(2)
         assert b.index == 2
 
-    def test_render_size(self):
+    def test_render_returns_none(self):
         b = BlankCard(0)
-        img = b.render()
-        assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
-        assert img.mode == "RGB"
+        assert b.render() is None
 
     def test_initially_dirty(self):
         b = BlankCard(0)


### PR DESCRIPTION
## Summary

- **BlankCard.render()** now returns `None` instead of a black rectangle, letting the touchstrip `background_color` show through in empty card slots.
- **Card.render()** return type widened to `Image.Image | None` — returning `None` means the compositor skips the slot and the background is visible.
- **Card.set_rendered()** accepts `None` to match.
- Removed unused `PIL` and `metrics` imports from `blank.py`.

## Why

The compositor (`compose_touchstrip`) already pre-fills the canvas with the background color and skips `None` entries. BlankCard was unnecessarily rendering a black rectangle that got pasted over the background, defeating the purpose of the background_color feature added in #47.

## Tests

663 tests pass, 99.18% coverage (threshold: 95%).