### PR TITLE
Add reasonable defaults for max_duration_ms and hold_ms

### DIFF
--- a/src/deckboard/dsui/loader.py
+++ b/src/deckboard/dsui/loader.py
@@ -14,6 +14,8 @@ from .schema import (
     BindingType,
     ColorBinding,
     EventMapping,
+    DEFAULT_HOLD_MS,
+    DEFAULT_MAX_DURATION_MS,
     HOLD_SOURCES,
     IconifyBinding,
     ImageBinding,
@@ -37,6 +39,9 @@ logger = logging.getLogger(__name__)
 
 # SVG namespace used by ElementTree
 _SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+
+# Sources that accept max_duration_ms.
+_PRESS_RELEASE_SOURCES = frozenset({"key_press_release", "encoder_press_release"})
 
 
 class PackageError(Exception):
@@ -277,16 +282,18 @@ def _parse_event(raw: dict[str, Any], index: int) -> EventMapping:
 
     hold_ms = raw.get("hold_ms")
     if source in HOLD_SOURCES:
-        if hold_ms is None:
-            raise PackageError(
-                f"Event '{name}': hold_ms is required for source '{source}'"
-            )
-        if not isinstance(hold_ms, int) or hold_ms <= 0:
+        if hold_ms is not None and (not isinstance(hold_ms, int) or hold_ms <= 0):
             raise PackageError(f"Event '{name}': hold_ms must be a positive integer")
     elif hold_ms is not None:
         raise PackageError(
             f"Event '{name}': hold_ms is only valid for key_hold/encoder_hold sources"
         )
+
+    # Apply reasonable defaults for omitted timing parameters.
+    if source in HOLD_SOURCES and hold_ms is None:
+        hold_ms = DEFAULT_HOLD_MS
+    if source in _PRESS_RELEASE_SOURCES and max_duration_ms is None:
+        max_duration_ms = DEFAULT_MAX_DURATION_MS
 
     return EventMapping(
         name=name,

--- a/src/deckboard/dsui/schema.py
+++ b/src/deckboard/dsui/schema.py
@@ -205,6 +205,13 @@ class EventMapping:
 # Sources that require the hold_ms field.
 HOLD_SOURCES = frozenset({"key_hold", "encoder_hold"})
 
+# Reasonable defaults applied when the user omits timing parameters.
+DEFAULT_MAX_DURATION_MS: int = 500
+"""Default max press duration (ms) for ``*_press_release`` events."""
+
+DEFAULT_HOLD_MS: int = 500
+"""Default hold duration (ms) for ``*_hold`` events."""
+
 
 @dataclass(frozen=True, slots=True)
 class Region:

--- a/tests/test_dsui_loader.py
+++ b/tests/test_dsui_loader.py
@@ -585,6 +585,20 @@ class TestLoadPackageInvalid:
         with pytest.raises(PackageError, match="invalid direction"):
             load_package(pkg)
 
+    def test_event_max_duration_ms_defaults_for_press_release(self, tmp_path):
+        pkg = tmp_path / "Good.dsui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Good\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: key_press_release",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        ev = next(e for e in spec.events if e.name == "x")
+        assert ev.max_duration_ms == 500
+
     def test_event_invalid_duration(self, tmp_path):
         pkg = tmp_path / "Bad.dsui"
         pkg.mkdir()
@@ -598,31 +612,33 @@ class TestLoadPackageInvalid:
         with pytest.raises(PackageError, match="positive integer"):
             load_package(pkg)
 
-    def test_event_hold_ms_required_for_key_hold(self, tmp_path):
-        pkg = tmp_path / "Bad.dsui"
+    def test_event_hold_ms_defaults_for_key_hold(self, tmp_path):
+        pkg = tmp_path / "Good.dsui"
         pkg.mkdir()
         svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
         (pkg / "layout.svg").write_text(svg, encoding="utf-8")
         (pkg / "manifest.yaml").write_text(
-            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "name: Good\ntype: Key\nversion: 1\nlayout: layout.svg\n"
             "events:\n  - name: x\n    source: key_hold",
             encoding="utf-8",
         )
-        with pytest.raises(PackageError, match="hold_ms is required"):
-            load_package(pkg)
+        spec = load_package(pkg)
+        ev = next(e for e in spec.events if e.name == "x")
+        assert ev.hold_ms == 500
 
-    def test_event_hold_ms_required_for_encoder_hold(self, tmp_path):
-        pkg = tmp_path / "Bad.dsui"
+    def test_event_hold_ms_defaults_for_encoder_hold(self, tmp_path):
+        pkg = tmp_path / "Good.dsui"
         pkg.mkdir()
         svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
         (pkg / "layout.svg").write_text(svg, encoding="utf-8")
         (pkg / "manifest.yaml").write_text(
-            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "name: Good\ntype: Key\nversion: 1\nlayout: layout.svg\n"
             "events:\n  - name: x\n    source: encoder_hold",
             encoding="utf-8",
         )
-        with pytest.raises(PackageError, match="hold_ms is required"):
-            load_package(pkg)
+        spec = load_package(pkg)
+        ev = next(e for e in spec.events if e.name == "x")
+        assert ev.hold_ms == 500
 
     def test_event_hold_ms_invalid(self, tmp_path):
         pkg = tmp_path / "Bad.dsui"


### PR DESCRIPTION
## Summary
- Add `DEFAULT_MAX_DURATION_MS` (500ms) applied to `*_press_release` events and `DEFAULT_HOLD_MS` (500ms) applied to `*_hold` events when omitted from `.dsui` manifests
- `hold_ms` is no longer required in manifests for hold sources — it defaults to 500ms if omitted
- `max_duration_ms` defaults to 500ms for press_release sources instead of accepting any duration