### PR TITLE
Add domain-scale range helpers (set_range, adjust_range, get_range)

### DIFF
--- a/docs/dsui.md
+++ b/docs/dsui.md
@@ -792,16 +792,13 @@ from deckboard.dsui import load_package, DsuiCard
 spec = load_package("./VolumeSlider.dsui")
 card = DsuiCard(spec)
 
-volume = 0.5
-card.set("volume", volume)
-card.set("value_text", f"{int(volume * 100)}%")
+card.set_range("volume", 50, min_val=0, max_val=100)
+card.set("value_text", "50%")
 
 @card.on("volume_up")
 async def up():
-    nonlocal volume
-    volume = min(1.0, volume + 0.05)
-    card.set("volume", volume)
-    card.set("value_text", f"{int(volume * 100)}%")
+    vol = card.adjust_range("volume", 5, min_val=0, max_val=100)
+    card.set("value_text", f"{int(vol)}%")
 
 @card.on("mute_toggle")
 async def mute():
@@ -893,6 +890,9 @@ suffix and loads each one.  Non-`.dsui` directories are ignored.
 | `.set(name, value)`     | Set a binding value. Returns `self`.                 |
 | `.set_many(**kwargs)`   | Set multiple bindings at once. Returns `self`.       |
 | `.get(name)`            | Get the current value of a binding.                  |
+| `.set_range(name, value, *, min_val, max_val)` | Set a range/slider binding in domain units. Normalises to 0–1. Returns `self`. |
+| `.adjust_range(name, delta, *, min_val, max_val)` | Adjust a range/slider by delta domain units. Returns the new domain value. |
+| `.get_range(name, *, min_val, max_val)` | Get a range/slider binding denormalised to domain units. |
 | `.on(event_name)`       | Decorator to register an async event handler.        |
 | `.bind_event(name, fn)` | Imperatively register an async event handler.        |
 | `.spec`                 | The `PackageSpec` backing this card.                 |
@@ -906,6 +906,9 @@ suffix and loads each one.  Non-`.dsui` directories are ignored.
 | `.set(name, value)`        | Set a binding value. Returns `self`.              |
 | `.set_many(**kwargs)`      | Set multiple bindings at once. Returns `self`.    |
 | `.get(name)`               | Get the current value of a binding.               |
+| `.set_range(name, value, *, min_val, max_val)` | Set a range/slider binding in domain units. Returns `self`. |
+| `.adjust_range(name, delta, *, min_val, max_val)` | Adjust a range/slider by delta domain units. Returns the new domain value. |
+| `.get_range(name, *, min_val, max_val)` | Get a range/slider binding denormalised to domain units. |
 | `.on_event(event_name)`    | Decorator to register an async event handler.     |
 | `.bind_event(name, fn)`    | Imperatively register an async event handler.     |
 | `.spec`                    | The `PackageSpec` backing this key.               |

--- a/examples/brightness_slider.py
+++ b/examples/brightness_slider.py
@@ -33,39 +33,32 @@ async def main():
         screen = deck.screen("main")
 
         card = DsuiCard(spec)
-        brightness = 0.5
 
-        card.set("brightness", brightness)
-        card.set("value_text", f"{int(brightness * 100)}%")
+        card.set_range("brightness", 50, min_val=0, max_val=100)
+        card.set("value_text", "50%")
         screen.set_card(0, card)
 
         @card.on("brightness_up")
         async def on_up():
-            nonlocal brightness
-            brightness = min(1.0, brightness + 0.05)
-            card.set("brightness", brightness)
-            card.set("value_text", f"{int(brightness * 100)}%")
-            deck.set_brightness(int(brightness * 100))
-            print(f"Brightness: {int(brightness * 100)}%")
+            val = card.adjust_range("brightness", 5, min_val=0, max_val=100)
+            card.set("value_text", f"{int(val)}%")
+            deck.set_brightness(int(val))
+            print(f"Brightness: {int(val)}%")
             await deck.refresh()
 
         @card.on("brightness_down")
         async def on_down():
-            nonlocal brightness
-            brightness = max(0.0, brightness - 0.05)
-            card.set("brightness", brightness)
-            card.set("value_text", f"{int(brightness * 100)}%")
-            deck.set_brightness(int(brightness * 100))
-            print(f"Brightness: {int(brightness * 100)}%")
+            val = card.adjust_range("brightness", -5, min_val=0, max_val=100)
+            card.set("value_text", f"{int(val)}%")
+            deck.set_brightness(int(val))
+            print(f"Brightness: {int(val)}%")
             await deck.refresh()
 
         @card.on("brightness_reset")
         async def on_reset():
-            nonlocal brightness
-            brightness = 0.5
-            card.set("brightness", brightness)
-            card.set("value_text", f"{int(brightness * 100)}%")
-            deck.set_brightness(int(brightness * 100))
+            card.set_range("brightness", 50, min_val=0, max_val=100)
+            card.set("value_text", "50%")
+            deck.set_brightness(50)
             print("Brightness reset to 50%")
             await deck.refresh()
 

--- a/examples/volume_slider.py
+++ b/examples/volume_slider.py
@@ -32,31 +32,26 @@ async def main():
         screen = deck.screen("main")
 
         card = DsuiCard(spec)
-        volume = 0.5
         muted = False
 
-        card.set("volume", volume)
-        card.set("value_text", f"{int(volume * 100)}%")
+        card.set_range("volume", 50, min_val=0, max_val=100)
+        card.set("value_text", "50%")
         screen.set_card(0, card)
 
         @card.on("volume_up")
         async def on_up():
-            nonlocal volume
-            volume = min(1.0, volume + 0.05)
-            card.set("volume", volume)
-            card.set("value_text", f"{int(volume * 100)}%")
+            vol = card.adjust_range("volume", 5, min_val=0, max_val=100)
+            card.set("value_text", f"{int(vol)}%")
             if muted:
                 card.set("bar_color", "#dedede")
-            print(f"Volume: {int(volume * 100)}%")
+            print(f"Volume: {int(vol)}%")
             await deck.refresh()
 
         @card.on("volume_down")
         async def on_down():
-            nonlocal volume
-            volume = max(0.0, volume - 0.05)
-            card.set("volume", volume)
-            card.set("value_text", f"{int(volume * 100)}%")
-            print(f"Volume: {int(volume * 100)}%")
+            vol = card.adjust_range("volume", -5, min_val=0, max_val=100)
+            card.set("value_text", f"{int(vol)}%")
+            print(f"Volume: {int(vol)}%")
             await deck.refresh()
 
         @card.on("mute_toggle")
@@ -68,7 +63,8 @@ async def main():
                 card.set("value_text", "MUTED")
             else:
                 card.set("bar_color", "#dedede")
-                card.set("value_text", f"{int(volume * 100)}%")
+                vol = card.get_range("volume", min_val=0, max_val=100)
+                card.set("value_text", f"{int(vol)}%")
             print(f"{'Muted' if muted else 'Unmuted'}")
             await deck.refresh()
 

--- a/src/deckboard/dsui/card.py
+++ b/src/deckboard/dsui/card.py
@@ -93,6 +93,89 @@ class DsuiCard(Card):
         """
         return self._renderer.get(name)
 
+    # -- Domain-scale range helpers ----------------------------------------
+
+    def set_range(
+        self, name: str, value: float, *, min_val: float = 0, max_val: float = 1
+    ) -> DsuiCard:
+        """Set a range/slider binding using a domain-scale value.
+
+        Normalises *value* from ``[min_val, max_val]`` to ``[0.0, 1.0]``
+        and delegates to :meth:`set`.
+
+        Args:
+            name: Binding name (must be a ``range`` or ``slider`` binding).
+            value: Value in domain units (e.g. 0–100 for a percentage).
+            min_val: Lower bound of the domain range.
+            max_val: Upper bound of the domain range.
+
+        Returns:
+            self, for method chaining.
+
+        Raises:
+            KeyError: If *name* is not a known binding.
+            ValueError: If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+        clamped = max(min_val, min(max_val, value))
+        normalised = (clamped - min_val) / (max_val - min_val)
+        return self.set(name, normalised)
+
+    def adjust_range(
+        self, name: str, delta: float, *, min_val: float = 0, max_val: float = 1
+    ) -> float:
+        """Adjust a range/slider binding by *delta* domain-scale units.
+
+        Reads the current normalised value, denormalises it, adds *delta*,
+        clamps, re-normalises, and calls :meth:`set`.
+
+        Args:
+            name: Binding name (must be a ``range`` or ``slider`` binding).
+            delta: Amount to add in domain units (negative to decrease).
+            min_val: Lower bound of the domain range.
+            max_val: Upper bound of the domain range.
+
+        Returns:
+            The new value in domain units (clamped to
+            ``[min_val, max_val]``), so callers can use it for display
+            without back-computing.
+
+        Raises:
+            KeyError: If *name* is not a known binding.
+            ValueError: If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+        current_norm = float(self.get(name) or 0.0)
+        current_domain = min_val + current_norm * (max_val - min_val)
+        new_domain = max(min_val, min(max_val, current_domain + delta))
+        normalised = (new_domain - min_val) / (max_val - min_val)
+        self.set(name, normalised)
+        return new_domain
+
+    def get_range(
+        self, name: str, *, min_val: float = 0, max_val: float = 1
+    ) -> float:
+        """Get a range/slider binding denormalised to domain units.
+
+        Args:
+            name: Binding name.
+            min_val: Lower bound of the domain range.
+            max_val: Upper bound of the domain range.
+
+        Returns:
+            The current value in domain units.
+
+        Raises:
+            KeyError: If *name* is not a known binding.
+            ValueError: If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+        current_norm = float(self.get(name) or 0.0)
+        return min_val + current_norm * (max_val - min_val)
+
     # -- Semantic event API ------------------------------------------------
 
     def on(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:

--- a/src/deckboard/dsui/key.py
+++ b/src/deckboard/dsui/key.py
@@ -97,6 +97,89 @@ class DsuiKey(KeySlot):
         """
         return self._renderer.get(name)
 
+    # -- Domain-scale range helpers ----------------------------------------
+
+    def set_range(
+        self, name: str, value: float, *, min_val: float = 0, max_val: float = 1
+    ) -> DsuiKey:
+        """Set a range/slider binding using a domain-scale value.
+
+        Normalises *value* from ``[min_val, max_val]`` to ``[0.0, 1.0]``
+        and delegates to :meth:`set`.
+
+        Args:
+            name: Binding name (must be a ``range`` or ``slider`` binding).
+            value: Value in domain units (e.g. 0–100 for a percentage).
+            min_val: Lower bound of the domain range.
+            max_val: Upper bound of the domain range.
+
+        Returns:
+            self, for method chaining.
+
+        Raises:
+            KeyError: If *name* is not a known binding.
+            ValueError: If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+        clamped = max(min_val, min(max_val, value))
+        normalised = (clamped - min_val) / (max_val - min_val)
+        return self.set(name, normalised)
+
+    def adjust_range(
+        self, name: str, delta: float, *, min_val: float = 0, max_val: float = 1
+    ) -> float:
+        """Adjust a range/slider binding by *delta* domain-scale units.
+
+        Reads the current normalised value, denormalises it, adds *delta*,
+        clamps, re-normalises, and calls :meth:`set`.
+
+        Args:
+            name: Binding name (must be a ``range`` or ``slider`` binding).
+            delta: Amount to add in domain units (negative to decrease).
+            min_val: Lower bound of the domain range.
+            max_val: Upper bound of the domain range.
+
+        Returns:
+            The new value in domain units (clamped to
+            ``[min_val, max_val]``), so callers can use it for display
+            without back-computing.
+
+        Raises:
+            KeyError: If *name* is not a known binding.
+            ValueError: If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+        current_norm = float(self.get(name) or 0.0)
+        current_domain = min_val + current_norm * (max_val - min_val)
+        new_domain = max(min_val, min(max_val, current_domain + delta))
+        normalised = (new_domain - min_val) / (max_val - min_val)
+        self.set(name, normalised)
+        return new_domain
+
+    def get_range(
+        self, name: str, *, min_val: float = 0, max_val: float = 1
+    ) -> float:
+        """Get a range/slider binding denormalised to domain units.
+
+        Args:
+            name: Binding name.
+            min_val: Lower bound of the domain range.
+            max_val: Upper bound of the domain range.
+
+        Returns:
+            The current value in domain units.
+
+        Raises:
+            KeyError: If *name* is not a known binding.
+            ValueError: If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+        current_norm = float(self.get(name) or 0.0)
+        return min_val + current_norm * (max_val - min_val)
+
     # -- Semantic event API ------------------------------------------------
 
     def on_event(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:

--- a/tests/test_dsui_card.py
+++ b/tests/test_dsui_card.py
@@ -162,6 +162,118 @@ class TestDsuiCardDataBinding:
         assert card.get("level") == 0.8
 
 
+class TestDsuiCardRangeHelpers:
+    """Tests for set_range, adjust_range, and get_range helpers."""
+
+    def _make_range_card(self, default: float = 0.0) -> DsuiCard:
+        spec = _make_card_spec(
+            bindings={"level": RangeBinding(node="bar", default=default)}
+        )
+        return DsuiCard(spec)
+
+    # -- set_range ---------------------------------------------------------
+
+    def test_set_range_normalises(self):
+        card = self._make_range_card()
+        card.set_range("level", 50, min_val=0, max_val=100)
+        assert card.get("level") == pytest.approx(0.5)
+
+    def test_set_range_clamps_high(self):
+        card = self._make_range_card()
+        card.set_range("level", 200, min_val=0, max_val=100)
+        assert card.get("level") == pytest.approx(1.0)
+
+    def test_set_range_clamps_low(self):
+        card = self._make_range_card()
+        card.set_range("level", -10, min_val=0, max_val=100)
+        assert card.get("level") == pytest.approx(0.0)
+
+    def test_set_range_returns_self(self):
+        card = self._make_range_card()
+        result = card.set_range("level", 50, min_val=0, max_val=100)
+        assert result is card
+
+    def test_set_range_marks_dirty(self):
+        card = self._make_range_card()
+        card.mark_clean()
+        card.set_range("level", 50, min_val=0, max_val=100)
+        assert card.is_dirty is True
+
+    def test_set_range_equal_min_max_raises(self):
+        card = self._make_range_card()
+        with pytest.raises(ValueError, match="must not be equal"):
+            card.set_range("level", 5, min_val=5, max_val=5)
+
+    def test_set_range_unknown_binding_raises(self):
+        card = self._make_range_card()
+        with pytest.raises(KeyError):
+            card.set_range("nonexistent", 50, min_val=0, max_val=100)
+
+    def test_set_range_custom_domain(self):
+        card = self._make_range_card()
+        card.set_range("level", 4000, min_val=2000, max_val=6000)
+        assert card.get("level") == pytest.approx(0.5)
+
+    # -- adjust_range ------------------------------------------------------
+
+    def test_adjust_range_increment(self):
+        card = self._make_range_card(default=0.5)
+        new_val = card.adjust_range("level", 10, min_val=0, max_val=100)
+        assert new_val == pytest.approx(60.0)
+        assert card.get("level") == pytest.approx(0.6)
+
+    def test_adjust_range_decrement(self):
+        card = self._make_range_card(default=0.5)
+        new_val = card.adjust_range("level", -20, min_val=0, max_val=100)
+        assert new_val == pytest.approx(30.0)
+        assert card.get("level") == pytest.approx(0.3)
+
+    def test_adjust_range_clamps_at_max(self):
+        card = self._make_range_card(default=0.9)
+        new_val = card.adjust_range("level", 20, min_val=0, max_val=100)
+        assert new_val == pytest.approx(100.0)
+        assert card.get("level") == pytest.approx(1.0)
+
+    def test_adjust_range_clamps_at_min(self):
+        card = self._make_range_card(default=0.1)
+        new_val = card.adjust_range("level", -20, min_val=0, max_val=100)
+        assert new_val == pytest.approx(0.0)
+        assert card.get("level") == pytest.approx(0.0)
+
+    def test_adjust_range_marks_dirty(self):
+        card = self._make_range_card(default=0.5)
+        card.mark_clean()
+        card.adjust_range("level", 5, min_val=0, max_val=100)
+        assert card.is_dirty is True
+
+    def test_adjust_range_equal_min_max_raises(self):
+        card = self._make_range_card()
+        with pytest.raises(ValueError, match="must not be equal"):
+            card.adjust_range("level", 5, min_val=5, max_val=5)
+
+    # -- get_range ---------------------------------------------------------
+
+    def test_get_range_denormalises(self):
+        card = self._make_range_card(default=0.75)
+        val = card.get_range("level", min_val=0, max_val=100)
+        assert val == pytest.approx(75.0)
+
+    def test_get_range_custom_domain(self):
+        card = self._make_range_card(default=0.5)
+        val = card.get_range("level", min_val=2000, max_val=6000)
+        assert val == pytest.approx(4000.0)
+
+    def test_get_range_equal_min_max_raises(self):
+        card = self._make_range_card()
+        with pytest.raises(ValueError, match="must not be equal"):
+            card.get_range("level", min_val=5, max_val=5)
+
+    def test_get_range_unknown_binding_raises(self):
+        card = self._make_range_card()
+        with pytest.raises(KeyError):
+            card.get_range("nonexistent", min_val=0, max_val=100)
+
+
 class TestDsuiCardToggleBinding:
     _TOGGLE_CARD_SVG = (
         '<svg id="TC" xmlns="http://www.w3.org/2000/svg" width="197" height="98">'

--- a/tests/test_dsui_key.py
+++ b/tests/test_dsui_key.py
@@ -12,6 +12,7 @@ from deckboard.dsui.schema import (
     EventMapping,
     PackageSpec,
     PackageType,
+    RangeBinding,
     TextBinding,
     ToggleBinding,
 )
@@ -320,3 +321,60 @@ class TestDsuiKeyDirtyTracking:
         key = DsuiKey(spec)
         key.mark_clean()
         assert key.is_dirty is False
+
+
+_KEY_BAR_SVG = (
+    '<svg id="TestKey" xmlns="http://www.w3.org/2000/svg" width="120" height="120">'
+    '<rect id="bg" width="120" height="120" fill="#1c1c1c"/>'
+    '<rect id="bar" x="4" y="100" width="112" height="4" fill="#00ff00"/>'
+    "</svg>"
+)
+
+
+class TestDsuiKeyRangeHelpers:
+    """Tests for set_range, adjust_range, and get_range on DsuiKey."""
+
+    def _make_range_key(self, default: float = 0.0) -> DsuiKey:
+        spec = PackageSpec(
+            name="TestKey",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_KEY_BAR_SVG,
+            bindings={"level": RangeBinding(node="bar", default=default)},
+            events=(),
+        )
+        return DsuiKey(spec)
+
+    def test_set_range_normalises(self):
+        key = self._make_range_key()
+        key.set_range("level", 50, min_val=0, max_val=100)
+        assert key.get("level") == pytest.approx(0.5)
+
+    def test_set_range_returns_self(self):
+        key = self._make_range_key()
+        result = key.set_range("level", 50, min_val=0, max_val=100)
+        assert result is key
+
+    def test_set_range_clamps(self):
+        key = self._make_range_key()
+        key.set_range("level", 200, min_val=0, max_val=100)
+        assert key.get("level") == pytest.approx(1.0)
+
+    def test_adjust_range(self):
+        key = self._make_range_key(default=0.5)
+        new_val = key.adjust_range("level", 10, min_val=0, max_val=100)
+        assert new_val == pytest.approx(60.0)
+
+    def test_get_range(self):
+        key = self._make_range_key(default=0.75)
+        val = key.get_range("level", min_val=0, max_val=100)
+        assert val == pytest.approx(75.0)
+
+    def test_equal_min_max_raises(self):
+        key = self._make_range_key()
+        with pytest.raises(ValueError):
+            key.set_range("level", 5, min_val=5, max_val=5)
+        with pytest.raises(ValueError):
+            key.adjust_range("level", 1, min_val=5, max_val=5)
+        with pytest.raises(ValueError):
+            key.get_range("level", min_val=5, max_val=5)


### PR DESCRIPTION
## Summary

- Add `set_range()`, `adjust_range()`, and `get_range()` methods to both `DsuiCard` and `DsuiKey`
- These helpers normalise domain-scale values (e.g. 0–100, 2000–6535) to the 0.0–1.0 range that range/slider bindings expect, eliminating manual arithmetic in handler code
- Update `examples/volume_slider.py` and `examples/brightness_slider.py` to use the new helpers
- Update `docs/dsui.md` API summary tables and code examples

## Before / After

```python
# BEFORE — manual normalisation, nonlocal tracking, clamping
env_brightness = max(0, env_brightness - 5)
await deck.set_brightness(env_brightness)
environment.set("brightness", env_brightness / 100)

# AFTER — one call handles it all
val = environment.adjust_range("brightness", -5, min_val=0, max_val=100)
await deck.set_brightness(int(val))
```

## New API

| Method | Returns | Description |
|--------|---------|-------------|
| `set_range(name, value, *, min_val, max_val)` | `self` | Set a range binding using domain units |
| `adjust_range(name, delta, *, min_val, max_val)` | `float` | Adjust by delta, returns new domain value |
| `get_range(name, *, min_val, max_val)` | `float` | Get current value in domain units |

All three raise `ValueError` if `min_val == max_val` and `KeyError` for unknown bindings.