### PR TITLE
Fix preview tool to respect key margins

### DIFF
--- a/src/deckboard/tools/preview.py
+++ b/src/deckboard/tools/preview.py
@@ -31,7 +31,11 @@ from PIL import Image
 from deckboard.render.icons import IconError
 from deckboard.render.key_renderer import _encode_jpeg
 from deckboard.render.metrics import (
+    KEY_MARGIN_LEFT,
+    KEY_MARGIN_TOP,
     KEY_SIZE,
+    KEY_USABLE_HEIGHT,
+    KEY_USABLE_WIDTH,
     MARGIN_LEFT,
     MARGIN_TOP,
     PANEL_COUNT,
@@ -147,14 +151,15 @@ def load_svg(path: Path, max_width: int, max_height: int) -> Image.Image:
 
 
 def compose_key_image(svg_img: Image.Image) -> bytes:
-    """Place *svg_img* centred on a 120x120 black key canvas.
+    """Place *svg_img* centred within the usable area of a key canvas.
 
-    The SVG is rendered at the full key size and centred on the canvas
-    so the design fills the entire physical key area.
+    The SVG is centred within the margin-bounded usable area
+    (``KEY_USABLE_WIDTH`` x ``KEY_USABLE_HEIGHT``) so the design
+    respects the key margins defined in ``render.metrics``.
     """
     canvas = Image.new("RGB", KEY_SIZE, "black")
-    x = (KEY_SIZE[0] - svg_img.width) // 2
-    y = (KEY_SIZE[1] - svg_img.height) // 2
+    x = KEY_MARGIN_LEFT + (KEY_USABLE_WIDTH - svg_img.width) // 2
+    y = KEY_MARGIN_TOP + (KEY_USABLE_HEIGHT - svg_img.height) // 2
     if svg_img.mode == "RGBA":
         canvas.paste(svg_img, (x, y), svg_img)
     else:
@@ -359,7 +364,7 @@ def render_preview(
             if not svg_path.exists():
                 print(f"ERROR: Key SVG not found: {svg_path}", file=sys.stderr)  # noqa: T201
                 sys.exit(1)
-            img = load_svg(svg_path, KEY_SIZE[0], KEY_SIZE[1])
+            img = load_svg(svg_path, KEY_USABLE_WIDTH, KEY_USABLE_HEIGHT)
             key_images[i] = compose_key_image(img)
             logger.info(
                 "Rendered key %d from %s (%dx%d)", i, svg_path, img.width, img.height

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -13,7 +13,13 @@ import pytest
 from PIL import Image
 
 from deckboard.render.metrics import (
+    KEY_MARGIN_BOTTOM,
+    KEY_MARGIN_LEFT,
+    KEY_MARGIN_RIGHT,
+    KEY_MARGIN_TOP,
     KEY_SIZE,
+    KEY_USABLE_HEIGHT,
+    KEY_USABLE_WIDTH,
     MARGIN_LEFT,
     MARGIN_TOP,
     PANEL_COUNT,
@@ -168,12 +174,49 @@ class TestComposeKeyImage:
         assert decoded.format == "JPEG"
         assert decoded.size == KEY_SIZE
 
-    def test_centres_icon_in_key(self):
-        """A small image should be centred in the icon area."""
+    def test_centres_within_usable_area(self):
+        """A small image should be centred within the margin-bounded usable area."""
         svg_img = Image.new("RGBA", (40, 40), (255, 0, 0, 255))
         result = compose_key_image(svg_img)
-        decoded = Image.open(io.BytesIO(result))
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
         assert decoded.size == KEY_SIZE
+
+        # Expected centre of the usable area
+        cx = KEY_MARGIN_LEFT + KEY_USABLE_WIDTH // 2
+        cy = KEY_MARGIN_TOP + KEY_USABLE_HEIGHT // 2
+        r, g, b = decoded.getpixel((cx, cy))
+        assert r > 200, f"Centre of usable area should be red, got ({r}, {g}, {b})"
+
+    def test_left_margin_is_clear(self):
+        """Outer edge of left margin should remain black (no content)."""
+        svg_img = Image.new(
+            "RGBA",
+            (KEY_USABLE_WIDTH, KEY_USABLE_HEIGHT),
+            (255, 0, 0, 255),
+        )
+        result = compose_key_image(svg_img)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        mid_y = KEY_SIZE[1] // 2
+        # Check the outermost column — JPEG bleed doesn't reach x=0.
+        r, g, b = decoded.getpixel((0, mid_y))
+        assert r < 20, f"Left margin edge pixel (0, {mid_y}) not black: ({r},{g},{b})"
+
+    def test_right_margin_is_clear(self):
+        """Outer edge of right margin should remain black (no content)."""
+        svg_img = Image.new(
+            "RGBA",
+            (KEY_USABLE_WIDTH, KEY_USABLE_HEIGHT),
+            (255, 0, 0, 255),
+        )
+        result = compose_key_image(svg_img)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        mid_y = KEY_SIZE[1] // 2
+        # Check the outermost column — JPEG bleed doesn't reach the far edge.
+        last_x = KEY_SIZE[0] - 1
+        r, g, b = decoded.getpixel((last_x, mid_y))
+        assert r < 20, (
+            f"Right margin edge pixel ({last_x}, {mid_y}) not black: ({r},{g},{b})"
+        )
 
     def test_rgb_image_no_alpha(self):
         """An RGB image (no alpha) should compose without error."""
@@ -182,12 +225,21 @@ class TestComposeKeyImage:
         decoded = Image.open(io.BytesIO(result))
         assert decoded.size == KEY_SIZE
 
-    def test_full_size_image(self):
-        """A 120x120 image should fill the entire key canvas."""
-        svg_img = Image.new("RGBA", KEY_SIZE, (255, 0, 0, 255))
+    def test_usable_size_image_fills_usable_area(self):
+        """A 106x106 image should fill exactly the usable area."""
+        svg_img = Image.new(
+            "RGBA",
+            (KEY_USABLE_WIDTH, KEY_USABLE_HEIGHT),
+            (255, 0, 0, 255),
+        )
         result = compose_key_image(svg_img)
-        decoded = Image.open(io.BytesIO(result))
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
         assert decoded.size == KEY_SIZE
+        # Centre of usable area should be red
+        cx = KEY_MARGIN_LEFT + KEY_USABLE_WIDTH // 2
+        cy = KEY_MARGIN_TOP + KEY_USABLE_HEIGHT // 2
+        r, _, _ = decoded.getpixel((cx, cy))
+        assert r > 200
 
 
 # -- compose_card_image ------------------------------------------------------


### PR DESCRIPTION
## Summary

- `compose_key_image()` now centres SVG content within the margin-bounded usable area (`KEY_MARGIN_LEFT + ...`) instead of the full 120x120 canvas
- `render_preview()` loads key SVGs at `KEY_USABLE_WIDTH` x `KEY_USABLE_HEIGHT` (106x106) instead of `KEY_SIZE` (120x120)
- Updated tests verify content is centred within the usable area and margins remain clear

## What was wrong

The preview tool was not updated when key margins were introduced in #50. SVGs were loaded at full key size (120x120) and centred on the entire canvas, ignoring the 7px margins on each side.