### PR TITLE
Add text wrapping support for .dsui text bindings

### DIFF
--- a/examples/LabelKey.dsui/layout.svg
+++ b/examples/LabelKey.dsui/layout.svg
@@ -1,0 +1,7 @@
+<svg id="LabelKey" width="106" height="106" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
+    <rect id="background" x="0" y="0" width="106" height="106" rx="10" ry="10" fill="#1A1A1A" stroke="none"/>
+    <text id="text" x="53" y="35" font-size="15" text-anchor="middle" fill="#D9D9D9">
+        Label
+    </text>
+    <rect id="indicator" x="33" y="92" width="40" height="4" rx="2" ry="2" fill="#333333"/>
+</svg>

--- a/examples/LabelKey.dsui/manifest.yaml
+++ b/examples/LabelKey.dsui/manifest.yaml
@@ -1,0 +1,29 @@
+name: LabelKey
+type: Key
+version: 1
+layout: layout.svg
+
+bindings:
+  label:
+    type: text
+    node: text
+    default: "Label"
+    max_width: 90
+    wrap: true
+    max_height: 54
+    overflow: ellipsis
+
+  indicator_color:
+    type: color
+    node: indicator
+    attribute: fill
+    default: "#333333"
+
+events:
+  - name: activate
+    source: key_press_release
+    max_duration_ms: 300
+
+  - name: long_hold
+    source: key_hold
+    hold_ms: 500

--- a/examples/label_key.py
+++ b/examples/label_key.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Example: word-wrapped text label on a physical key.
+
+Demonstrates the ``wrap`` text binding feature which automatically breaks
+long text into multiple lines using ``<tspan>`` elements.  Font metrics
+are auto-detected from the SVG ``<text>`` element and Pillow is used for
+pixel-accurate text measurement.
+
+The LabelKey.dsui package defines:
+- A ``text`` binding named ``label`` with ``wrap: true``, ``max_width: 90``,
+  and ``max_height: 54``.  Long labels word-wrap across multiple lines and
+  overflow is truncated with an ellipsis.
+- A ``color`` binding for an indicator strip below the label.
+- ``key_press_release`` and ``key_hold`` events.
+
+Run with::
+
+    python examples/label_key.py
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+from deckboard import Deck, DsuiKey, load_package
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+EXAMPLES_DIR = Path(__file__).parent
+
+# Sample labels — some short, some long enough to wrap
+LABELS = [
+    "Play",
+    "Arthur Olsen's Favorites",
+    "Morning Commute Playlist",
+    "Lo-Fi Beats",
+    "Saturday Night Dance Party Mix Vol. 2",
+]
+
+
+async def main():
+    spec = load_package(EXAMPLES_DIR / "LabelKey.dsui")
+
+    print(f"Loaded: {spec.name} (v{spec.version})")
+    print(f"  Bindings: {sorted(spec.bindings)}")
+    print(f"  Events:   {[e.name for e in spec.events]}")
+
+    async with Deck(brightness=80) as deck:
+        screen = deck.screen("main")
+
+        key = DsuiKey(0, spec)
+        screen.set_key(0, key)
+
+        label_index = 0
+        key.set("label", LABELS[label_index])
+
+        @key.on_event("activate")
+        async def on_activate():
+            nonlocal label_index
+            label_index = (label_index + 1) % len(LABELS)
+            label = LABELS[label_index]
+            key.set("label", label)
+            key.set("indicator_color", "#4CAF50")
+            print(f"Label: {label!r}")
+            await deck.refresh()
+
+        @key.on_event("long_hold")
+        async def on_hold():
+            key.set("label", "Reset")
+            key.set("indicator_color", "#333333")
+            print("Reset to default")
+            await deck.refresh()
+
+        await deck.set_screen("main")
+        print("\nDeck ready! Press key 0 to cycle labels, long-hold to reset.")
+        await deck.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deckboard/dsui/loader.py
+++ b/src/deckboard/dsui/loader.py
@@ -99,11 +99,43 @@ def _parse_binding(name: str, raw: dict[str, Any]) -> Binding:
                 f"Binding '{name}' has invalid overflow '{overflow_raw}'. "
                 f"Valid modes: {valid_modes}"
             ) from None
+
+        wrap = bool(raw.get("wrap", False))
+        max_width = raw.get("max_width")
+        if wrap and max_width is None:
+            raise PackageError(
+                f"Binding '{name}' has wrap=true but no max_width. "
+                "max_width is required when wrapping is enabled."
+            )
+
+        max_height_raw = raw.get("max_height")
+        max_height: int | None = None
+        if max_height_raw is not None:
+            if not isinstance(max_height_raw, int) or max_height_raw <= 0:
+                raise PackageError(
+                    f"Binding '{name}' max_height must be a positive integer, "
+                    f"got {max_height_raw!r}"
+                )
+            max_height = max_height_raw
+
+        line_height_raw = raw.get("line_height")
+        line_height: float | None = None
+        if line_height_raw is not None:
+            if not isinstance(line_height_raw, (int, float)) or line_height_raw <= 0:
+                raise PackageError(
+                    f"Binding '{name}' line_height must be a positive number, "
+                    f"got {line_height_raw!r}"
+                )
+            line_height = float(line_height_raw)
+
         return TextBinding(
             node=node,
             default=str(raw.get("default", "")),
-            max_width=raw.get("max_width"),
+            max_width=max_width,
             overflow=overflow,
+            wrap=wrap,
+            max_height=max_height,
+            line_height=line_height,
         )
 
     if binding_type == BindingType.IMAGE:

--- a/src/deckboard/dsui/schema.py
+++ b/src/deckboard/dsui/schema.py
@@ -49,12 +49,22 @@ class RangeDirection(Enum):
 
 @dataclass(frozen=True, slots=True)
 class TextBinding:
-    """Bind a value to a <text> SVG element's content."""
+    """Bind a value to a ``<text>`` SVG element's content.
+
+    When *wrap* is ``True`` the renderer word-wraps the text into
+    multiple ``<tspan>`` lines that each fit within *max_width* pixels.
+    Font metrics are auto-detected from the SVG ``<text>`` element.
+    If the wrapped text exceeds *max_height*, the last visible line is
+    truncated according to *overflow*.
+    """
 
     node: str
     default: str = ""
     max_width: int | None = None
     overflow: OverflowMode = OverflowMode.ELLIPSIS
+    wrap: bool = False
+    max_height: int | None = None
+    line_height: float | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/deckboard/dsui/svg_renderer.py
+++ b/src/deckboard/dsui/svg_renderer.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import base64
 import copy
+import functools
 import io
 import logging
+import math
 import xml.etree.ElementTree as ET
 from typing import Any
 
-from PIL import Image
+from PIL import Image, ImageFont
 
 from .schema import (
     Binding,
@@ -110,6 +112,169 @@ def _truncate_text(text: str, max_width: int, overflow: OverflowMode) -> str:
         return text
 
     return text[: max(1, max_chars - 1)] + "\u2026"  # ellipsis character
+
+
+# ---------------------------------------------------------------------------
+# Font resolution and text wrapping
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FONT_FAMILY = "sans-serif"
+_DEFAULT_FONT_SIZE = 16.0
+_DEFAULT_LINE_HEIGHT_RATIO = 1.2
+
+
+def _resolve_font_attrs(root: ET.Element, elem: ET.Element) -> tuple[str, float]:
+    """Resolve font-family and font-size from an SVG element and its ancestors.
+
+    Walks from *elem* up through the SVG tree to find ``font-family``
+    and ``font-size`` attributes.  Falls back to sensible defaults if
+    neither the element nor any ancestor declares them.
+
+    Returns:
+        A ``(font_family, font_size)`` tuple.
+    """
+    family: str | None = None
+    size: float | None = None
+
+    # Build a parent map so we can walk upward
+    parent_map: dict[ET.Element, ET.Element] = {}
+    for parent in root.iter():
+        for child in parent:
+            parent_map[child] = parent
+
+    # Walk from elem upward
+    current: ET.Element | None = elem
+    while current is not None:
+        if family is None:
+            raw_family = current.get("font-family")
+            if raw_family:
+                family = raw_family.split(",")[0].strip().strip("'\"")
+        if size is None:
+            raw_size = current.get("font-size")
+            if raw_size:
+                try:
+                    size = float(raw_size.rstrip("px"))
+                except ValueError:
+                    pass
+        if family is not None and size is not None:
+            break
+        current = parent_map.get(current)
+
+    return (
+        family or _DEFAULT_FONT_FAMILY,
+        size or _DEFAULT_FONT_SIZE,
+    )
+
+
+@functools.lru_cache(maxsize=32)
+def _load_font(family: str, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Load a TrueType font by family name and size, with fallbacks.
+
+    Tries several name variations.  If all fail, logs a warning and
+    returns Pillow's built-in default font.  Results are cached.
+
+    Args:
+        family: Font family name (e.g. ``"ArialMT"``).
+        size: Font size in pixels (integer for cache-key hashability).
+    """
+    # Build candidate names: original, stripped suffixes, lowercase
+    candidates: list[str] = [family]
+    for suffix in ("MT", "Bold", "Italic", "-Regular", "-Bold"):
+        if family.endswith(suffix):
+            candidates.append(family[: -len(suffix)])
+    candidates.append(family.lower())
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for c in candidates:
+        if c not in seen:
+            seen.add(c)
+            unique.append(c)
+
+    for name in unique:
+        try:
+            return ImageFont.truetype(name, size)
+        except (OSError, IOError):
+            continue
+
+    logger.warning(
+        "Could not load font '%s' at size %d; using Pillow default font. "
+        "Text wrapping measurements may be inaccurate.",
+        family,
+        size,
+    )
+    return ImageFont.load_default()
+
+
+def _wrap_text(
+    text: str,
+    max_width: int,
+    font: ImageFont.FreeTypeFont | ImageFont.ImageFont,
+    overflow: OverflowMode,
+    max_height: int | None = None,
+    line_height: float = 18.0,
+) -> list[str]:
+    """Word-wrap *text* into lines that fit within *max_width* pixels.
+
+    Uses *font* for pixel-accurate text measurement via
+    :meth:`~PIL.ImageFont.ImageFont.getlength`.
+
+    If *max_height* is set, the number of visible lines is capped at
+    ``floor(max_height / line_height)``.  When there are more lines
+    than fit, the last visible line is truncated with an ellipsis
+    character (if *overflow* is :attr:`~OverflowMode.ELLIPSIS`).
+
+    Args:
+        text: The text string to wrap.
+        max_width: Maximum line width in pixels.
+        font: A Pillow font object for measurement.
+        overflow: How to handle text that doesn't fit.
+        max_height: Optional vertical pixel budget.
+        line_height: Vertical spacing between lines in pixels.
+
+    Returns:
+        A list of line strings, one per wrapped line.
+    """
+    if not text or not text.strip():
+        return []
+
+    words = text.split()
+    if not words:
+        return []
+
+    lines: list[str] = []
+    current_line = words[0]
+
+    for word in words[1:]:
+        test_line = current_line + " " + word
+        if font.getlength(test_line) <= max_width:
+            current_line = test_line
+        else:
+            lines.append(current_line)
+            current_line = word
+
+    lines.append(current_line)
+
+    # Apply max_height constraint
+    if max_height is not None and line_height > 0:
+        max_lines = max(1, math.floor(max_height / line_height))
+        if len(lines) > max_lines:
+            # Truncate to max_lines; handle last-line overflow
+            lines = lines[:max_lines]
+            if overflow == OverflowMode.ELLIPSIS:
+                last = lines[-1]
+                # Re-join remaining text that was cut off is implicit
+                # — we just need to mark the last line with ellipsis
+                ellipsis = "\u2026"
+                if font.getlength(last + ellipsis) > max_width:
+                    # Trim characters until it fits
+                    while len(last) > 1 and font.getlength(last + ellipsis) > max_width:
+                        last = last[:-1]
+                    lines[-1] = last.rstrip() + ellipsis
+                else:
+                    lines[-1] = last + ellipsis
+
+    return lines
 
 
 class SvgRenderer:
@@ -266,7 +431,7 @@ class SvgRenderer:
             return
 
         if isinstance(binding, TextBinding):
-            self._apply_text(elem, binding, value)
+            self._apply_text(root, elem, binding, value)
         elif isinstance(binding, ImageBinding):
             self._apply_image(root, elem, binding, value)
         elif isinstance(binding, VisibilityBinding):
@@ -278,12 +443,65 @@ class SvgRenderer:
         elif isinstance(binding, SliderBinding):
             self._apply_slider(elem, binding, value)
 
-    def _apply_text(self, elem: ET.Element, binding: TextBinding, value: Any) -> None:
-        """Set text content, applying truncation if configured."""
+    def _apply_text(
+        self,
+        root: ET.Element,
+        elem: ET.Element,
+        binding: TextBinding,
+        value: Any,
+    ) -> None:
+        """Set text content, applying wrapping or truncation if configured."""
         text = str(value) if value is not None else binding.default
+
+        if binding.wrap and binding.max_width is not None:
+            self._apply_wrapped_text(root, elem, binding, text)
+            return
+
         if binding.max_width is not None:
             text = _truncate_text(text, binding.max_width, binding.overflow)
         elem.text = text
+
+    def _apply_wrapped_text(
+        self,
+        root: ET.Element,
+        elem: ET.Element,
+        binding: TextBinding,
+        text: str,
+    ) -> None:
+        """Word-wrap text into ``<tspan>`` children of *elem*.
+
+        Each ``<tspan>`` carries the parent ``<text>`` element's ``x``
+        attribute so that ``text-anchor`` alignment is respected on
+        every line.
+        """
+        # Resolve font from the SVG tree
+        family, size_f = _resolve_font_attrs(root, elem)
+        font = _load_font(family, int(size_f))
+
+        line_height = binding.line_height or (size_f * _DEFAULT_LINE_HEIGHT_RATIO)
+
+        lines = _wrap_text(
+            text,
+            binding.max_width,  # type: ignore[arg-type]  # validated non-None
+            font,
+            binding.overflow,
+            max_height=binding.max_height,
+            line_height=line_height,
+        )
+
+        # Clear existing content and children
+        elem.text = None
+        for child in list(elem):
+            elem.remove(child)
+
+        # Inherit x from the parent <text> so text-anchor is respected
+        x_attr = elem.get("x", "0")
+
+        for i, line in enumerate(lines):
+            tspan = ET.SubElement(elem, f"{{{_SVG_NS}}}tspan")
+            tspan.set("x", x_attr)
+            tspan.set("dy", "0" if i == 0 else str(line_height))
+            tspan.text = line
 
     def _apply_image(
         self,

--- a/tests/test_dsui_loader.py
+++ b/tests/test_dsui_loader.py
@@ -53,6 +53,53 @@ class TestLoadPackageValid:
         assert isinstance(b, TextBinding)
         assert b.max_width is None
 
+    def test_text_binding_wrap_default_false(self, card_dsui_path):
+        spec = load_package(card_dsui_path)
+        b = spec.bindings["title"]
+        assert isinstance(b, TextBinding)
+        assert b.wrap is False
+        assert b.max_height is None
+        assert b.line_height is None
+
+    def test_text_binding_wrap_true(self, tmp_path):
+        pkg = tmp_path / "Wrap.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Wrap\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  label:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    max_height: 60\n"
+            "    line_height: 18.0",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        b = spec.bindings["label"]
+        assert isinstance(b, TextBinding)
+        assert b.wrap is True
+        assert b.max_width == 90
+        assert b.max_height == 60
+        assert b.line_height == 18.0
+
+    def test_text_binding_wrap_without_max_height(self, tmp_path):
+        """wrap=true without max_height is valid (unlimited vertical space)."""
+        pkg = tmp_path / "WrapNoH.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: WrapNoH\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  label:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        b = spec.bindings["label"]
+        assert isinstance(b, TextBinding)
+        assert b.wrap is True
+        assert b.max_height is None
+        assert b.line_height is None
+
     def test_image_binding_parsed(self, card_dsui_path):
         spec = load_package(card_dsui_path)
         b = spec.bindings["cover"]
@@ -939,6 +986,103 @@ class TestLoadPackageInvalid:
             encoding="utf-8",
         )
         with pytest.raises(PackageError, match="node_off 'missing'.*does not exist"):
+            load_package(pkg)
+
+    def test_text_binding_wrap_without_max_width(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n    wrap: true",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="max_width is required"):
+            load_package(pkg)
+
+    def test_text_binding_max_height_invalid(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    max_height: -5",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="max_height must be a positive integer"):
+            load_package(pkg)
+
+    def test_text_binding_max_height_zero(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    max_height: 0",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="max_height must be a positive integer"):
+            load_package(pkg)
+
+    def test_text_binding_max_height_not_int(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    max_height: big",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="max_height must be a positive integer"):
+            load_package(pkg)
+
+    def test_text_binding_line_height_invalid(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    line_height: -1.0",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="line_height must be a positive number"):
+            load_package(pkg)
+
+    def test_text_binding_line_height_zero(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    line_height: 0",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="line_height must be a positive number"):
+            load_package(pkg)
+
+    def test_text_binding_line_height_not_number(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><text id="t"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  t:\n    type: text\n    node: t\n"
+            "    max_width: 90\n    wrap: true\n    line_height: wide",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="line_height must be a positive number"):
             load_package(pkg)
 
     def test_version_string_invalid(self, tmp_path):

--- a/tests/test_dsui_schema.py
+++ b/tests/test_dsui_schema.py
@@ -70,6 +70,9 @@ class TestTextBinding:
         assert b.default == ""
         assert b.max_width is None
         assert b.overflow == OverflowMode.ELLIPSIS
+        assert b.wrap is False
+        assert b.max_height is None
+        assert b.line_height is None
 
     def test_custom(self):
         b = TextBinding(
@@ -83,6 +86,24 @@ class TestTextBinding:
         b = TextBinding(node="title")
         with pytest.raises(AttributeError):
             b.node = "other"  # type: ignore[misc]
+
+    def test_wrap_fields(self):
+        b = TextBinding(
+            node="label",
+            max_width=90,
+            wrap=True,
+            max_height=60,
+            line_height=18.0,
+        )
+        assert b.wrap is True
+        assert b.max_height == 60
+        assert b.line_height == 18.0
+
+    def test_wrap_defaults_false(self):
+        b = TextBinding(node="label", max_width=90)
+        assert b.wrap is False
+        assert b.max_height is None
+        assert b.line_height is None
 
 
 class TestImageBinding:

--- a/tests/test_dsui_svg_renderer.py
+++ b/tests/test_dsui_svg_renderer.py
@@ -25,7 +25,10 @@ from deckboard.dsui.svg_renderer import (
     SvgRenderer,
     _fit_image,
     _image_to_data_uri,
+    _load_font,
+    _resolve_font_attrs,
     _truncate_text,
+    _wrap_text,
 )
 
 
@@ -1071,3 +1074,477 @@ class TestSvgRendererToggleRender:
             renderer.render()
         assert "node_on 'ghost_on' not found" in caplog.text
         assert "node_off 'ghost_off' not found" in caplog.text
+
+
+# -- Text wrapping tests -------------------------------------------------------
+
+_WRAP_SVG = (
+    '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="106" height="106"'
+    ' font-family="Arial,sans-serif">'
+    '<rect id="bg" width="106" height="106" fill="#000000"/>'
+    '<text id="label" x="53" y="30" font-size="15" text-anchor="middle"'
+    ' fill="#ffffff">Placeholder</text>'
+    "</svg>"
+)
+
+_WRAP_SVG_FONT_ON_TEXT = (
+    '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+    '<rect id="bg" width="100" height="100" fill="#000000"/>'
+    '<text id="label" x="50" y="20" font-size="12" font-family="Helvetica,sans-serif"'
+    ' fill="#ffffff">Text</text>'
+    "</svg>"
+)
+
+_WRAP_SVG_NO_FONT = (
+    '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+    '<rect id="bg" width="100" height="100" fill="#000000"/>'
+    '<text id="label" x="50" y="20" fill="#ffffff">Text</text>'
+    "</svg>"
+)
+
+
+class TestResolveFontAttrs:
+    """Test _resolve_font_attrs — font detection from SVG elements."""
+
+    def test_font_from_text_element(self):
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(_WRAP_SVG_FONT_ON_TEXT)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        family, size = _resolve_font_attrs(root, elem)
+        assert family == "Helvetica"
+        assert size == 12.0
+
+    def test_font_inherited_from_svg_root(self):
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(_WRAP_SVG)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        family, size = _resolve_font_attrs(root, elem)
+        assert family == "Arial"
+        assert size == 15.0
+
+    def test_font_defaults_when_missing(self):
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(_WRAP_SVG_NO_FONT)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        family, size = _resolve_font_attrs(root, elem)
+        # Should fall back to defaults
+        assert family == "sans-serif"
+        assert size == 16.0
+
+    def test_font_size_with_px_suffix(self):
+        import xml.etree.ElementTree as ET
+
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+            '<text id="t" font-size="20px" font-family="Courier">hi</text>'
+            "</svg>"
+        )
+        root = ET.fromstring(svg)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "t")
+        family, size = _resolve_font_attrs(root, elem)
+        assert family == "Courier"
+        assert size == 20.0
+
+
+class TestLoadFont:
+    """Test _load_font — font loading with fallbacks."""
+
+    def test_loads_known_font(self):
+        from PIL import ImageFont
+
+        font = _load_font("Arial", 15)
+        assert isinstance(font, (ImageFont.FreeTypeFont, ImageFont.ImageFont))
+
+    def test_strips_mt_suffix(self):
+        from PIL import ImageFont
+
+        font = _load_font("ArialMT", 15)
+        # Should succeed either via ArialMT or by stripping to Arial
+        assert isinstance(font, (ImageFont.FreeTypeFont, ImageFont.ImageFont))
+
+    def test_unknown_font_returns_default_and_warns(self, caplog):
+        import logging
+
+        _load_font.cache_clear()
+        with caplog.at_level(logging.WARNING):
+            font = _load_font("TotallyFakeFont12345", 15)
+        assert "Could not load font" in caplog.text
+        # Should still return a usable font
+        assert hasattr(font, "getlength")
+        _load_font.cache_clear()
+
+    def test_cached_result(self):
+        _load_font.cache_clear()
+        font1 = _load_font("Arial", 12)
+        font2 = _load_font("Arial", 12)
+        assert font1 is font2
+        _load_font.cache_clear()
+
+
+class TestWrapText:
+    """Test _wrap_text — word-wrapping algorithm."""
+
+    def test_single_line_fits(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text("Hello", 200, font, OverflowMode.ELLIPSIS)
+        assert lines == ["Hello"]
+
+    def test_multi_line_wrap(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text("Arthur Olsen's Favorites", 80, font, OverflowMode.ELLIPSIS)
+        assert len(lines) >= 2
+        # All words should be present across lines
+        joined = " ".join(lines)
+        assert "Arthur" in joined
+        assert "Favorites" in joined
+
+    def test_empty_string(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text("", 100, font, OverflowMode.ELLIPSIS)
+        assert lines == []
+
+    def test_whitespace_only(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text("   ", 100, font, OverflowMode.ELLIPSIS)
+        assert lines == []
+
+    def test_single_word_per_line(self):
+        font = _load_font("Arial", 15)
+        # Very narrow width — each word gets its own line
+        lines = _wrap_text("One Two Three", 30, font, OverflowMode.ELLIPSIS)
+        assert len(lines) >= 3
+
+    def test_max_height_truncates(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text(
+            "One Two Three Four Five Six Seven",
+            60,
+            font,
+            OverflowMode.ELLIPSIS,
+            max_height=36,
+            line_height=18.0,
+        )
+        # max_height=36, line_height=18 → max 2 lines
+        assert len(lines) <= 2
+        # Last line should end with ellipsis
+        assert lines[-1].endswith("\u2026")
+
+    def test_max_height_no_truncation_needed(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text(
+            "Short",
+            200,
+            font,
+            OverflowMode.ELLIPSIS,
+            max_height=100,
+            line_height=18.0,
+        )
+        assert lines == ["Short"]
+        assert not lines[0].endswith("\u2026")
+
+    def test_max_height_clip_mode(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text(
+            "One Two Three Four Five Six Seven",
+            60,
+            font,
+            OverflowMode.CLIP,
+            max_height=36,
+            line_height=18.0,
+        )
+        # CLIP mode should still truncate lines but NOT add ellipsis
+        assert len(lines) <= 2
+        assert not lines[-1].endswith("\u2026")
+
+    def test_long_single_word(self):
+        font = _load_font("Arial", 15)
+        lines = _wrap_text("Supercalifragilistic", 50, font, OverflowMode.ELLIPSIS)
+        # Single word that doesn't fit — goes on one line
+        assert len(lines) == 1
+        assert lines[0] == "Supercalifragilistic"
+
+    def test_custom_line_height(self):
+        font = _load_font("Arial", 15)
+        # line_height=10 with max_height=25 → 2 lines
+        lines = _wrap_text(
+            "A B C D E F G H",
+            40,
+            font,
+            OverflowMode.ELLIPSIS,
+            max_height=25,
+            line_height=10.0,
+        )
+        assert len(lines) <= 2
+
+
+class TestSvgRendererWrappedText:
+    """Test SvgRenderer with wrap=True text bindings."""
+
+    def test_wrap_produces_tspan_elements(self):
+        """Wrapped text creates <tspan> children in the <text> element."""
+        import copy
+        import xml.etree.ElementTree as ET
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(node="label", default="", max_width=80, wrap=True),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        renderer.set("label", "Arthur Olsen's Favorites")
+
+        root = copy.deepcopy(renderer._base_root)
+        binding = spec.bindings["label"]
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        renderer._apply_text(root, elem, binding, "Arthur Olsen's Favorites")
+
+        tspans = list(elem)
+        assert len(tspans) >= 2
+        # Each tspan should inherit the x attribute from the parent
+        for tspan in tspans:
+            assert tspan.get("x") == "53"
+        # First tspan has dy="0", subsequent have the line height
+        assert tspans[0].get("dy") == "0"
+        for tspan in tspans[1:]:
+            assert float(tspan.get("dy")) > 0
+
+    def test_wrap_respects_text_anchor(self):
+        """All tspans get the parent's x attribute for text-anchor centering."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(node="label", default="", max_width=60, wrap=True),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+        renderer._apply_text(root, elem, binding, "Hello World Foo Bar")
+
+        for tspan in elem:
+            assert tspan.get("x") == "53"
+
+    def test_wrap_single_line_short_text(self):
+        """Short text that fits in one line produces one tspan."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(
+                    node="label", default="", max_width=200, wrap=True
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+        renderer._apply_text(root, elem, binding, "Hi")
+
+        tspans = list(elem)
+        assert len(tspans) == 1
+        assert tspans[0].text == "Hi"
+
+    def test_wrap_empty_string(self):
+        """Empty text produces no tspan elements."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(node="label", default="", max_width=80, wrap=True),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+        renderer._apply_text(root, elem, binding, "")
+
+        tspans = list(elem)
+        assert len(tspans) == 0
+        assert elem.text is None
+
+    def test_wrap_max_height_truncates_with_ellipsis(self):
+        """Excess lines are dropped and the last visible line gets an ellipsis."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(
+                    node="label",
+                    default="",
+                    max_width=60,
+                    wrap=True,
+                    max_height=36,
+                    overflow=OverflowMode.ELLIPSIS,
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+        renderer._apply_text(
+            root, elem, binding, "One Two Three Four Five Six Seven Eight"
+        )
+
+        tspans = list(elem)
+        # font-size=15, line_height=15*1.2=18, max_height=36 → max 2 lines
+        assert len(tspans) <= 2
+        # Last line should contain ellipsis
+        assert tspans[-1].text.endswith("\u2026")
+
+    def test_wrap_custom_line_height(self):
+        """Custom line_height is used for dy spacing."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(
+                    node="label",
+                    default="",
+                    max_width=60,
+                    wrap=True,
+                    line_height=20.0,
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+        renderer._apply_text(root, elem, binding, "Hello World Foo Bar")
+
+        tspans = list(elem)
+        assert len(tspans) >= 2
+        # Second tspan should have dy=20.0
+        assert tspans[1].get("dy") == "20.0"
+
+    def test_wrap_clears_previous_tspans(self):
+        """Re-applying wrapped text clears previously generated tspans."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(node="label", default="", max_width=60, wrap=True),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+
+        renderer._apply_text(root, elem, binding, "One Two Three Four Five")
+        first_count = len(list(elem))
+
+        renderer._apply_text(root, elem, binding, "Short")
+        second_count = len(list(elem))
+
+        assert second_count == 1  # "Short" fits one line
+        assert first_count > second_count
+
+    def test_wrap_disabled_uses_truncation(self):
+        """wrap=False still uses the old truncation behavior."""
+        import copy
+
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(
+                    node="label",
+                    default="",
+                    max_width=35,
+                    wrap=False,
+                    overflow=OverflowMode.ELLIPSIS,
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = copy.deepcopy(renderer._base_root)
+        from deckboard.dsui.svg_renderer import _find_element_by_id
+
+        elem = _find_element_by_id(root, "label")
+        binding = spec.bindings["label"]
+        renderer._apply_text(
+            root, elem, binding, "A very long piece of text that should be truncated"
+        )
+
+        # No tspan children — text is set directly
+        assert len(list(elem)) == 0
+        assert elem.text is not None
+        assert elem.text.endswith("\u2026")
+
+    def test_wrap_renders_to_image(self):
+        """Full render with wrapping produces a valid PIL Image."""
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(
+                    node="label",
+                    default="",
+                    max_width=80,
+                    wrap=True,
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        renderer.set("label", "Arthur Olsen's Favorites")
+        img = renderer.render()
+        assert isinstance(img, Image.Image)
+        assert img.mode == "RGB"
+        assert img.size == (106, 106)
+
+    def test_wrap_different_text_different_pixels(self):
+        """Different wrapped text produces different rendered images."""
+        spec = _make_spec(
+            _WRAP_SVG,
+            bindings={
+                "label": TextBinding(
+                    node="label",
+                    default="Hello",
+                    max_width=80,
+                    wrap=True,
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        img_before = renderer.render()
+
+        renderer.set("label", "Arthur Olsen's Favorites")
+        img_after = renderer.render()
+
+        assert img_before.tobytes() != img_after.tobytes()


### PR DESCRIPTION
## Summary

- Add word-wrapping to `TextBinding` via `wrap: true` that breaks long text into multiple `<tspan>` lines within SVG `<text>` elements
- Auto-detect font metrics (font-family, font-size) from the SVG tree; use Pillow `ImageFont.getlength()` for pixel-accurate text measurement
- Each `<tspan>` inherits the parent `<text>` element's `x` attribute so `text-anchor` alignment (middle/start/end) is respected on every line
- Add `LabelKey.dsui` example package and `label_key.py` example script demonstrating the feature

## New TextBinding Fields

- `wrap` (bool, default `False`): Enable word-wrapping
- `max_height` (int or None): Vertical pixel budget; excess lines truncated with ellipsis
- `line_height` (float or None): Override dy spacing between lines (default: 1.2x font_size)

## Manifest YAML Example

```yaml
bindings:
  label:
    type: text
    node: text
    max_width: 90
    wrap: true
    max_height: 54
    overflow: ellipsis
```

## Generated SVG Output

For "Arthur Olsen's Favorites" with max_width=90, font-size=15, text-anchor=middle:

```xml
<text id="text" x="53" y="35" font-size="15" text-anchor="middle" fill="#D9D9D9">
    <tspan x="53" dy="0">Arthur</tspan>
    <tspan x="53" dy="18.0">Olsen's</tspan>
    <tspan x="53" dy="18.0">Favorites</tspan>
</text>
```

## Test Results

All 723 tests pass. Coverage: 98.65% (well above the 95% gate).