### PR TITLE
Add third-party notices and README acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,17 @@ mypy src/deckboard/
 | `RasterizeError` | SVG rasterisation failure |
 | `PackageError` | Invalid .dsui manifest or layout |
 
+## Acknowledgments
+
+Deckboard is built on these excellent open-source libraries:
+
+- **[python-elgato-streamdeck](https://github.com/abcminiuser/python-elgato-streamdeck)** — Low-level HID interface for Stream Deck devices (MIT)
+- **[Pillow](https://github.com/python-pillow/Pillow)** — Image processing and rendering (HPND)
+- **[CairoSVG](https://github.com/Kozea/CairoSVG)** — SVG-to-PNG rasterisation (LGPL-3.0)
+- **[PyYAML](https://github.com/yaml/pyyaml)** — YAML parsing for .dsui manifests (MIT)
+
+See [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) for full license texts.
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,126 @@
+# Third-Party Notices
+
+Deckboard depends on the following open-source libraries. We are grateful to
+their authors and contributors.
+
+---
+
+## python-elgato-streamdeck (streamdeck)
+
+- **Repository:** <https://github.com/abcminiuser/python-elgato-streamdeck>
+- **License:** MIT
+
+```
+MIT License
+
+Copyright (c) Dean Camera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## Pillow
+
+- **Repository:** <https://github.com/python-pillow/Pillow>
+- **License:** HPND (Historical Permission Notice and Disclaimer)
+
+```
+The Python Imaging Library (PIL) is
+
+    Copyright © 1997-2011 by Secret Labs AB
+    Copyright © 1995-2011 by Fredrik Lundh and contributors
+
+Pillow is the friendly PIL fork. It is
+
+    Copyright © 2010-2024 by Jeffrey A. Clark and contributors
+
+Like PIL, Pillow is licensed under the open source HPND License:
+
+By obtaining, using, and/or copying this software and/or its associated
+documentation, you agree that you have read, understood, and will comply with
+the following terms and conditions:
+
+Permission to use, copy, modify and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided that
+the above copyright notice appears in all copies, and that both that copyright
+notice and this permission notice appear in supporting documentation, and that
+the name of Secret Labs AB or the author not be used in advertising or
+publicity pertaining to distribution of the software without specific, written
+prior permission.
+
+SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN
+NO EVENT SHALL SECRET LABS AB OR THE AUTHOR BE LIABLE FOR ANY SPECIAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
+---
+
+## CairoSVG
+
+- **Repository:** <https://github.com/Kozea/CairoSVG>
+- **License:** LGPL-3.0
+
+```
+CairoSVG is free software: you can redistribute it and/or modify it under the
+terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+CairoSVG is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with CairoSVG. If not, see <https://www.gnu.org/licenses/>.
+```
+
+---
+
+## PyYAML
+
+- **Repository:** <https://github.com/yaml/pyyaml>
+- **License:** MIT
+
+```
+Copyright (c) 2017-2021 Ingy döt Net
+Copyright (c) 2006-2016 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```


### PR DESCRIPTION
## Summary
- Add `THIRD-PARTY-NOTICES.md` with full license texts for all runtime dependencies (python-elgato-streamdeck, Pillow, CairoSVG, PyYAML)
- Add Acknowledgments section to `README.md` linking to each library and the notices file