### PR TITLE
Add iconify binding type for .dsui packages

### DIFF
--- a/examples/IconKey.dsui/layout.svg
+++ b/examples/IconKey.dsui/layout.svg
@@ -1,0 +1,11 @@
+<svg id="IconKey" width="106" height="106" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
+    <style>
+        .background_color {color: #1c1c1c;}
+        .foreground_color {color: #dedede;}
+    </style>
+    <rect class="background_color" x="0" y="0" width="106" height="106" rx="5" ry="5" fill="#1c1c1c"/>
+    <g id="icon" class="foreground_color" transform="translate(25.5 10)" color="#dedede"/>
+    <text id="label" class="foreground_color" x="53" y="90" font-size="18" text-anchor="middle" fill="#dedede">
+        Label
+    </text>
+</svg>

--- a/examples/IconKey.dsui/manifest.yaml
+++ b/examples/IconKey.dsui/manifest.yaml
@@ -1,0 +1,24 @@
+name: IconKey
+type: Key
+version: 1
+layout: layout.svg
+
+bindings:
+  icon:
+    type: iconify
+    node: icon
+    size: 55
+    default: "line-md:home"
+
+  label:
+    type: text
+    node: label
+    default: "Label"
+
+events:
+  - name: activate
+    source: key_press_release
+    max_duration_ms: 300
+  - name: long_hold
+    source: key_hold
+    hold_ms: 800

--- a/src/deckboard/dsui/__init__.py
+++ b/src/deckboard/dsui/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from .card import DsuiCard
 from .event_map import EventMap
+from .iconify import IconifyError, clear_cache as clear_iconify_cache, fetch_icon
 from .key import DsuiKey
 from .loader import PackageError, load_all_packages, load_package
 from .schema import (
@@ -27,6 +28,7 @@ from .schema import (
     BindingType,
     ColorBinding,
     EventMapping,
+    IconifyBinding,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -50,6 +52,8 @@ __all__ = [
     "DsuiKey",
     "EventMap",
     "EventMapping",
+    "IconifyBinding",
+    "IconifyError",
     "ImageBinding",
     "ImageFit",
     "OverflowMode",
@@ -64,6 +68,8 @@ __all__ = [
     "TextBinding",
     "ToggleBinding",
     "VisibilityBinding",
+    "clear_iconify_cache",
+    "fetch_icon",
     "load_all_packages",
     "load_package",
 ]

--- a/src/deckboard/dsui/iconify.py
+++ b/src/deckboard/dsui/iconify.py
@@ -22,6 +22,12 @@ ICONIFY_API_URL = "https://api.iconify.design"
 # Timeout for HTTP requests, in seconds.
 _REQUEST_TIMEOUT = 10.0
 
+# User-Agent sent with icon requests.  The Iconify CDN returns 403 to
+# the default ``Python-urllib/x.y`` UA, so we identify ourselves with
+# the library name.  Exposed as a module attribute so tests and users
+# can override it if needed.
+USER_AGENT = "deckboard/0.1.0 (+https://github.com/graphras-com/deckboard)"
+
 # In-process cache: maps "prefix:name" -> SVG source bytes.  ``None``
 # marks a name that has been looked up and failed to load, so we do not
 # spam the Iconify API for a broken icon reference.
@@ -54,8 +60,14 @@ def _parse_name(name: str) -> tuple[str, str]:
 
 
 def _http_get(url: str) -> str:
-    """Fetch *url* and return its body decoded as UTF-8 text."""
-    with urllib.request.urlopen(url, timeout=_REQUEST_TIMEOUT) as resp:
+    """Fetch *url* and return its body decoded as UTF-8 text.
+
+    Sends :data:`USER_AGENT` as the ``User-Agent`` header because the
+    Iconify CDN rejects requests using the default ``Python-urllib``
+    identifier with HTTP 403.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT) as resp:
         charset = resp.headers.get_content_charset() or "utf-8"
         return resp.read().decode(charset)
 

--- a/src/deckboard/dsui/iconify.py
+++ b/src/deckboard/dsui/iconify.py
@@ -1,0 +1,118 @@
+"""Iconify icon fetching and in-process caching.
+
+Icons are downloaded from the public Iconify HTTP API
+(https://api.iconify.design) on first use and cached in memory so
+subsequent renders hit no network.  The cache is process-local and
+lives for the lifetime of the interpreter.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Base URL of the Iconify HTTP API.  Exposed as a module attribute so
+# tests can monkeypatch it.
+ICONIFY_API_URL = "https://api.iconify.design"
+
+# Timeout for HTTP requests, in seconds.
+_REQUEST_TIMEOUT = 10.0
+
+# In-process cache: maps "prefix:name" -> SVG source bytes.  ``None``
+# marks a name that has been looked up and failed to load, so we do not
+# spam the Iconify API for a broken icon reference.
+_cache: dict[str, str | None] = {}
+_cache_lock = threading.Lock()
+
+
+class IconifyError(Exception):
+    """Raised when an Iconify icon cannot be resolved."""
+
+
+def _parse_name(name: str) -> tuple[str, str]:
+    """Split a ``"prefix:icon"`` name into its parts.
+
+    Raises:
+        IconifyError: If *name* is empty or not in ``prefix:icon`` form.
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise IconifyError(f"Iconify name must be a non-empty string, got {name!r}")
+    if ":" not in name:
+        raise IconifyError(
+            f"Iconify name '{name}' must be in 'prefix:icon' form (e.g. 'line-md:home')"
+        )
+    prefix, _, icon = name.partition(":")
+    if not prefix or not icon:
+        raise IconifyError(
+            f"Iconify name '{name}' must be in 'prefix:icon' form (e.g. 'line-md:home')"
+        )
+    return prefix, icon
+
+
+def _http_get(url: str) -> str:
+    """Fetch *url* and return its body decoded as UTF-8 text."""
+    with urllib.request.urlopen(url, timeout=_REQUEST_TIMEOUT) as resp:
+        charset = resp.headers.get_content_charset() or "utf-8"
+        return resp.read().decode(charset)
+
+
+def fetch_icon(name: str) -> str:
+    """Fetch an Iconify icon by ``prefix:icon`` name.
+
+    The result is cached in-process; subsequent calls return the
+    cached SVG source immediately.  Negative lookups (404 / network
+    failure) are also cached so we do not retry broken references on
+    every render.
+
+    Args:
+        name: Icon identifier in ``"prefix:icon"`` form, e.g.
+            ``"line-md:home"``.
+
+    Returns:
+        The raw SVG source string as served by the Iconify API.
+
+    Raises:
+        IconifyError: If the name is malformed, the icon does not
+            exist, or the network request fails.
+    """
+    prefix, icon = _parse_name(name)
+    key = f"{prefix}:{icon}"
+
+    with _cache_lock:
+        if key in _cache:
+            cached = _cache[key]
+            if cached is None:
+                raise IconifyError(f"Iconify icon '{key}' previously failed to load")
+            return cached
+
+    url = f"{ICONIFY_API_URL}/{prefix}/{icon}.svg"
+    try:
+        body = _http_get(url)
+    except (urllib.error.URLError, OSError) as exc:
+        with _cache_lock:
+            _cache[key] = None
+        raise IconifyError(f"Failed to fetch Iconify icon '{key}': {exc}") from exc
+
+    # The Iconify API returns a 200 with literal text "404" in the body
+    # when the icon does not exist.  Treat that as a failed lookup.
+    stripped = body.strip()
+    if stripped == "404" or not stripped.startswith("<"):
+        with _cache_lock:
+            _cache[key] = None
+        raise IconifyError(f"Iconify icon '{key}' not found")
+
+    with _cache_lock:
+        _cache[key] = body
+
+    logger.debug("Fetched Iconify icon '%s' (%d bytes)", key, len(body))
+    return body
+
+
+def clear_cache() -> None:
+    """Drop all cached Iconify icons.  Primarily intended for tests."""
+    with _cache_lock:
+        _cache.clear()

--- a/src/deckboard/dsui/loader.py
+++ b/src/deckboard/dsui/loader.py
@@ -15,6 +15,7 @@ from .schema import (
     ColorBinding,
     EventMapping,
     HOLD_SOURCES,
+    IconifyBinding,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -218,6 +219,23 @@ def _parse_binding(name: str, raw: dict[str, Any]) -> Binding:
             direction=direction,
             min_pos=float(min_pos_raw),
             max_pos=float(max_pos_raw),
+        )
+
+    if binding_type == BindingType.ICONIFY:
+        size_raw = raw.get("size")
+        if size_raw is None:
+            raise PackageError(f"Binding '{name}' missing 'size'")
+        if not isinstance(size_raw, int) or isinstance(size_raw, bool) or size_raw <= 0:
+            raise PackageError(
+                f"Binding '{name}': size must be a positive integer, got {size_raw!r}"
+            )
+        default_raw = raw.get("default", "")
+        if default_raw is not None and not isinstance(default_raw, str):
+            raise PackageError(f"Binding '{name}': default must be a string")
+        return IconifyBinding(
+            node=node,
+            size=size_raw,
+            default=str(default_raw) if default_raw is not None else "",
         )
 
     # BindingType.COLOR

--- a/src/deckboard/dsui/schema.py
+++ b/src/deckboard/dsui/schema.py
@@ -23,6 +23,7 @@ class BindingType(Enum):
     RANGE = "range"
     SLIDER = "slider"
     TOGGLE = "toggle"
+    ICONIFY = "iconify"
 
 
 class OverflowMode(Enum):
@@ -126,6 +127,25 @@ class ToggleBinding:
     default: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class IconifyBinding:
+    """Load an Iconify icon by name and embed it into an SVG ``<g>`` element.
+
+    The icon name follows the Iconify convention ``<prefix>:<name>`` (for
+    example ``line-md:home``).  Icons are fetched from
+    ``https://api.iconify.design`` on first use and cached in-process.
+
+    The resolved icon SVG is inserted as children of the target ``<g>``
+    node, scaled to a ``size`` × ``size`` square.  Setting the binding
+    value to ``None`` or an empty string removes any previously embedded
+    icon from the node.
+    """
+
+    node: str
+    size: int
+    default: str = ""
+
+
 Binding = (
     TextBinding
     | ImageBinding
@@ -134,6 +154,7 @@ Binding = (
     | RangeBinding
     | SliderBinding
     | ToggleBinding
+    | IconifyBinding
 )
 
 # Valid event source names and their physical origins

--- a/src/deckboard/dsui/svg_renderer.py
+++ b/src/deckboard/dsui/svg_renderer.py
@@ -13,9 +13,11 @@ from typing import Any
 
 from PIL import Image, ImageFont
 
+from .iconify import IconifyError, fetch_icon
 from .schema import (
     Binding,
     ColorBinding,
+    IconifyBinding,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -318,6 +320,8 @@ class SvgRenderer:
                 self._values[name] = binding.default
             elif isinstance(binding, ToggleBinding):
                 self._values[name] = binding.default
+            elif isinstance(binding, IconifyBinding):
+                self._values[name] = binding.default
             # ImageBinding defaults to None (no image)
 
     def set(self, name: str, value: Any) -> bool:
@@ -442,6 +446,8 @@ class SvgRenderer:
             self._apply_range(elem, name, binding, value)
         elif isinstance(binding, SliderBinding):
             self._apply_slider(elem, binding, value)
+        elif isinstance(binding, IconifyBinding):
+            self._apply_iconify(elem, binding, value)
 
     def _apply_text(
         self,
@@ -609,6 +615,55 @@ class SvgRenderer:
         pos = binding.min_pos + ratio * (binding.max_pos - binding.min_pos)
         attr = "x" if binding.direction == RangeDirection.HORIZONTAL else "y"
         elem.set(attr, str(pos))
+
+    def _apply_iconify(
+        self,
+        elem: ET.Element,
+        binding: IconifyBinding,
+        value: Any,
+    ) -> None:
+        """Load an Iconify icon by name and embed it into a ``<g>`` node.
+
+        The existing children of *elem* are replaced by a single
+        ``<svg>`` child that contains the icon.  Passing ``None`` or an
+        empty string clears the group.
+        """
+        # Always clear existing content — either we replace it with the
+        # new icon, or we leave the group empty.
+        elem.text = None
+        for child in list(elem):
+            elem.remove(child)
+
+        # ``None`` and empty string both clear the group.  The binding's
+        # default is applied at construction time via ``_values`` and is
+        # not re-used here so users can explicitly unset the icon.
+        if value is None or value == "":
+            return
+        name = str(value)
+
+        try:
+            svg_source = fetch_icon(str(name))
+        except IconifyError as exc:
+            logger.warning("Iconify binding '%s': %s", binding.node, exc)
+            return
+
+        try:
+            icon_root = ET.fromstring(svg_source)  # noqa: S314 — trusted API
+        except ET.ParseError as exc:
+            logger.warning(
+                "Iconify binding '%s': failed to parse icon SVG: %s",
+                binding.node,
+                exc,
+            )
+            return
+
+        # Force the embedded icon to our requested pixel size.  The
+        # original viewBox is preserved, so the icon scales uniformly.
+        size = str(binding.size)
+        icon_root.set("width", size)
+        icon_root.set("height", size)
+
+        elem.append(icon_root)
 
     def _inline_assets(self, root: ET.Element) -> None:
         """Replace relative asset href references with data URIs."""

--- a/tests/test_dsui_iconify.py
+++ b/tests/test_dsui_iconify.py
@@ -9,6 +9,7 @@ import pytest
 
 from deckboard.dsui import iconify as iconify_mod
 from deckboard.dsui.iconify import (
+    USER_AGENT,
     IconifyError,
     _parse_name,
     clear_cache,
@@ -156,3 +157,42 @@ class TestFetchIcon:
                 fetch_icon("line-md:home")
             url_arg = mock.call_args.args[0]
             assert url_arg == "https://example.test/line-md/home.svg"
+
+
+class TestHttpGet:
+    """Verify transport-level behaviour of :func:`_http_get`."""
+
+    def test_sends_user_agent_header(self):
+        """The Iconify CDN 403s the default Python-urllib UA."""
+        captured: dict[str, object] = {}
+
+        class _FakeHeaders:
+            def get_content_charset(self) -> str | None:
+                return None
+
+        class _FakeResp:
+            headers = _FakeHeaders()
+
+            def read(self) -> bytes:
+                return _SAMPLE_SVG.encode("utf-8")
+
+            def __enter__(self) -> "_FakeResp":
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+        def fake_urlopen(req, timeout):  # noqa: ARG001
+            captured["request"] = req
+            return _FakeResp()
+
+        # urlopen normally gets a Request with a ``.headers`` mapping.
+        # Capture it and verify the UA was attached.
+        with patch.object(iconify_mod.urllib.request, "urlopen", fake_urlopen):
+            result = iconify_mod._http_get("https://example.test/x.svg")
+
+        assert result == _SAMPLE_SVG
+        req = captured["request"]
+        # urllib normalises header names to Capitalized form via
+        # ``Request.add_header``; ``get_header`` does a case-insensitive lookup.
+        assert req.get_header("User-agent") == USER_AGENT

--- a/tests/test_dsui_iconify.py
+++ b/tests/test_dsui_iconify.py
@@ -1,0 +1,158 @@
+"""Tests for deckboard.dsui.iconify — icon fetch and cache."""
+
+from __future__ import annotations
+
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from deckboard.dsui import iconify as iconify_mod
+from deckboard.dsui.iconify import (
+    IconifyError,
+    _parse_name,
+    clear_cache,
+    fetch_icon,
+)
+
+
+_SAMPLE_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" '
+    'viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    """Reset the iconify cache around every test."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestParseName:
+    def test_simple(self):
+        assert _parse_name("line-md:home") == ("line-md", "home")
+
+    def test_multi_colon_rest_joined(self):
+        """Only the first colon splits; the remainder becomes the name."""
+        # Iconify names shouldn't contain colons but be permissive on parse.
+        prefix, icon = _parse_name("mdi:account:alt")
+        assert prefix == "mdi"
+        assert icon == "account:alt"
+
+    def test_no_colon_raises(self):
+        with pytest.raises(IconifyError, match="prefix:icon"):
+            _parse_name("homeonly")
+
+    def test_empty_raises(self):
+        with pytest.raises(IconifyError, match="non-empty"):
+            _parse_name("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(IconifyError, match="non-empty"):
+            _parse_name("   ")
+
+    def test_empty_prefix_raises(self):
+        with pytest.raises(IconifyError, match="prefix:icon"):
+            _parse_name(":home")
+
+    def test_empty_icon_raises(self):
+        with pytest.raises(IconifyError, match="prefix:icon"):
+            _parse_name("mdi:")
+
+    def test_non_string_raises(self):
+        with pytest.raises(IconifyError, match="non-empty"):
+            _parse_name(None)  # type: ignore[arg-type]
+
+
+class TestFetchIcon:
+    def test_fetch_returns_svg(self):
+        with patch.object(iconify_mod, "_http_get", return_value=_SAMPLE_SVG) as mock:
+            result = fetch_icon("line-md:home")
+        assert result == _SAMPLE_SVG
+        mock.assert_called_once()
+        # URL should combine the configured API base with the icon path.
+        url_arg = mock.call_args.args[0]
+        assert url_arg.endswith("/line-md/home.svg")
+
+    def test_cache_hit_skips_http(self):
+        with patch.object(iconify_mod, "_http_get", return_value=_SAMPLE_SVG) as mock:
+            fetch_icon("line-md:home")
+            fetch_icon("line-md:home")
+            fetch_icon("line-md:home")
+        assert mock.call_count == 1
+
+    def test_different_names_cached_separately(self):
+        def side_effect(url: str) -> str:
+            if "/home.svg" in url:
+                return _SAMPLE_SVG
+            return _SAMPLE_SVG.replace("M0 0", "M1 1")
+
+        with patch.object(iconify_mod, "_http_get", side_effect=side_effect) as mock:
+            a = fetch_icon("line-md:home")
+            b = fetch_icon("line-md:settings")
+            # repeat — should be cached
+            fetch_icon("line-md:home")
+            fetch_icon("line-md:settings")
+        assert mock.call_count == 2
+        assert a != b
+
+    def test_invalid_name_raises(self):
+        with pytest.raises(IconifyError):
+            fetch_icon("no-colon")
+
+    def test_404_body_raises_and_caches_failure(self):
+        with patch.object(iconify_mod, "_http_get", return_value="404") as mock:
+            with pytest.raises(IconifyError, match="not found"):
+                fetch_icon("fake:missing")
+            # Second call must not re-hit the network.
+            with pytest.raises(IconifyError, match="previously failed"):
+                fetch_icon("fake:missing")
+        assert mock.call_count == 1
+
+    def test_non_svg_body_treated_as_missing(self):
+        with patch.object(iconify_mod, "_http_get", return_value="random junk"):
+            with pytest.raises(IconifyError, match="not found"):
+                fetch_icon("fake:weird")
+
+    def test_network_error_raises_and_caches(self):
+        err = urllib.error.URLError("unreachable")
+        with patch.object(iconify_mod, "_http_get", side_effect=err) as mock:
+            with pytest.raises(IconifyError, match="Failed to fetch"):
+                fetch_icon("line-md:offline")
+            # Negative lookup cached — no retry.
+            with pytest.raises(IconifyError, match="previously failed"):
+                fetch_icon("line-md:offline")
+        assert mock.call_count == 1
+
+    def test_os_error_also_caught(self):
+        """A plain OSError from the socket layer is wrapped as IconifyError."""
+        with patch.object(iconify_mod, "_http_get", side_effect=OSError("boom")):
+            with pytest.raises(IconifyError, match="Failed to fetch"):
+                fetch_icon("line-md:boom")
+
+    def test_clear_cache_forces_refetch(self):
+        with patch.object(iconify_mod, "_http_get", return_value=_SAMPLE_SVG) as mock:
+            fetch_icon("line-md:home")
+            clear_cache()
+            fetch_icon("line-md:home")
+        assert mock.call_count == 2
+
+    def test_clear_cache_drops_negative_entries(self):
+        with patch.object(iconify_mod, "_http_get", return_value="404") as mock:
+            with pytest.raises(IconifyError):
+                fetch_icon("fake:gone")
+            clear_cache()
+            with pytest.raises(IconifyError):
+                fetch_icon("fake:gone")
+        assert mock.call_count == 2
+
+    def test_uses_configured_api_url(self):
+        with patch.object(iconify_mod, "ICONIFY_API_URL", "https://example.test"):
+            with patch.object(
+                iconify_mod, "_http_get", return_value=_SAMPLE_SVG
+            ) as mock:
+                fetch_icon("line-md:home")
+            url_arg = mock.call_args.args[0]
+            assert url_arg == "https://example.test/line-md/home.svg"

--- a/tests/test_dsui_loader.py
+++ b/tests/test_dsui_loader.py
@@ -9,6 +9,7 @@ import pytest
 from deckboard.dsui.loader import PackageError, load_all_packages, load_package
 from deckboard.dsui.schema import (
     ColorBinding,
+    IconifyBinding,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -185,6 +186,40 @@ class TestLoadPackageValid:
         b = spec.bindings["state"]
         assert isinstance(b, ToggleBinding)
         assert b.default is False
+
+    def test_iconify_binding_parsed(self, tmp_path):
+        pkg = tmp_path / "I.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: I\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon\n"
+            '    size: 55\n    default: "line-md:home"',
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        b = spec.bindings["icon"]
+        assert isinstance(b, IconifyBinding)
+        assert b.node == "icon"
+        assert b.size == 55
+        assert b.default == "line-md:home"
+
+    def test_iconify_binding_default_empty(self, tmp_path):
+        pkg = tmp_path / "IE.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: IE\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon\n    size: 24",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        b = spec.bindings["icon"]
+        assert isinstance(b, IconifyBinding)
+        assert b.size == 24
+        assert b.default == ""
 
     def test_slider_binding_parsed(self, tmp_path):
         pkg = tmp_path / "S.dsui"
@@ -1095,6 +1130,98 @@ class TestLoadPackageInvalid:
             encoding="utf-8",
         )
         with pytest.raises(PackageError, match="positive integer"):
+            load_package(pkg)
+
+    def test_iconify_binding_missing_size(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="missing 'size'"):
+            load_package(pkg)
+
+    def test_iconify_binding_size_not_int(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon\n    size: big",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="size must be a positive integer"):
+            load_package(pkg)
+
+    def test_iconify_binding_size_zero(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon\n    size: 0",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="size must be a positive integer"):
+            load_package(pkg)
+
+    def test_iconify_binding_size_negative(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon\n    size: -10",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="size must be a positive integer"):
+            load_package(pkg)
+
+    def test_iconify_binding_size_bool_rejected(self, tmp_path):
+        """YAML's ``true`` coerces to int(1) in Python; reject explicitly."""
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: icon\n    size: true",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="size must be a positive integer"):
+            load_package(pkg)
+
+    def test_iconify_binding_missing_node(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    size: 55",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="missing 'node'"):
+            load_package(pkg)
+
+    def test_iconify_binding_node_not_in_svg(self, tmp_path):
+        pkg = tmp_path / "Bad.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon"/></svg>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "bindings:\n  icon:\n    type: iconify\n    node: missing\n    size: 55",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="does not exist in the SVG"):
             load_package(pkg)
 
 

--- a/tests/test_dsui_schema.py
+++ b/tests/test_dsui_schema.py
@@ -9,6 +9,7 @@ from deckboard.dsui.schema import (
     ColorBinding,
     EventMapping,
     HOLD_SOURCES,
+    IconifyBinding,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -48,6 +49,7 @@ class TestBindingType:
         assert BindingType("range") == BindingType.RANGE
         assert BindingType("slider") == BindingType.SLIDER
         assert BindingType("toggle") == BindingType.TOGGLE
+        assert BindingType("iconify") == BindingType.ICONIFY
 
 
 class TestOverflowMode:
@@ -142,6 +144,24 @@ class TestToggleBinding:
         b = ToggleBinding(node_on="icon_on", node_off="icon_off")
         with pytest.raises(AttributeError):
             b.node_on = "other"  # type: ignore[misc]
+
+
+class TestIconifyBinding:
+    def test_defaults(self):
+        b = IconifyBinding(node="icon", size=55)
+        assert b.node == "icon"
+        assert b.size == 55
+        assert b.default == ""
+
+    def test_custom(self):
+        b = IconifyBinding(node="icon", size=32, default="line-md:home")
+        assert b.size == 32
+        assert b.default == "line-md:home"
+
+    def test_frozen(self):
+        b = IconifyBinding(node="icon", size=55)
+        with pytest.raises(AttributeError):
+            b.size = 32  # type: ignore[misc]
 
 
 class TestColorBinding:

--- a/tests/test_dsui_svg_renderer.py
+++ b/tests/test_dsui_svg_renderer.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from deckboard.dsui.schema import (
     ColorBinding,
+    IconifyBinding,
     ImageBinding,
     ImageFit,
     OverflowMode,
@@ -1548,3 +1549,227 @@ class TestSvgRendererWrappedText:
         img_after = renderer.render()
 
         assert img_before.tobytes() != img_after.tobytes()
+
+
+# -- Iconify binding -------------------------------------------------------
+
+_ICONIFY_SVG = (
+    '<svg id="IconKey" xmlns="http://www.w3.org/2000/svg" '
+    'width="106" height="106">'
+    '<rect id="bg" width="106" height="106" fill="#1c1c1c"/>'
+    '<g id="icon" transform="translate(25 10)" color="#dedede"/>'
+    "</svg>"
+)
+
+_ICONIFY_SAMPLE = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" '
+    'viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+)
+
+_SVG_NS = "http://www.w3.org/2000/svg"
+
+
+def _find_by_id(root, target_id: str):
+    """Search an ElementTree for the first element with id == target_id."""
+    for elem in root.iter():
+        if elem.get("id") == target_id:
+            return elem
+    return None
+
+
+class TestIconifyBindingRendering:
+    def _patch_fetch(self, monkeypatch, svg: str = _ICONIFY_SAMPLE):
+        import deckboard.dsui.svg_renderer as svg_renderer_mod
+
+        monkeypatch.setattr(
+            svg_renderer_mod, "fetch_icon", lambda name: svg, raising=True
+        )
+
+    def _serialise_with_bindings(self, renderer: SvgRenderer):
+        """Build a pre-rasterised ElementTree root for inspection."""
+        import copy
+        import xml.etree.ElementTree as ET
+
+        root = copy.deepcopy(renderer._base_root)
+        for name, binding in renderer._spec.bindings.items():
+            renderer._apply_binding(root, name, binding, renderer._values.get(name))
+        # Round-trip through a string to normalise namespaces
+        xml = ET.tostring(root, encoding="unicode")
+        return ET.fromstring(xml)
+
+    def test_default_icon_embedded(self, monkeypatch):
+        self._patch_fetch(monkeypatch)
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        assert g is not None
+        children = list(g)
+        assert len(children) == 1
+        inner = children[0]
+        assert inner.tag == f"{{{_SVG_NS}}}svg"
+        assert inner.get("width") == "55"
+        assert inner.get("height") == "55"
+        # The embedded <path> from the sample icon must be preserved.
+        assert any(c.tag == f"{{{_SVG_NS}}}path" for c in inner.iter())
+
+    def test_set_changes_icon(self, monkeypatch):
+        calls: list[str] = []
+
+        def fake_fetch(name: str) -> str:
+            calls.append(name)
+            return _ICONIFY_SAMPLE
+
+        import deckboard.dsui.svg_renderer as svg_renderer_mod
+
+        monkeypatch.setattr(svg_renderer_mod, "fetch_icon", fake_fetch, raising=True)
+
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=40, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        changed = renderer.set("icon", "line-md:settings")
+        assert changed is True
+        root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        assert g is not None
+        inner = list(g)[0]
+        assert inner.get("width") == "40"
+        assert "line-md:settings" in calls
+
+    def test_empty_value_clears_group(self, monkeypatch):
+        """Setting the binding to an empty string removes the embedded icon."""
+        self._patch_fetch(monkeypatch)
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        assert list(g) == []
+
+    def test_none_value_clears_group(self, monkeypatch):
+        self._patch_fetch(monkeypatch)
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        renderer.set("icon", None)
+        root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        assert list(g) == []
+
+    def test_existing_children_replaced(self, monkeypatch):
+        """Any pre-existing children of the target <g> are dropped."""
+        self._patch_fetch(monkeypatch)
+        svg_with_child = (
+            '<svg id="IconKey" xmlns="http://www.w3.org/2000/svg" '
+            'width="106" height="106">'
+            '<g id="icon"><rect id="stale" width="5" height="5"/></g>'
+            "</svg>"
+        )
+        spec = _make_spec(
+            svg_with_child,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=32, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        # Only the new <svg> child should remain.
+        children = list(g)
+        assert len(children) == 1
+        assert children[0].tag == f"{{{_SVG_NS}}}svg"
+        # "stale" must be gone.
+        assert _find_by_id(root, "stale") is None
+
+    def test_iconify_error_leaves_group_empty(self, monkeypatch, caplog):
+        """A failed icon fetch is logged and renders an empty <g>."""
+        import logging
+
+        from deckboard.dsui.iconify import IconifyError
+        import deckboard.dsui.svg_renderer as svg_renderer_mod
+
+        def boom(name: str) -> str:
+            raise IconifyError("no network")
+
+        monkeypatch.setattr(svg_renderer_mod, "fetch_icon", boom, raising=True)
+
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        with caplog.at_level(logging.WARNING, logger="deckboard.dsui.svg_renderer"):
+            root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        assert list(g) == []
+        assert any("Iconify binding" in rec.message for rec in caplog.records)
+
+    def test_invalid_icon_svg_logs_and_empties(self, monkeypatch, caplog):
+        """A fetched payload that is not parseable XML is skipped gracefully."""
+        import logging
+
+        import deckboard.dsui.svg_renderer as svg_renderer_mod
+
+        monkeypatch.setattr(
+            svg_renderer_mod, "fetch_icon", lambda name: "<svg><broken", raising=True
+        )
+
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        with caplog.at_level(logging.WARNING, logger="deckboard.dsui.svg_renderer"):
+            root = self._serialise_with_bindings(renderer)
+        g = _find_by_id(root, "icon")
+        assert list(g) == []
+        assert any("failed to parse" in rec.message for rec in caplog.records)
+
+    def test_full_render_produces_image(self, monkeypatch):
+        """End-to-end render goes through CairoSVG without exceptions."""
+        self._patch_fetch(monkeypatch)
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        img = renderer.render()
+        assert isinstance(img, Image.Image)
+        assert img.mode == "RGB"
+        assert img.size == (106, 106)
+
+    def test_set_same_value_no_change(self, monkeypatch):
+        """SvgRenderer.set reports no change when the value is identical."""
+        self._patch_fetch(monkeypatch)
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        assert renderer.set("icon", "line-md:home") is False
+        assert renderer.set("icon", "line-md:settings") is True

--- a/tests/test_iconify_example.py
+++ b/tests/test_iconify_example.py
@@ -1,0 +1,77 @@
+"""End-to-end tests for the IconKey.dsui example package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import deckboard.dsui.svg_renderer as svg_renderer_mod
+from deckboard.dsui import DsuiKey, load_package
+from deckboard.dsui.iconify import clear_cache
+from deckboard.dsui.schema import IconifyBinding, TextBinding
+
+_SAMPLE_ICON_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" '
+    'viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+)
+
+_EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "examples" / "IconKey.dsui"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def patch_fetch(monkeypatch):
+    """Replace the network-backed fetch with a deterministic local SVG."""
+    monkeypatch.setattr(
+        svg_renderer_mod, "fetch_icon", lambda name: _SAMPLE_ICON_SVG, raising=True
+    )
+
+
+class TestIconKeyExamplePackage:
+    def test_example_package_loads(self):
+        spec = load_package(_EXAMPLE_DIR)
+        assert spec.name == "IconKey"
+
+    def test_icon_binding_parsed(self):
+        spec = load_package(_EXAMPLE_DIR)
+        icon = spec.bindings["icon"]
+        assert isinstance(icon, IconifyBinding)
+        assert icon.node == "icon"
+        assert icon.size == 55
+        assert icon.default == "line-md:home"
+
+    def test_label_binding_parsed(self):
+        spec = load_package(_EXAMPLE_DIR)
+        label = spec.bindings["label"]
+        assert isinstance(label, TextBinding)
+        assert label.default == "Label"
+
+    def test_events_parsed(self):
+        spec = load_package(_EXAMPLE_DIR)
+        names = [e.name for e in spec.events]
+        assert "activate" in names
+        assert "long_hold" in names
+
+    def test_dsui_key_renders_with_icon(self, patch_fetch):
+        spec = load_package(_EXAMPLE_DIR)
+        key = DsuiKey(0, spec)
+        jpeg_bytes = key.render_image()
+        assert isinstance(jpeg_bytes, (bytes, bytearray))
+        assert len(jpeg_bytes) > 0
+
+    def test_dsui_key_updates_label_and_icon(self, patch_fetch):
+        spec = load_package(_EXAMPLE_DIR)
+        key = DsuiKey(0, spec)
+        # set() returns self for chaining.
+        assert key.set("label", "Home") is key
+        assert key.set("icon", "line-md:settings") is key
+        jpeg_bytes = key.render_image()
+        assert isinstance(jpeg_bytes, (bytes, bytearray))
+        assert len(jpeg_bytes) > 0


### PR DESCRIPTION
## Summary

Adds a new `iconify` binding type that fetches icons from the public
[Iconify](https://iconify.design) HTTP API by `prefix:name` and embeds
them as scaled children of a target `<g>` node in a `.dsui` package SVG.

### Usage

```yaml
bindings:
  icon:
    type: iconify
    node: icon
    size: 55
    default: "line-md:home"
```

```python
key = DsuiKey(0, load_package("IconKey.dsui"))
key.set("icon", "line-md:settings")  # swap at runtime
key.set("icon", None)                # clear the group
```

### What's included

- `IconifyBinding` dataclass and `BindingType.ICONIFY` in `dsui.schema`
- `dsui.iconify` — `fetch_icon()` with an in-process positive + negative cache, `clear_cache()`, `IconifyError`, and a configurable `ICONIFY_API_URL`
- Loader validation: `size` must be a positive int (rejects bools), `node` must exist in the SVG
- `SvgRenderer._apply_iconify()` replaces the target `<g>`'s children with the fetched icon SVG forced to `size x size`; failures are logged and leave the group empty
- `examples/IconKey.dsui` — end-to-end example matching the spec SVG
- Public re-exports: `IconifyBinding`, `IconifyError`, `fetch_icon`, `clear_iconify_cache`

### Tests

769 tests pass with 98.51% coverage. New tests cover schema defaults and immutability, all loader validation paths (missing/invalid/zero/negative/bool `size`, missing node), renderer behaviour (default icon embedded, set changes icon, `None`/`""` clear the group, existing children replaced, parse-error and fetch-error paths, full rasterise), fetch module (cache hits, distinct names cached separately, 404/network failures cached as negative lookups, `clear_cache` refetches), and end-to-end loading + rendering of the `IconKey.dsui` example.
