### PR TITLE
Add 'color' as valid attribute for ColorBinding

### DIFF
--- a/src/deckboard/dsui/schema.py
+++ b/src/deckboard/dsui/schema.py
@@ -85,13 +85,24 @@ class VisibilityBinding:
     default: bool = True
 
 
+_COLOR_ATTRIBUTES: frozenset[str] = frozenset({"fill", "stroke", "color"})
+
+
 @dataclass(frozen=True, slots=True)
 class ColorBinding:
-    """Bind a colour value to an SVG element's fill or stroke."""
+    """Bind a colour value to an SVG element's fill, stroke, or color."""
 
     node: str
     attribute: str = "fill"
     default: str = "#ffffff"
+
+    def __post_init__(self) -> None:
+        if self.attribute not in _COLOR_ATTRIBUTES:
+            msg = (
+                f"Invalid color attribute {self.attribute!r}; "
+                f"must be one of {sorted(_COLOR_ATTRIBUTES)}"
+            )
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/deckboard/dsui/svg_renderer.py
+++ b/src/deckboard/dsui/svg_renderer.py
@@ -583,7 +583,7 @@ class SvgRenderer:
                 elem_on.set("display", "none")
 
     def _apply_color(self, elem: ET.Element, binding: ColorBinding, value: Any) -> None:
-        """Set an element's fill or stroke colour."""
+        """Set an element's fill, stroke, or color attribute."""
         color_val = str(value) if value is not None else binding.default
         elem.set(binding.attribute, color_val)
 

--- a/tests/test_dsui_schema.py
+++ b/tests/test_dsui_schema.py
@@ -174,6 +174,14 @@ class TestColorBinding:
         b = ColorBinding(node="border", attribute="stroke", default="#000000")
         assert b.attribute == "stroke"
 
+    def test_color(self):
+        b = ColorBinding(node="group", attribute="color", default="#00ff00")
+        assert b.attribute == "color"
+
+    def test_invalid_attribute_raises(self):
+        with pytest.raises(ValueError, match="Invalid color attribute"):
+            ColorBinding(node="bg", attribute="opacity")
+
 
 class TestRangeDirection:
     def test_modes(self):

--- a/tests/test_dsui_svg_renderer.py
+++ b/tests/test_dsui_svg_renderer.py
@@ -317,6 +317,30 @@ class TestSvgRendererRender:
 
         assert img_red.tobytes() != img_blue.tobytes()
 
+    def test_color_binding_color_attribute(self):
+        """The 'color' attribute is set on <g> elements for currentColor use."""
+        svg = (
+            '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="50">'
+            '<g id="group" color="#ff0000">'
+            '<rect width="100" height="50" fill="currentColor"/>'
+            "</g></svg>"
+        )
+        spec = _make_spec(
+            svg,
+            bindings={
+                "group_color": ColorBinding(
+                    node="group", attribute="color", default="#ff0000"
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        img_default = renderer.render()
+
+        renderer.set("group_color", "#00ff00")
+        img_changed = renderer.render()
+
+        assert img_default.tobytes() != img_changed.tobytes()
+
     def test_image_binding_with_pil(self):
         spec = _make_spec(
             _IMAGE_SVG,


### PR DESCRIPTION
## Summary
- Adds `color` to the allowed `attribute` values for `ColorBinding` (alongside `fill` and `stroke`), enabling setting the CSS `color` property on `<g>` elements so child elements can use `currentColor`.
- Adds `__post_init__` validation to `ColorBinding` that rejects invalid attribute values with a clear error message.
- Adds tests for the new `color` attribute in both schema and renderer test suites.