### PR TITLE
Fix preview tool rendering keys at 80x80 instead of 120x120

### DIFF
--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -31,8 +31,6 @@ from PIL import Image
 from deckboard.render.icons import IconError
 from deckboard.render.key_renderer import _encode_jpeg
 from deckboard.render.metrics import (
-    ICON_PADDING,
-    ICON_SIZE,
     KEY_SIZE,
     MARGIN_LEFT,
     MARGIN_TOP,
@@ -151,12 +149,12 @@ def load_svg(path: Path, max_width: int, max_height: int) -> Image.Image:
 def compose_key_image(svg_img: Image.Image) -> bytes:
     """Place *svg_img* centred on a 120x120 black key canvas.
 
-    The image is fitted inside the icon area (80x80 by default) using
-    ``ICON_PADDING`` as the margin on each side.
+    The SVG is rendered at the full key size and centred on the canvas
+    so the design fills the entire physical key area.
     """
     canvas = Image.new("RGB", KEY_SIZE, "black")
-    x = ICON_PADDING + (ICON_SIZE - svg_img.width) // 2
-    y = ICON_PADDING + (ICON_SIZE - svg_img.height) // 2
+    x = (KEY_SIZE[0] - svg_img.width) // 2
+    y = (KEY_SIZE[1] - svg_img.height) // 2
     if svg_img.mode == "RGBA":
         canvas.paste(svg_img, (x, y), svg_img)
     else:
@@ -361,7 +359,7 @@ def render_preview(
             if not svg_path.exists():
                 print(f"ERROR: Key SVG not found: {svg_path}", file=sys.stderr)  # noqa: T201
                 sys.exit(1)
-            img = load_svg(svg_path, ICON_SIZE, ICON_SIZE)
+            img = load_svg(svg_path, KEY_SIZE[0], KEY_SIZE[1])
             key_images[i] = compose_key_image(img)
             logger.info(
                 "Rendered key %d from %s (%dx%d)", i, svg_path, img.width, img.height

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -13,8 +13,6 @@ import pytest
 from PIL import Image
 
 from deckboard.render.metrics import (
-    ICON_PADDING,
-    ICON_SIZE,
     KEY_SIZE,
     MARGIN_LEFT,
     MARGIN_TOP,
@@ -184,9 +182,9 @@ class TestComposeKeyImage:
         decoded = Image.open(io.BytesIO(result))
         assert decoded.size == KEY_SIZE
 
-    def test_full_size_icon(self):
-        """An 80x80 icon should be placed at (ICON_PADDING, ICON_PADDING)."""
-        svg_img = Image.new("RGBA", (ICON_SIZE, ICON_SIZE), (255, 0, 0, 255))
+    def test_full_size_image(self):
+        """A 120x120 image should fill the entire key canvas."""
+        svg_img = Image.new("RGBA", KEY_SIZE, (255, 0, 0, 255))
         result = compose_key_image(svg_img)
         decoded = Image.open(io.BytesIO(result))
         assert decoded.size == KEY_SIZE


### PR DESCRIPTION
## Summary

- **Bug**: The preview tool loaded key SVGs constrained to `ICON_SIZE` (80x80) and composed them with `ICON_PADDING`, causing keys to render at 80x80 instead of the full 120x120 key area.
- **Fix**: Key SVGs are now loaded at `KEY_SIZE` (120x120) and centred directly on the key canvas without the icon-area inset, so designs fill the entire physical key.
- Updated tests to match the new full-size key rendering behaviour. All 663 tests pass at 99.18% coverage.