### PR TITLE
Add key_hold/encoder_hold sources with async hold timer

### DIFF
--- a/examples/PowerKey.dsui/manifest.yaml
+++ b/examples/PowerKey.dsui/manifest.yaml
@@ -33,4 +33,5 @@ events:
     max_duration_ms: 300
 
   - name: long_hold
-    source: key_press
+    source: key_hold
+    hold_ms: 500

--- a/examples/dsui_packages.py
+++ b/examples/dsui_packages.py
@@ -103,19 +103,28 @@ async def main():
 
         @power.on_event("activate")
         async def on_power():
-            print("Power activated — stopping deck")
+            print("Power SHORT press — shutting down")
+            power.set("indicator_color", "#44ff44")  # flash green
+            await deck.refresh()
+            await asyncio.sleep(0.5)
             await deck.stop()
 
         @power.on_event("long_hold")
         async def on_power_hold():
-            print("Power long-hold detected")
+            print("Power LONG HOLD — force restart")
+            power.set("ring_color", "#ff8800")
+            power.set("line_color", "#ff8800")
+            power.set("indicator_color", "#ff8800")  # orange = held
+            await deck.refresh()
 
         # -- Activate and run ----------------------------------------------
 
         await deck.set_screen("main")
         print("\nDeck ready!")
         print("  Encoder 0: turn for next/prev track, press for play/pause")
-        print("  Key 7 (Shutdown): press to exit")
+        print("  Key 7 (Shutdown):")
+        print("    Short press (<300ms): clean shutdown (green flash)")
+        print("    Long hold  (>500ms):  force restart  (turns orange)")
         await deck.wait_closed()
 
 

--- a/src/deckboard/dsui/event_map.py
+++ b/src/deckboard/dsui/event_map.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -22,6 +23,10 @@ class EventMap:
 
     - ``encoder_press_release``: fires only if the press duration is
       within ``max_duration_ms``.
+    - ``encoder_hold`` / ``key_hold``: starts a timer on press and fires
+      the handler after ``hold_ms`` while the key/encoder is still held.
+      Suppresses any ``press_release`` or ``release`` event for that
+      press–release cycle.
     - ``encoder_press_turn``: fires turn events only while the encoder
       is held down.
     - Direction filtering: ``encoder_turn`` with ``direction: left``
@@ -44,6 +49,10 @@ class EventMap:
         # Gesture state
         self._press_time: float | None = None
         self._pressed = False
+
+        # Hold timer state
+        self._hold_task: asyncio.Task[None] | None = None
+        self._hold_fired = False
 
         # Pre-index mappings by source for fast lookup
         self._by_source: dict[str, list[EventMapping]] = {}
@@ -72,6 +81,39 @@ class EventMap:
         """All semantic event names defined in this map."""
         return [m.name for m in self._mappings]
 
+    # -- Hold timer --------------------------------------------------------
+
+    def _start_hold_timer(self, source: str) -> None:
+        """Start a hold timer for the first matching hold mapping.
+
+        Args:
+            source: ``"key_hold"`` or ``"encoder_hold"``.
+        """
+        for mapping in self._by_source.get(source, []):
+            handler = self._handlers.get(mapping.name)
+            if handler is None:
+                continue
+            hold_ms = mapping.hold_ms
+            if hold_ms is None:
+                continue  # pragma: no cover — validated by loader
+            self._hold_task = asyncio.ensure_future(
+                self._hold_delay(hold_ms / 1000.0, handler)
+            )
+            return
+
+    async def _hold_delay(self, seconds: float, handler: AsyncHandler) -> None:
+        """Sleep then fire the hold handler if still pressed."""
+        await asyncio.sleep(seconds)
+        if self._pressed:
+            self._hold_fired = True
+            await handler()
+
+    def _cancel_hold_timer(self) -> None:
+        """Cancel an in-progress hold timer if one is running."""
+        if self._hold_task is not None:
+            self._hold_task.cancel()
+            self._hold_task = None
+
     # -- Encoder events ----------------------------------------------------
 
     def handle_encoder_turn(self, direction: int) -> AsyncHandler | None:
@@ -99,13 +141,17 @@ class EventMap:
     def handle_encoder_press(self) -> AsyncHandler | None:
         """Match an encoder press to a semantic event.
 
-        Records the press timestamp for gesture detection.
+        Records the press timestamp for gesture detection and starts
+        a hold timer if an ``encoder_hold`` mapping exists.
 
         Returns:
             The handler to call, or ``None`` if no mapping matched.
         """
         self._press_time = time.monotonic()
         self._pressed = True
+        self._hold_fired = False
+
+        self._start_hold_timer("encoder_hold")
 
         for mapping in self._by_source.get("encoder_press", []):
             return self._handlers.get(mapping.name)
@@ -115,12 +161,20 @@ class EventMap:
     def handle_encoder_release(self) -> AsyncHandler | None:
         """Match an encoder release to a semantic event.
 
-        Checks ``encoder_press_release`` gesture timing.
+        Cancels any running hold timer.  If the hold already fired,
+        suppresses ``encoder_press_release`` and ``encoder_release``
+        events for this press–release cycle.
 
         Returns:
             The handler to call, or ``None`` if no mapping matched.
         """
         self._pressed = False
+        self._cancel_hold_timer()
+
+        if self._hold_fired:
+            self._hold_fired = False
+            self._press_time = None
+            return None
 
         # Check press_release gesture first
         if self._press_time is not None:
@@ -141,9 +195,16 @@ class EventMap:
     # -- Key events --------------------------------------------------------
 
     def handle_key_press(self) -> AsyncHandler | None:
-        """Match a key press to a semantic event."""
+        """Match a key press to a semantic event.
+
+        Records the press timestamp and starts a hold timer if a
+        ``key_hold`` mapping exists.
+        """
         self._press_time = time.monotonic()
         self._pressed = True
+        self._hold_fired = False
+
+        self._start_hold_timer("key_hold")
 
         for mapping in self._by_source.get("key_press", []):
             return self._handlers.get(mapping.name)
@@ -151,8 +212,19 @@ class EventMap:
         return None
 
     def handle_key_release(self) -> AsyncHandler | None:
-        """Match a key release to a semantic event."""
+        """Match a key release to a semantic event.
+
+        Cancels any running hold timer.  If the hold already fired,
+        suppresses ``key_press_release`` and ``key_release`` events
+        for this press–release cycle.
+        """
         self._pressed = False
+        self._cancel_hold_timer()
+
+        if self._hold_fired:
+            self._hold_fired = False
+            self._press_time = None
+            return None
 
         # Check press_release gesture first
         if self._press_time is not None:

--- a/src/deckboard/dsui/loader.py
+++ b/src/deckboard/dsui/loader.py
@@ -14,6 +14,7 @@ from .schema import (
     BindingType,
     ColorBinding,
     EventMapping,
+    HOLD_SOURCES,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -146,11 +147,25 @@ def _parse_event(raw: dict[str, Any], index: int) -> EventMapping:
                 f"Event '{name}': max_duration_ms must be a positive integer"
             )
 
+    hold_ms = raw.get("hold_ms")
+    if source in HOLD_SOURCES:
+        if hold_ms is None:
+            raise PackageError(
+                f"Event '{name}': hold_ms is required for source '{source}'"
+            )
+        if not isinstance(hold_ms, int) or hold_ms <= 0:
+            raise PackageError(f"Event '{name}': hold_ms must be a positive integer")
+    elif hold_ms is not None:
+        raise PackageError(
+            f"Event '{name}': hold_ms is only valid for key_hold/encoder_hold sources"
+        )
+
     return EventMapping(
         name=name,
         source=source,
         direction=direction,
         max_duration_ms=max_duration_ms,
+        hold_ms=hold_ms,
     )
 
 

--- a/src/deckboard/dsui/schema.py
+++ b/src/deckboard/dsui/schema.py
@@ -83,9 +83,11 @@ VALID_SOURCES = frozenset(
         "encoder_press_release",
         "encoder_turn",
         "encoder_press_turn",
+        "encoder_hold",
         "key_press",
         "key_release",
         "key_press_release",
+        "key_hold",
         "tap",
         "long_press",
     }
@@ -104,6 +106,11 @@ class EventMapping:
     source: str
     direction: str | None = None
     max_duration_ms: int | None = None
+    hold_ms: int | None = None
+
+
+# Sources that require the hold_ms field.
+HOLD_SOURCES = frozenset({"key_hold", "encoder_hold"})
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,8 @@ events:
     source: key_press_release
     max_duration_ms: 300
   - name: hold
-    source: key_press
+    source: key_hold
+    hold_ms: 500
 """
     (pkg_dir / "manifest.yaml").write_text(manifest, encoding="utf-8")
     return pkg_dir

--- a/tests/test_dsui_event_map.py
+++ b/tests/test_dsui_event_map.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock
 
@@ -229,6 +230,191 @@ class TestKeyEvents:
         em.handle_key_press()
         time.sleep(0.01)
         assert em.handle_key_release() is handler
+
+
+class TestKeyHold:
+    async def test_hold_fires_after_delay(self):
+        """key_hold handler fires after hold_ms while key is still held."""
+        events = _make_events(
+            ("long_hold", "key_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("long_hold", handler)
+
+        em.handle_key_press()
+        await asyncio.sleep(0.05)  # wait well past 10ms
+        handler.assert_awaited_once()
+
+    async def test_hold_cancelled_on_early_release(self):
+        """key_hold does NOT fire if released before hold_ms."""
+        events = _make_events(
+            ("long_hold", "key_hold", {"hold_ms": 5000}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("long_hold", handler)
+
+        em.handle_key_press()
+        em.handle_key_release()  # immediate release
+        await asyncio.sleep(0.01)
+        handler.assert_not_awaited()
+
+    async def test_hold_suppresses_press_release(self):
+        """After key_hold fires, key_press_release is suppressed on release."""
+        events = _make_events(
+            ("activate", "key_press_release", {"max_duration_ms": 5000}),
+            ("long_hold", "key_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        tap_handler = AsyncMock()
+        hold_handler = AsyncMock()
+        em.on("activate", tap_handler)
+        em.on("long_hold", hold_handler)
+
+        em.handle_key_press()
+        await asyncio.sleep(0.05)  # hold fires
+        hold_handler.assert_awaited_once()
+
+        result = em.handle_key_release()
+        assert result is None  # press_release suppressed
+        tap_handler.assert_not_awaited()
+
+    async def test_hold_suppresses_key_release(self):
+        """After key_hold fires, key_release is also suppressed."""
+        events = _make_events(
+            ("up", "key_release"),
+            ("long_hold", "key_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        release_handler = AsyncMock()
+        hold_handler = AsyncMock()
+        em.on("up", release_handler)
+        em.on("long_hold", hold_handler)
+
+        em.handle_key_press()
+        await asyncio.sleep(0.05)
+        hold_handler.assert_awaited_once()
+
+        result = em.handle_key_release()
+        assert result is None
+        release_handler.assert_not_awaited()
+
+    async def test_short_tap_still_works_with_hold(self):
+        """Quick release fires press_release, not the hold."""
+        events = _make_events(
+            ("activate", "key_press_release", {"max_duration_ms": 300}),
+            ("long_hold", "key_hold", {"hold_ms": 500}),
+        )
+        em = EventMap(events)
+        tap_handler = AsyncMock()
+        hold_handler = AsyncMock()
+        em.on("activate", tap_handler)
+        em.on("long_hold", hold_handler)
+
+        em.handle_key_press()
+        # Release immediately — well before 500ms hold
+        result = em.handle_key_release()
+        assert result is tap_handler
+        hold_handler.assert_not_awaited()
+
+    async def test_hold_no_handler_registered(self):
+        """If no handler is registered, no timer starts."""
+        events = _make_events(
+            ("long_hold", "key_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        # Don't register any handler
+
+        em.handle_key_press()
+        await asyncio.sleep(0.05)
+        # Should not crash — task was never created
+        assert em._hold_task is None
+
+    async def test_hold_reset_between_presses(self):
+        """hold_fired is reset on each new press."""
+        events = _make_events(
+            ("activate", "key_press_release"),
+            ("long_hold", "key_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        tap_handler = AsyncMock()
+        hold_handler = AsyncMock()
+        em.on("activate", tap_handler)
+        em.on("long_hold", hold_handler)
+
+        # First: long hold
+        em.handle_key_press()
+        await asyncio.sleep(0.05)
+        hold_handler.assert_awaited_once()
+        em.handle_key_release()  # suppressed
+
+        # Second: quick tap
+        em.handle_key_press()
+        result = em.handle_key_release()
+        assert result is tap_handler
+
+
+class TestEncoderHold:
+    async def test_encoder_hold_fires_after_delay(self):
+        events = _make_events(
+            ("enc_hold", "encoder_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("enc_hold", handler)
+
+        em.handle_encoder_press()
+        await asyncio.sleep(0.05)
+        handler.assert_awaited_once()
+
+    async def test_encoder_hold_cancelled_on_early_release(self):
+        events = _make_events(
+            ("enc_hold", "encoder_hold", {"hold_ms": 5000}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("enc_hold", handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_release()
+        await asyncio.sleep(0.01)
+        handler.assert_not_awaited()
+
+    async def test_encoder_hold_suppresses_press_release(self):
+        events = _make_events(
+            ("toggle", "encoder_press_release", {"max_duration_ms": 5000}),
+            ("enc_hold", "encoder_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        toggle_handler = AsyncMock()
+        hold_handler = AsyncMock()
+        em.on("toggle", toggle_handler)
+        em.on("enc_hold", hold_handler)
+
+        em.handle_encoder_press()
+        await asyncio.sleep(0.05)
+        hold_handler.assert_awaited_once()
+
+        result = em.handle_encoder_release()
+        assert result is None
+        toggle_handler.assert_not_awaited()
+
+    async def test_encoder_short_tap_still_works_with_hold(self):
+        events = _make_events(
+            ("toggle", "encoder_press_release", {"max_duration_ms": 300}),
+            ("enc_hold", "encoder_hold", {"hold_ms": 500}),
+        )
+        em = EventMap(events)
+        toggle_handler = AsyncMock()
+        hold_handler = AsyncMock()
+        em.on("toggle", toggle_handler)
+        em.on("enc_hold", hold_handler)
+
+        em.handle_encoder_press()
+        result = em.handle_encoder_release()
+        assert result is toggle_handler
+        hold_handler.assert_not_awaited()
 
 
 class TestTouchEvents:

--- a/tests/test_dsui_loader.py
+++ b/tests/test_dsui_loader.py
@@ -373,6 +373,71 @@ class TestLoadPackageInvalid:
         with pytest.raises(PackageError, match="positive integer"):
             load_package(pkg)
 
+    def test_event_hold_ms_required_for_key_hold(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: key_hold",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="hold_ms is required"):
+            load_package(pkg)
+
+    def test_event_hold_ms_required_for_encoder_hold(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: encoder_hold",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="hold_ms is required"):
+            load_package(pkg)
+
+    def test_event_hold_ms_invalid(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: key_hold\n    hold_ms: -1",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="hold_ms must be a positive integer"):
+            load_package(pkg)
+
+    def test_event_hold_ms_zero(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: key_hold\n    hold_ms: 0",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="hold_ms must be a positive integer"):
+            load_package(pkg)
+
+    def test_event_hold_ms_not_allowed_on_other_sources(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: key_press\n    hold_ms: 500",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="hold_ms is only valid for"):
+            load_package(pkg)
+
     def test_duplicate_event_name(self, tmp_path):
         pkg = tmp_path / "Bad.dsui"
         pkg.mkdir()

--- a/tests/test_dsui_schema.py
+++ b/tests/test_dsui_schema.py
@@ -8,6 +8,7 @@ from deckboard.dsui.schema import (
     BindingType,
     ColorBinding,
     EventMapping,
+    HOLD_SOURCES,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -125,6 +126,14 @@ class TestEventMapping:
         )
         assert e.max_duration_ms == 250
 
+    def test_with_hold_ms(self):
+        e = EventMapping(name="hold", source="key_hold", hold_ms=500)
+        assert e.hold_ms == 500
+
+    def test_hold_ms_default_none(self):
+        e = EventMapping(name="play", source="encoder_press")
+        assert e.hold_ms is None
+
     def test_frozen(self):
         e = EventMapping(name="play", source="encoder_press")
         with pytest.raises(AttributeError):
@@ -176,11 +185,16 @@ class TestValidSets:
         assert "encoder_press_release" in VALID_SOURCES
         assert "encoder_turn" in VALID_SOURCES
         assert "encoder_press_turn" in VALID_SOURCES
+        assert "encoder_hold" in VALID_SOURCES
         assert "key_press" in VALID_SOURCES
         assert "key_release" in VALID_SOURCES
         assert "key_press_release" in VALID_SOURCES
+        assert "key_hold" in VALID_SOURCES
         assert "tap" in VALID_SOURCES
         assert "long_press" in VALID_SOURCES
+
+    def test_hold_sources(self):
+        assert HOLD_SOURCES == frozenset({"key_hold", "encoder_hold"})
 
     def test_valid_directions(self):
         assert VALID_DIRECTIONS == frozenset({"left", "right"})


### PR DESCRIPTION
## Summary

- Adds new `key_hold` and `encoder_hold` event sources with a required `hold_ms` field
- Starts an async timer on press that fires the handler after `hold_ms` while the key/encoder is still held down
- On release: cancels any pending hold timer, and if the hold already fired, suppresses `press_release` and `release` events for that cycle
- Includes loader validation: `hold_ms` is required for hold sources, must be a positive integer, and is rejected on non-hold sources

## Usage

```yaml
events:
  - name: activate
    source: key_press_release
    max_duration_ms: 300      # fires on quick tap (<=300ms)

  - name: long_hold
    source: key_hold
    hold_ms: 500              # fires after 500ms while still held
```

Short tap: `activate` fires on release. Long hold: `long_hold` fires after 500ms while the key is still pressed, and the subsequent release is ignored.

## Tests

All 696 tests pass, 99.21% coverage.