### PR TITLE
Remove index parameter from DsuiKey and DsuiCard constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ async def main():
         screen = deck.screen("main")
 
         # touchscreen card from .dsui
-        card = DsuiCard(0, audio_spec)
+        card = DsuiCard(audio_spec)
         card.set("title", "Bohemian Rhapsody")
         card.set("artist", "Queen")
         screen.set_card(0, card)
@@ -272,7 +272,7 @@ async def main():
             await deck.refresh()
 
         # key from .dsui
-        power = DsuiKey(0, power_spec)
+        power = DsuiKey(power_spec)
         power.set("ring_color", "#00ff00")
         screen.set_key(0, power)
 

--- a/docs/dsui.md
+++ b/docs/dsui.md
@@ -19,7 +19,7 @@ Load a package and use it as a card or key:
 from deckboard.dsui import load_package, DsuiCard, DsuiKey
 
 spec = load_package("./AudioCard.dsui")
-card = DsuiCard(0, spec)
+card = DsuiCard(spec)
 card.set("artist", "Ash Walker")
 
 @card.on("toggle_play_pause")
@@ -605,7 +605,7 @@ regions:
 from deckboard.dsui import load_package, DsuiCard
 
 spec = load_package("./AudioCard.dsui")
-card = DsuiCard(0, spec)
+card = DsuiCard(spec)
 
 card.set("artist", "Ash Walker").set("title", "Aquamarine")
 card.set("progress", 0.35)  # 35% through the track
@@ -663,7 +663,7 @@ events:
 from deckboard.dsui import load_package, DsuiKey
 
 spec = load_package("./PowerKey.dsui")
-key = DsuiKey(0, spec)
+key = DsuiKey(spec)
 
 key.set("label", "Shutdown")
 
@@ -720,7 +720,7 @@ events:
 from deckboard.dsui import load_package, DsuiCard
 
 spec = load_package("./VolumeSlider.dsui")
-card = DsuiCard(0, spec)
+card = DsuiCard(spec)
 
 volume = 0.5
 card.set("volume", volume)
@@ -775,7 +775,7 @@ events:
 from deckboard.dsui import load_package, DsuiKey
 
 spec = load_package("./LightsKey.dsui")
-key = DsuiKey(0, spec)
+key = DsuiKey(spec)
 
 lights_on = False
 
@@ -819,7 +819,7 @@ suffix and loads each one.  Non-`.dsui` directories are ignored.
 
 | Method / Property       | Description                                          |
 |-------------------------|------------------------------------------------------|
-| `DsuiCard(index, spec)` | Create a card for touch-strip zone `index` (0-3).    |
+| `DsuiCard(spec)`        | Create a card from a `.dsui` package.            |
 | `.set(name, value)`     | Set a binding value. Returns `self`.                 |
 | `.set_many(**kwargs)`   | Set multiple bindings at once. Returns `self`.       |
 | `.get(name)`            | Get the current value of a binding.                  |
@@ -832,7 +832,7 @@ suffix and loads each one.  Non-`.dsui` directories are ignored.
 
 | Method / Property          | Description                                       |
 |----------------------------|---------------------------------------------------|
-| `DsuiKey(index, spec)`     | Create a key for key index `index` (0-7).         |
+| `DsuiKey(spec)`            | Create a key from a `.dsui` package.              |
 | `.set(name, value)`        | Set a binding value. Returns `self`.              |
 | `.set_many(**kwargs)`      | Set multiple bindings at once. Returns `self`.    |
 | `.get(name)`               | Get the current value of a binding.               |

--- a/examples/brightness_slider.py
+++ b/examples/brightness_slider.py
@@ -32,7 +32,7 @@ async def main():
     async with Deck(brightness=80) as deck:
         screen = deck.screen("main")
 
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         brightness = 0.5
 
         card.set("brightness", brightness)

--- a/examples/dsui_packages.py
+++ b/examples/dsui_packages.py
@@ -46,7 +46,7 @@ async def main():
         screen = deck.screen("main")
 
         # Install the audio card on touch-strip zone 0
-        audio = DsuiCard(0, audio_spec)
+        audio = DsuiCard(audio_spec)
         audio.set("artist", "Ash Walker")
         audio.set("title", "Afghanistan")
         audio.set("album", "Echo Chamber (Deluxe)")
@@ -55,7 +55,7 @@ async def main():
         screen.set_card(0, audio)
 
         # Install the power key on key slot 7
-        power = DsuiKey(7, power_spec)
+        power = DsuiKey(power_spec)
         power.set("label", "Shutdown")
         power.set("ring_color", "#ff4444")
         power.set("line_color", "#ff4444")

--- a/examples/label_key.py
+++ b/examples/label_key.py
@@ -48,7 +48,7 @@ async def main():
     async with Deck(brightness=80) as deck:
         screen = deck.screen("main")
 
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         screen.set_key(0, key)
 
         label_index = 0

--- a/examples/lights_toggle.py
+++ b/examples/lights_toggle.py
@@ -37,7 +37,7 @@ async def main():
     async with Deck(brightness=80) as deck:
         screen = deck.screen("main")
 
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         screen.set_key(0, key)
 
         lights_on = False

--- a/examples/volume_slider.py
+++ b/examples/volume_slider.py
@@ -31,7 +31,7 @@ async def main():
     async with Deck(brightness=80) as deck:
         screen = deck.screen("main")
 
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         volume = 0.5
         muted = False
 

--- a/src/deckboard/dsui/__init__.py
+++ b/src/deckboard/dsui/__init__.py
@@ -8,7 +8,7 @@ Example::
     from deckboard.dsui import DsuiCard, load_package
 
     spec = load_package("./AudioCard.dsui")
-    card = DsuiCard(0, spec)
+    card = DsuiCard(spec)
     card.set("artist", "Ash Walker")
 
     @card.on("toggle_play_pause")

--- a/src/deckboard/dsui/card.py
+++ b/src/deckboard/dsui/card.py
@@ -31,20 +31,22 @@ class DsuiCard(Card):
         from deckboard.dsui import load_package, DsuiCard
 
         spec = load_package("./AudioCard.dsui")
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.set("artist", "Ash Walker")
 
         @card.on("toggle_play_pause")
         async def handle():
             ...
 
+    The card index is assigned automatically when you install the card
+    on a screen with :meth:`~deckboard.ui.screen.Screen.set_card`.
+
     Args:
-        index: Touch-strip zone index (0-3).
         spec: A validated :class:`~deckboard.dsui.schema.PackageSpec`.
     """
 
-    def __init__(self, index: int, spec: PackageSpec) -> None:
-        super().__init__(index)
+    def __init__(self, spec: PackageSpec) -> None:
+        super().__init__(-1)
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events, spec.regions)

--- a/src/deckboard/dsui/key.py
+++ b/src/deckboard/dsui/key.py
@@ -33,20 +33,22 @@ class DsuiKey(KeySlot):
         from deckboard.dsui import load_package, DsuiKey
 
         spec = load_package("./PowerKey.dsui")
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.set("label", "Shutdown")
 
         @key.on_event("activate")
         async def handle():
             ...
 
+    The key index is assigned automatically when you install the key
+    on a screen with :meth:`~deckboard.ui.screen.Screen.set_key`.
+
     Args:
-        index: Key index (0-7 for Stream Deck+).
         spec: A validated :class:`~deckboard.dsui.schema.PackageSpec`.
     """
 
-    def __init__(self, index: int, spec: PackageSpec) -> None:
-        super().__init__(index)
+    def __init__(self, spec: PackageSpec) -> None:
+        super().__init__(-1)
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events)

--- a/src/deckboard/ui/screen.py
+++ b/src/deckboard/ui/screen.py
@@ -72,6 +72,7 @@ class Screen:
             raise IndexError(f"Key index must be 0-{_KEY_COUNT - 1}, got {index}")
         if not isinstance(key, KeySlot):
             raise TypeError(f"Expected KeySlot, got {type(key).__name__}")
+        key._index = index
         self._keys[index] = key
 
     def encoder(self, index: int) -> EncoderSlot:

--- a/src/deckboard/ui/touch_strip.py
+++ b/src/deckboard/ui/touch_strip.py
@@ -54,6 +54,7 @@ class TouchStrip:
         if not isinstance(card, Card):
             msg = f"Expected a Card instance, got {type(card).__name__}"
             raise TypeError(msg)
+        card._index = index
         self._cards[index] = card
 
     @property

--- a/tests/test_dsui_card.py
+++ b/tests/test_dsui_card.py
@@ -19,6 +19,7 @@ from deckboard.dsui.schema import (
 )
 from deckboard.runtime.events import EventType, TouchEvent
 from deckboard.ui.cards.base import Card
+from deckboard.ui.screen import Screen
 
 
 # -- Helpers ---------------------------------------------------------------
@@ -50,15 +51,17 @@ def _make_card_spec(
 
 class TestDsuiCardIsCard:
     def test_is_card_subclass(self, card_package_spec):
-        card = DsuiCard(0, card_package_spec)
+        card = DsuiCard(card_package_spec)
         assert isinstance(card, Card)
 
-    def test_has_index(self, card_package_spec):
-        card = DsuiCard(2, card_package_spec)
+    def test_has_index_after_set_card(self, card_package_spec):
+        card = DsuiCard(card_package_spec)
+        screen = Screen("test")
+        screen.set_card(2, card)
         assert card.index == 2
 
     def test_has_spec(self, card_package_spec):
-        card = DsuiCard(0, card_package_spec)
+        card = DsuiCard(card_package_spec)
         assert card.spec is card_package_spec
 
 
@@ -67,7 +70,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         assert card.is_dirty is False
 
@@ -78,7 +81,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="Same")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         card.set("title", "Same")
         assert card.is_dirty is False
@@ -87,7 +90,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         result = card.set("title", "Test")
         assert result is card
 
@@ -95,7 +98,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         result = card.set_many(title="New")
         assert result is card
@@ -105,7 +108,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="Same")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         card.set_many(title="Same")
         assert card.is_dirty is False
@@ -114,20 +117,20 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="Init")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         assert card.get("title") == "Init"
         card.set("title", "Changed")
         assert card.get("title") == "Changed"
 
     def test_set_unknown_raises(self):
         spec = _make_card_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         with pytest.raises(KeyError):
             card.set("nonexistent", "val")
 
     def test_get_unknown_raises(self):
         spec = _make_card_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         with pytest.raises(KeyError):
             card.get("nonexistent")
 
@@ -135,7 +138,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"level": RangeBinding(node="bar", default=0.0)}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         card.set("level", 0.5)
         assert card.is_dirty is True
@@ -144,7 +147,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"level": RangeBinding(node="bar", default=0.5)}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         card.set("level", 0.5)
         assert card.is_dirty is False
@@ -153,7 +156,7 @@ class TestDsuiCardDataBinding:
         spec = _make_card_spec(
             bindings={"level": RangeBinding(node="bar", default=0.3)}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         assert card.get("level") == 0.3
         card.set("level", 0.8)
         assert card.get("level") == 0.8
@@ -183,28 +186,28 @@ class TestDsuiCardToggleBinding:
 
     def test_set_toggle_marks_dirty(self):
         spec = self._make_toggle_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         card.set("lights", True)
         assert card.is_dirty is True
 
     def test_set_toggle_same_value_not_dirty(self):
         spec = self._make_toggle_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         card.set("lights", False)  # same as default
         assert card.is_dirty is False
 
     def test_get_toggle_value(self):
         spec = self._make_toggle_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         assert card.get("lights") is False
         card.set("lights", True)
         assert card.get("lights") is True
 
     def test_toggle_renders_differently(self):
         spec = self._make_toggle_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         img_off = card.render()
 
         card.set("lights", True)
@@ -218,7 +221,7 @@ class TestDsuiCardRender:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="Hello")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         img = card.render()
         assert isinstance(img, Image.Image)
         assert img.mode == "RGB"
@@ -228,7 +231,7 @@ class TestDsuiCardRender:
         spec = _make_card_spec(
             bindings={"title": TextBinding(node="title", default="Hello")}
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         img1 = card.render()
         card.set("title", "World")
         img2 = card.render()
@@ -238,7 +241,7 @@ class TestDsuiCardRender:
 class TestDsuiCardPrepareAssets:
     async def test_prepare_assets_is_noop(self):
         spec = _make_card_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         await card.prepare_assets()
         # Should not raise or call anything
 
@@ -248,7 +251,7 @@ class TestDsuiCardEvents:
         spec = _make_card_spec(
             events=(EventMapping(name="play", source="encoder_press"),),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
 
         @card.on("play")
         async def handler():
@@ -260,7 +263,7 @@ class TestDsuiCardEvents:
         spec = _make_card_spec(
             events=(EventMapping(name="play", source="encoder_press"),),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("play", handler)
         # Event should be routed
@@ -275,7 +278,7 @@ class TestDsuiCardEvents:
                 EventMapping(name="next", source="encoder_turn", direction="right"),
             ),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("next", handler)
 
@@ -289,7 +292,7 @@ class TestDsuiCardEvents:
                 EventMapping(name="next", source="encoder_turn", direction="right"),
             ),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("next", handler)
 
@@ -301,7 +304,7 @@ class TestDsuiCardEvents:
         spec = _make_card_spec(
             events=(EventMapping(name="press", source="encoder_press"),),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("press", handler)
 
@@ -313,7 +316,7 @@ class TestDsuiCardEvents:
         spec = _make_card_spec(
             events=(EventMapping(name="release", source="encoder_release"),),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("release", handler)
 
@@ -329,7 +332,7 @@ class TestDsuiCardEvents:
                 Region(name="card", x=0, y=0, width=197, height=98, events=("tap",)),
             ),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("card_tap", handler)
 
@@ -339,7 +342,7 @@ class TestDsuiCardEvents:
 
     async def test_dispatch_touch_falls_back_to_base(self):
         spec = _make_card_spec()  # no events
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         base_handler = AsyncMock()
         card.on_tap(base_handler)
 
@@ -354,7 +357,7 @@ class TestDsuiCardEvents:
                 EventMapping(name="next", source="encoder_turn", direction="right"),
             ),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("next", handler)
 
@@ -368,7 +371,7 @@ class TestDsuiCardEvents:
         spec = _make_card_spec(
             events=(EventMapping(name="press", source="encoder_press"),),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("press", handler)
 
@@ -380,7 +383,7 @@ class TestDsuiCardEvents:
         spec = _make_card_spec(
             events=(EventMapping(name="release", source="encoder_release"),),
         )
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("release", handler)
 
@@ -395,12 +398,12 @@ class TestDsuiCardEvents:
 class TestDsuiCardDirtyTracking:
     def test_starts_dirty(self):
         spec = _make_card_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         assert card.is_dirty is True
 
     def test_mark_clean_and_dirty(self):
         spec = _make_card_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.mark_clean()
         assert card.is_dirty is False
         card.mark_dirty()
@@ -408,7 +411,7 @@ class TestDsuiCardDirtyTracking:
 
     def test_set_rendered_clears_dirty(self):
         spec = _make_card_spec()
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         img = Image.new("RGB", (197, 98))
         card.set_rendered(img)
         assert card.is_dirty is False

--- a/tests/test_dsui_integration.py
+++ b/tests/test_dsui_integration.py
@@ -65,13 +65,13 @@ def _card_spec() -> PackageSpec:
 class TestScreenSetKey:
     def test_set_key_installs_dsui_key(self):
         screen = Screen("test")
-        key = DsuiKey(0, _key_spec())
+        key = DsuiKey(_key_spec())
         screen.set_key(0, key)
         assert screen.keys[0] is key
 
     def test_set_key_validates_index(self):
         screen = Screen("test")
-        key = DsuiKey(0, _key_spec())
+        key = DsuiKey(_key_spec())
         with pytest.raises(IndexError):
             screen.set_key(8, key)
         with pytest.raises(IndexError):
@@ -85,7 +85,7 @@ class TestScreenSetKey:
     def test_set_key_replaces_existing(self):
         screen = Screen("test")
         old = screen.key(0)
-        new = DsuiKey(0, _key_spec())
+        new = DsuiKey(_key_spec())
         screen.set_key(0, new)
         assert screen.keys[0] is new
         assert screen.keys[0] is not old
@@ -100,7 +100,7 @@ class TestScreenSetKey:
 class TestScreenSetCard:
     def test_set_card_with_dsui_card(self):
         screen = Screen("test")
-        card = DsuiCard(0, _card_spec())
+        card = DsuiCard(_card_spec())
         screen.set_card(0, card)
         assert screen.card(0) is card
 
@@ -111,7 +111,7 @@ class TestDeckDsuiKeyRendering:
     def test_is_dsui_key_true(self):
         from deckboard.runtime.deck import Deck
 
-        key = DsuiKey(0, _key_spec())
+        key = DsuiKey(_key_spec())
         assert Deck._is_dsui_key(key) is True
 
     def test_is_dsui_key_false_for_regular(self):
@@ -207,7 +207,7 @@ class TestEndToEnd:
 
     def test_load_and_render_card(self, card_dsui_path):
         spec = load_package(card_dsui_path)
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         card.set("title", "Integration Test")
         img = card.render()
         assert isinstance(img, Image.Image)
@@ -215,7 +215,7 @@ class TestEndToEnd:
 
     def test_load_and_render_key(self, key_dsui_path):
         spec = load_package(key_dsui_path)
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.set("label", "Power")
         data = key.render_image()
         assert isinstance(data, bytes)
@@ -223,7 +223,7 @@ class TestEndToEnd:
 
     async def test_card_event_roundtrip(self, card_dsui_path):
         spec = load_package(card_dsui_path)
-        card = DsuiCard(0, spec)
+        card = DsuiCard(spec)
         handler = AsyncMock()
         card.bind_event("toggle_play", handler)
 
@@ -240,7 +240,7 @@ class TestEndToEnd:
 
     async def test_key_event_roundtrip(self, key_dsui_path):
         spec = load_package(key_dsui_path)
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         handler = AsyncMock()
         key.bind_event("activate", handler)
 
@@ -253,10 +253,10 @@ class TestEndToEnd:
         assert len(packages) == 2
 
         screen = Screen("test")
-        card = DsuiCard(0, packages["TestCard"])
+        card = DsuiCard(packages["TestCard"])
         screen.set_card(0, card)
 
-        key = DsuiKey(0, packages["TestKey"])
+        key = DsuiKey(packages["TestKey"])
         screen.set_key(0, key)
 
         assert screen.card(0) is card

--- a/tests/test_dsui_key.py
+++ b/tests/test_dsui_key.py
@@ -16,6 +16,7 @@ from deckboard.dsui.schema import (
     ToggleBinding,
 )
 from deckboard.ui.controls.key_slot import KeySlot
+from deckboard.ui.screen import Screen
 
 
 # -- Helpers ---------------------------------------------------------------
@@ -45,29 +46,31 @@ def _make_key_spec(
 class TestDsuiKeyIsKeySlot:
     def test_is_key_slot_subclass(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert isinstance(key, KeySlot)
 
-    def test_has_index(self):
+    def test_has_index_after_set_key(self):
         spec = _make_key_spec()
-        key = DsuiKey(3, spec)
+        key = DsuiKey(spec)
+        screen = Screen("test")
+        screen.set_key(3, key)
         assert key.index == 3
 
     def test_has_spec(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert key.spec is spec
 
     def test_has_dsui_content(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert key.has_dsui_content is True
 
 
 class TestDsuiKeyDataBinding:
     def test_set_marks_dirty(self):
         spec = _make_key_spec(bindings={"label": TextBinding(node="label", default="")})
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         key.set("label", "Hello")
         assert key.is_dirty is True
@@ -76,19 +79,19 @@ class TestDsuiKeyDataBinding:
         spec = _make_key_spec(
             bindings={"label": TextBinding(node="label", default="Same")}
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         key.set("label", "Same")
         assert key.is_dirty is False
 
     def test_set_returns_self(self):
         spec = _make_key_spec(bindings={"label": TextBinding(node="label", default="")})
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert key.set("label", "Test") is key
 
     def test_set_many(self):
         spec = _make_key_spec(bindings={"label": TextBinding(node="label", default="")})
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         result = key.set_many(label="New")
         assert result is key
@@ -98,7 +101,7 @@ class TestDsuiKeyDataBinding:
         spec = _make_key_spec(
             bindings={"label": TextBinding(node="label", default="Same")}
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         key.set_many(label="Same")
         assert key.is_dirty is False
@@ -107,18 +110,18 @@ class TestDsuiKeyDataBinding:
         spec = _make_key_spec(
             bindings={"label": TextBinding(node="label", default="Init")}
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert key.get("label") == "Init"
 
     def test_set_unknown_raises(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         with pytest.raises(KeyError):
             key.set("nope", "val")
 
     def test_get_unknown_raises(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         with pytest.raises(KeyError):
             key.get("nope")
 
@@ -128,7 +131,7 @@ class TestDsuiKeyRender:
         spec = _make_key_spec(
             bindings={"label": TextBinding(node="label", default="Test")}
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         data = key.render_image()
         assert isinstance(data, bytes)
         assert len(data) > 0
@@ -137,7 +140,7 @@ class TestDsuiKeyRender:
 
     def test_render_image_is_120x120(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         data = key.render_image()
         import io
 
@@ -159,7 +162,7 @@ class TestDsuiKeyRender:
             svg_source=svg,
             bindings={"label": TextBinding(node="label", default="Hi")},
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         data = key.render_image()
         import io
 
@@ -191,28 +194,28 @@ class TestDsuiKeyToggleBinding:
 
     def test_set_toggle_marks_dirty(self):
         spec = self._make_toggle_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         key.set("state", True)
         assert key.is_dirty is True
 
     def test_set_toggle_same_value_not_dirty(self):
         spec = self._make_toggle_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         key.set("state", False)  # same as default
         assert key.is_dirty is False
 
     def test_get_toggle_value(self):
         spec = self._make_toggle_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert key.get("state") is False
         key.set("state", True)
         assert key.get("state") is True
 
     def test_toggle_renders_different_images(self):
         spec = self._make_toggle_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         data_off = key.render_image()
 
         key.set("state", True)
@@ -226,7 +229,7 @@ class TestDsuiKeyEvents:
         spec = _make_key_spec(
             events=(EventMapping(name="activate", source="key_press"),),
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
 
         @key.on_event("activate")
         async def handler():
@@ -238,7 +241,7 @@ class TestDsuiKeyEvents:
         spec = _make_key_spec(
             events=(EventMapping(name="activate", source="key_press"),),
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         handler = AsyncMock()
         key.bind_event("activate", handler)
 
@@ -246,7 +249,7 @@ class TestDsuiKeyEvents:
         spec = _make_key_spec(
             events=(EventMapping(name="activate", source="key_press"),),
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         handler = AsyncMock()
         key.bind_event("activate", handler)
 
@@ -257,7 +260,7 @@ class TestDsuiKeyEvents:
         spec = _make_key_spec(
             events=(EventMapping(name="up", source="key_release"),),
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         handler = AsyncMock()
         key.bind_event("up", handler)
 
@@ -267,7 +270,7 @@ class TestDsuiKeyEvents:
 
     async def test_dispatch_falls_back_to_base(self):
         spec = _make_key_spec()  # no events
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         base_handler = AsyncMock()
         key.on_press(base_handler)
 
@@ -276,7 +279,7 @@ class TestDsuiKeyEvents:
 
     async def test_dispatch_release_falls_back(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         base_handler = AsyncMock()
         key.on_release(base_handler)
 
@@ -291,7 +294,7 @@ class TestDsuiKeyEvents:
                 ),
             ),
         )
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         handler = AsyncMock()
         key.bind_event("tap", handler)
 
@@ -303,17 +306,17 @@ class TestDsuiKeyEvents:
 class TestDsuiKeyDirtyTracking:
     def test_starts_dirty(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         assert key.is_dirty is True
 
     def test_set_rendered_image_clears_dirty(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.set_rendered_image(b"\xff\xd8fake_jpeg")
         assert key.is_dirty is False
 
     def test_mark_clean(self):
         spec = _make_key_spec()
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         key.mark_clean()
         assert key.is_dirty is False

--- a/tests/test_iconify_example.py
+++ b/tests/test_iconify_example.py
@@ -61,14 +61,14 @@ class TestIconKeyExamplePackage:
 
     def test_dsui_key_renders_with_icon(self, patch_fetch):
         spec = load_package(_EXAMPLE_DIR)
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         jpeg_bytes = key.render_image()
         assert isinstance(jpeg_bytes, (bytes, bytearray))
         assert len(jpeg_bytes) > 0
 
     def test_dsui_key_updates_label_and_icon(self, patch_fetch):
         spec = load_package(_EXAMPLE_DIR)
-        key = DsuiKey(0, spec)
+        key = DsuiKey(spec)
         # set() returns self for chaining.
         assert key.set("label", "Home") is key
         assert key.set("icon", "line-md:settings") is key


### PR DESCRIPTION
## Summary

- Remove the redundant `index` parameter from `DsuiKey` and `DsuiCard` constructors — the position is now assigned automatically by `set_key()` / `set_card()`
- Fix a latent bug where mismatched indices between the constructor and `set_key`/`set_card` would cause `deck.py` to render to the wrong physical key
- Update all tests, examples, and documentation to use the new `DsuiKey(spec)` / `DsuiCard(spec)` API

## API change

Before:
```python
key = DsuiKey(7, spec)
screen.set_key(7, key)
```

After:
```python
key = DsuiKey(spec)
screen.set_key(7, key)
```

All 770 tests pass with 98.67% coverage.