### PR TITLE
Remove set_icon, set_label, and icon/label properties from KeySlot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ if TYPE_CHECKING:
 
 - **Async context manager** for resource lifecycle (`Deck.__aenter__`/`__aexit__`).
 - **Decorator-based event registration** — `@key.on_press`, `@encoder.on_turn`.
-- **Method chaining** — mutators return `self` (e.g., `key.set_icon(...).set_label(...)`).
+- **Method chaining** — mutators return `self` (e.g., `card.set("title", "...").set("artist", "...")`).
 - **Dirty tracking** — `is_dirty` / `mark_clean()` / `mark_dirty()` on cards and key slots.
 - **Abstract base classes** — `Card(ABC)` with `@abstractmethod render()`.
 - **Thread-safe bridge** — `runtime/transport.py` uses `loop.call_soon_threadsafe()` to enqueue events from the HID reader thread.
@@ -209,12 +209,12 @@ target-version = "py311"
 - **All hardware is mocked** — tests run without a physical Stream Deck.
 - `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` decorator needed.
 - Use `unittest.mock.MagicMock` / `AsyncMock` for device mocking.
-- Use `respx` for mocking HTTP requests (icon fetching).
+
 
 ### Test file conventions
 
 - One file per source module: `test_key_slot.py`, `test_deck.py`, `test_widgets_volume.py`.
-- Group related tests in classes: `class TestKeySlotSetIcon:`, `class TestDeckDispatch:`.
+- Group related tests in classes: `class TestKeySlotRendering:`, `class TestDeckDispatch:`.
 - Shared fixtures in `conftest.py` (key slots, encoder slots, cards, mock device, sample images).
 - Test edge cases and error paths, not just the happy path.
 
@@ -227,15 +227,16 @@ from __future__ import annotations
 import pytest
 from deckboard.ui.controls.key_slot import KeySlot
 
-class TestKeySlotSetIcon:
-    def test_sets_icon_name(self, key_slot: KeySlot):
-        key_slot.set_icon("mdi:home")
-        assert key_slot.icon_name == "mdi:home"
+class TestKeySlotRendering:
+    def test_set_rendered_image(self, key_slot: KeySlot):
+        key_slot.set_rendered_image(b"jpeg-data")
+        assert key_slot.image_bytes == b"jpeg-data"
+        assert key_slot.is_dirty is False
 
-    def test_marks_dirty(self, key_slot: KeySlot):
-        key_slot.mark_clean()
-        key_slot.set_icon("mdi:home")
+    def test_mark_clean(self, key_slot: KeySlot):
         assert key_slot.is_dirty is True
+        key_slot.mark_clean()
+        assert key_slot.is_dirty is False
 ```
 
 ## Branch naming

--- a/README.md
+++ b/README.md
@@ -4,21 +4,19 @@ An asyncio-native Python 3.11+ library for building rich interfaces on the
 Elgato Stream Deck+.
 
 Deckboard wraps the low-level HID layer and gives you a high-level API for
-keys, rotary encoders, and the touchscreen strip. Define multi-page layouts,
-bind Iconify icons by name, register event handlers with decorators, and let
-the library handle rendering and device I/O.
+keys, rotary encoders, and the touchscreen strip. Define multi-screen layouts,
+register event handlers with decorators, and use declarative `.dsui` packages
+for SVG-based UI — the library handles rendering and device I/O.
 
 ## Quick start
 
 ```python
 import asyncio
-from deckboard import Deck
+from deckboard import Deck, DsuiKey, load_package
 
 async def main():
     async with Deck() as deck:
         screen = deck.screen("main")
-        screen.key(0).set_icon("mdi:home").set_label("Home")
-        screen.key(1).set_icon("mdi:cog").set_label("Settings")
 
         @screen.key(0).on_press
         async def on_home():
@@ -76,7 +74,6 @@ The constructor accepts optional parameters:
 | `device_type`    | `"Stream Deck +"`  | Stream Deck model to search for    |
 | `device_index`   | `0`                | Which device if multiple are found |
 | `brightness`     | `80`               | Initial brightness (0-100)         |
-| `icon_cache_dir` | `None`             | Override default icon cache path   |
 
 ### Screens
 
@@ -87,25 +84,14 @@ slots, and 4 touchscreen card zones. Switch between screens atomically:
 main = deck.screen("main")
 settings = deck.screen("settings")
 
-# configure each screen independently
-main.key(0).set_icon("mdi:home").set_label("Home")
-settings.key(0).set_icon("mdi:arrow-left").set_label("Back")
-
 await deck.set_screen("main")       # render and activate
 await deck.set_screen("settings")   # swap instantly
 ```
 
 ### Keys
 
-`KeySlot` wraps a single physical key (indices 0-7). Configuration methods
-return `self` for chaining:
-
-```python
-key = screen.key(0)
-key.set_icon("mdi:play", color="#00ff00").set_label("Play")
-```
-
-Register press and release handlers with decorators:
+`KeySlot` wraps a single physical key (indices 0-7). Register press and
+release handlers with decorators:
 
 ```python
 @screen.key(0).on_press
@@ -116,6 +102,8 @@ async def handle_press():
 async def handle_release():
     print("released")
 ```
+
+For keys with custom visual content, use `.dsui` key packages (see below).
 
 ### Encoders
 
@@ -183,11 +171,11 @@ async def on_enc_turn(direction: int):
 
 ### Dirty tracking and rendering
 
-Key slots and cards track whether they need re-rendering. After updating
-values programmatically, call `refresh()` to push changes to the device:
+Cards track whether they need re-rendering. After updating values
+programmatically, call `refresh()` to push changes to the device:
 
 ```python
-screen.key(0).set_label("Updated")
+card.set("title", "Updated")
 await deck.refresh()
 ```
 
@@ -318,7 +306,7 @@ Arguments: `--key0` through `--key7`, `--card0` through `--card3`,
 ```
 src/deckboard/
   runtime/          # Device lifecycle, events, async transport
-  render/           # Image rendering, fonts, icon fetching
+  render/           # Image rendering, SVG rasterisation
   ui/               # Screens, key slots, encoder slots, cards
   dsui/             # Declarative .dsui package system
   tools/            # CLI utilities (preview)

--- a/examples/dsui_packages.py
+++ b/examples/dsui_packages.py
@@ -62,10 +62,6 @@ async def main():
         power.set("indicator_color", "#ff4444")
         screen.set_key(7, power)
 
-        # Regular keys alongside .dsui keys
-        screen.key(0).set_icon("mdi:home").set_label("Home")
-        screen.key(1).set_icon("mdi:music").set_label("Music")
-
         # -- Register event handlers ---------------------------------------
 
         playing = True

--- a/src/deckboard/ui/controls/key_slot.py
+++ b/src/deckboard/ui/controls/key_slot.py
@@ -21,9 +21,6 @@ class KeySlot:
 
     def __init__(self, index: int) -> None:
         self._index = index
-        self._icon_name: str | None = None
-        self._icon_color: str = "white"
-        self._label: str | None = None
         self._press_handler: AsyncHandler | None = None
         self._release_handler: AsyncHandler | None = None
         self._image_bytes: bytes | None = None
@@ -32,56 +29,6 @@ class KeySlot:
     @property
     def index(self) -> int:
         return self._index
-
-    @property
-    def icon_name(self) -> str | None:
-        return self._icon_name
-
-    @property
-    def label(self) -> str | None:
-        return self._label
-
-    @property
-    def icon_color(self) -> str:
-        return self._icon_color
-
-    # -- Configuration methods (return self for chaining) ------------------
-
-    def set_icon(self, name: str, color: str = "white") -> KeySlot:
-        """Set the icon by Iconify name (e.g. ``mdi:home``).
-
-        Args:
-            name: Icon name in ``prefix:name`` format.
-            color: Icon color (CSS color string). Defaults to white.
-
-        Returns:
-            self, for method chaining.
-        """
-        self._icon_name = name
-        self._icon_color = color
-        self._dirty = True
-        return self
-
-    def set_label(self, label: str | None) -> KeySlot:
-        """Set a text label displayed below the icon.
-
-        Args:
-            label: Text label, or None to remove.
-
-        Returns:
-            self, for method chaining.
-        """
-        self._label = label
-        self._dirty = True
-        return self
-
-    def clear(self) -> KeySlot:
-        """Clear the icon and label, resetting to a blank key."""
-        self._icon_name = None
-        self._label = None
-        self._image_bytes = None
-        self._dirty = True
-        return self
 
     # -- Decorator-based event registration --------------------------------
 

--- a/src/deckboard/ui/screen.py
+++ b/src/deckboard/ui/screen.py
@@ -26,7 +26,6 @@ class Screen:
     Usage::
 
         main = deck.screen("main")
-        main.key(0).set_icon("mdi:home")
 
         @main.key(0).on_press
         async def handle():

--- a/tests/test_key_slot.py
+++ b/tests/test_key_slot.py
@@ -12,92 +12,12 @@ class TestKeySlotInit:
         assert key_slot.index == 0
 
     def test_defaults(self, key_slot: KeySlot):
-        assert key_slot.icon_name is None
-        assert key_slot.label is None
         assert key_slot.image_bytes is None
         assert key_slot.is_dirty is True
 
     def test_custom_index(self):
         k = KeySlot(7)
         assert k.index == 7
-
-
-class TestKeySlotSetIcon:
-    def test_sets_icon_name(self, key_slot: KeySlot):
-        key_slot.set_icon("mdi:home")
-        assert key_slot.icon_name == "mdi:home"
-
-    def test_sets_icon_color(self, key_slot: KeySlot):
-        key_slot.set_icon("mdi:home", color="red")
-        assert key_slot._icon_color == "red"
-
-    def test_default_color_is_white(self, key_slot: KeySlot):
-        key_slot.set_icon("mdi:home")
-        assert key_slot._icon_color == "white"
-
-    def test_marks_dirty(self, key_slot: KeySlot):
-        key_slot.mark_clean()
-        assert key_slot.is_dirty is False
-        key_slot.set_icon("mdi:home")
-        assert key_slot.is_dirty is True
-
-    def test_returns_self(self, key_slot: KeySlot):
-        result = key_slot.set_icon("mdi:home")
-        assert result is key_slot
-
-
-class TestKeySlotSetLabel:
-    def test_sets_label(self, key_slot: KeySlot):
-        key_slot.set_label("Home")
-        assert key_slot.label == "Home"
-
-    def test_set_none_removes_label(self, key_slot: KeySlot):
-        key_slot.set_label("Home")
-        key_slot.set_label(None)
-        assert key_slot.label is None
-
-    def test_marks_dirty(self, key_slot: KeySlot):
-        key_slot.mark_clean()
-        key_slot.set_label("test")
-        assert key_slot.is_dirty is True
-
-    def test_returns_self(self, key_slot: KeySlot):
-        result = key_slot.set_label("x")
-        assert result is key_slot
-
-
-class TestKeySlotClear:
-    def test_clears_icon(self, key_slot: KeySlot):
-        key_slot.set_icon("mdi:home")
-        key_slot.clear()
-        assert key_slot.icon_name is None
-
-    def test_clears_label(self, key_slot: KeySlot):
-        key_slot.set_label("test")
-        key_slot.clear()
-        assert key_slot.label is None
-
-    def test_clears_image_bytes(self, key_slot: KeySlot):
-        key_slot.set_rendered_image(b"jpeg")
-        key_slot.clear()
-        assert key_slot.image_bytes is None
-
-    def test_marks_dirty(self, key_slot: KeySlot):
-        key_slot.mark_clean()
-        key_slot.clear()
-        assert key_slot.is_dirty is True
-
-    def test_returns_self(self, key_slot: KeySlot):
-        assert key_slot.clear() is key_slot
-
-
-class TestKeySlotChaining:
-    def test_chained_calls(self):
-        k = KeySlot(0)
-        result = k.set_icon("mdi:home", color="red").set_label("Home")
-        assert result is k
-        assert k.icon_name == "mdi:home"
-        assert k.label == "Home"
 
 
 class TestKeySlotEventHandlers:


### PR DESCRIPTION
## Summary

- **Remove** `set_icon()`, `set_label()`, `icon_name`, `icon_color`, `label`, and `clear()` from `KeySlot` — dead code after the icon/font rendering pipeline was removed in #59
- **Update** `README.md` — rewrite Quick start, Screens, and Keys sections to remove all `set_icon`/`set_label` examples; update dirty tracking example to use dsui card bindings; fix project structure description
- **Update** `AGENTS.md` — update method chaining example, test example, remove `respx` reference
- **Update** `examples/dsui_packages.py` — remove `set_icon`/`set_label` calls on regular keys
- **Update** `screen.py` docstring — remove `set_icon` usage example
- **Simplify** `test_key_slot.py` — remove icon/label/clear/chaining test classes (15 tests removed)

All 683 tests pass with 98.74% coverage (threshold: 95%).