### PR TITLE
Add multi-device support, auto-reconnect, and device discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,81 @@ Constructor parameters:
 |-----------|---------|-------------|
 | `serial_number` | `None` | Target a specific device by serial number |
 | `device_index` | `0` | Which device if multiple visual decks are found |
-| `brightness` | `80` | Initial brightness (0–100) |
+| `brightness` | `80` | Initial brightness (0-100) |
+| `deck_type` | `None` | Only connect to devices of this type (e.g. `"Stream Deck +"`) |
+| `auto_reconnect` | `False` | Automatically reconnect on USB disconnect |
+| `reconnect_poll_interval` | `2.0` | Seconds between reconnection attempts |
+
+### Device discovery
+
+Enumerate all connected devices without creating a `Deck`:
+
+```python
+from deckboard import list_devices
+
+devices = await list_devices()
+for info in devices:
+    print(f"{info.deck_type} serial={info.serial}")
+
+# Filter by type
+plus_devices = await list_devices(deck_type="Stream Deck +")
+```
+
+### Wait for device
+
+Wait for a matching device to be plugged in:
+
+```python
+deck = await Deck.wait_for_device(
+    deck_type="Stream Deck +",
+    poll_interval=1.0,
+)
+```
+
+### Auto-reconnect
+
+Survive USB disconnects automatically:
+
+```python
+async with Deck(auto_reconnect=True) as deck:
+    @deck.on_disconnect
+    async def on_lost():
+        print("Device disconnected, waiting...")
+
+    @deck.on_reconnect
+    async def on_back():
+        print("Reconnected! UI restored.")
+
+    await deck.set_screen("main")
+    await deck.wait_closed()
+```
+
+### Multi-device with DeckManager
+
+Orchestrate multiple Stream Decks with hot-plug detection:
+
+```python
+from deckboard import DeckManager
+
+manager = DeckManager(poll_interval=2.0)
+
+@manager.on_connect(deck_type="Stream Deck +")
+async def handle_plus(deck):
+    screen = deck.screen("main")
+
+    @screen.key(0).on_press
+    async def on_press():
+        print(f"Key pressed on {deck.info.serial}")
+
+    await deck.set_screen("main")
+
+@manager.on_disconnect
+async def handle_lost(info):
+    print(f"Lost: {info.serial}")
+
+async with manager:
+    await manager.wait_closed()
+```
 
 ### Screens
 
@@ -367,6 +441,7 @@ mypy src/deckboard/
 | Class | Module | Description |
 |-------|--------|-------------|
 | `Deck` | `deckboard.runtime.deck` | Main entry point, auto-detects device |
+| `DeckManager` | `deckboard.runtime.manager` | Multi-device orchestrator with hot-plug |
 | `DeviceCapabilities` | `deckboard.runtime.capabilities` | Frozen snapshot of device hardware |
 | `RenderMetrics` | `deckboard.render.metrics` | Computed rendering dimensions and margins |
 | `Screen` | `deckboard.ui.screen` | Named layout of keys, encoders, and cards |
@@ -403,6 +478,13 @@ mypy src/deckboard/
 | `DeckError` | Device not found, not opened, or HID error |
 | `RasterizeError` | SVG rasterisation failure |
 | `PackageError` | Invalid .dsui manifest or layout |
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `list_devices()` | Enumerate all connected Stream Deck devices |
+| `Deck.wait_for_device()` | Wait for a matching device to appear |
 
 ## Acknowledgments
 

--- a/examples/multi_device.py
+++ b/examples/multi_device.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Example: multi-device management with auto-reconnect.
+
+Demonstrates the new multi-device features:
+
+- ``list_devices()`` — enumerate connected Stream Decks
+- ``Deck.wait_for_device()`` — wait for a specific device to appear
+- ``DeckManager`` — orchestrate multiple devices with hot-plug detection
+- ``auto_reconnect`` — survive USB disconnects gracefully
+- ``deck_type`` filter — target specific hardware models
+
+Run with::
+
+    python examples/multi_device.py
+"""
+
+import asyncio
+import logging
+
+from deckboard import Deck, DeckManager, DeviceInfo, list_devices
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+async def demo_list_devices() -> None:
+    """Show all connected Stream Deck devices."""
+    print("=== list_devices() ===")
+    devices = await list_devices()
+    if not devices:
+        print("  No devices found.\n")
+        return
+    for info in devices:
+        print(f"  {info.deck_type} (serial={info.serial}, keys={info.key_count})")
+    print()
+
+
+async def demo_single_deck_reconnect() -> None:
+    """Single deck with auto-reconnect enabled.
+
+    If you unplug the device it will attempt to reconnect automatically.
+    Plug it back in and the UI will be restored.
+    """
+    print("=== Single Deck with auto_reconnect ===")
+    print("  Waiting for a Stream Deck to connect...")
+
+    deck = await Deck.wait_for_device(
+        auto_reconnect=True,
+        poll_interval=1.0,
+        brightness=80,
+    )
+
+    @deck.on_disconnect
+    async def on_disc():
+        print("  Device disconnected! Waiting for reconnect...")
+
+    @deck.on_reconnect
+    async def on_recon():
+        print("  Device reconnected! UI restored.")
+
+    screen = deck.screen("main")
+
+    @screen.key(0).on_press
+    async def on_home():
+        print("  Key 0 pressed!")
+
+    await deck.set_screen("main")
+    print(f"  Connected: {deck.info.deck_type} (serial={deck.info.serial})")
+    print("  Press Ctrl+C to exit.\n")
+
+    try:
+        await deck.wait_closed()
+    except KeyboardInterrupt:
+        await deck.stop()
+
+
+async def demo_deck_manager() -> None:
+    """Multi-device orchestration with DeckManager.
+
+    The manager scans for devices every 2 seconds. When a matching
+    device appears, the on_connect handler is called. When it
+    disappears, on_disconnect fires.
+    """
+    print("=== DeckManager (multi-device) ===")
+
+    manager = DeckManager(poll_interval=2.0, brightness=80)
+
+    @manager.on_connect(deck_type="Stream Deck +")
+    async def handle_plus(deck: Deck) -> None:
+        info = deck.info
+        print(f"  [+] Stream Deck+ connected: {info.serial}")
+
+        screen = deck.screen("main")
+
+        @screen.key(0).on_press
+        async def on_k0():
+            print(f"    [{info.serial}] Key 0 pressed!")
+
+        if deck.capabilities.has_encoders:
+
+            @screen.encoder(0).on_turn
+            async def on_turn(direction: int) -> None:
+                print(f"    [{info.serial}] Encoder 0 turned: {direction}")
+
+        await deck.set_screen("main")
+
+    @manager.on_connect()  # catch-all for any device type
+    async def handle_any(deck: Deck) -> None:
+        info = deck.info
+        if info.deck_type == "Stream Deck +":
+            return  # Already handled above
+        print(f"  [+] {info.deck_type} connected: {info.serial}")
+
+        screen = deck.screen("main")
+
+        @screen.key(0).on_press
+        async def on_k0():
+            print(f"    [{info.serial}] Key 0 pressed!")
+
+        await deck.set_screen("main")
+
+    @manager.on_disconnect
+    async def handle_lost(info: DeviceInfo) -> None:
+        print(f"  [-] Lost: {info.serial} ({info.deck_type})")
+
+    async with manager:
+        print("  Scanning for devices... Press Ctrl+C to exit.\n")
+        try:
+            await manager.wait_closed()
+        except KeyboardInterrupt:
+            pass
+
+
+async def main() -> None:
+    # 1. Show connected devices
+    await demo_list_devices()
+
+    # 2. Pick which demo to run
+    print("Choose a demo:")
+    print("  1) Single deck with auto-reconnect")
+    print("  2) DeckManager (multi-device)")
+    print()
+
+    choice = input("Enter 1 or 2: ").strip()
+
+    if choice == "1":
+        await demo_single_deck_reconnect()
+    elif choice == "2":
+        await demo_deck_manager()
+    else:
+        print("Invalid choice.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deckboard/__init__.py
+++ b/src/deckboard/__init__.py
@@ -34,6 +34,7 @@ from .runtime import (
     Deck,
     DeckError,
     DeckEvent,
+    DeckManager,
     DeviceCapabilities,
     DeviceInfo,
     EncoderPressEvent,
@@ -41,6 +42,7 @@ from .runtime import (
     EventType,
     KeyEvent,
     TouchEvent,
+    list_devices,
 )
 from .ui import (
     BlankCard,
@@ -58,6 +60,7 @@ __all__ = [
     "Deck",
     "DeckError",
     "DeckEvent",
+    "DeckManager",
     "DeviceCapabilities",
     "DeviceInfo",
     "DsuiCard",
@@ -75,6 +78,7 @@ __all__ = [
     "Screen",
     "TouchEvent",
     "TouchStrip",
+    "list_devices",
     "load_all_packages",
     "load_package",
 ]

--- a/src/deckboard/runtime/__init__.py
+++ b/src/deckboard/runtime/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .capabilities import DeviceCapabilities
 from .deck import Deck, DeckError
 from .device_info import DeviceInfo
+from .discovery import list_devices
 from .events import (
     AsyncHandler,
     DeckEvent,
@@ -14,6 +15,7 @@ from .events import (
     KeyEvent,
     TouchEvent,
 )
+from .manager import DeckManager
 from .transport import AsyncTransport
 
 __all__ = [
@@ -22,6 +24,7 @@ __all__ = [
     "Deck",
     "DeckError",
     "DeckEvent",
+    "DeckManager",
     "DeviceCapabilities",
     "DeviceInfo",
     "EncoderPressEvent",
@@ -29,4 +32,5 @@ __all__ = [
     "EventType",
     "KeyEvent",
     "TouchEvent",
+    "list_devices",
 ]

--- a/src/deckboard/runtime/deck.py
+++ b/src/deckboard/runtime/deck.py
@@ -15,6 +15,7 @@ from ..render.touch_renderer import compose_touchstrip
 from .capabilities import DeviceCapabilities
 from .device_info import DeviceInfo
 from .events import (
+    AsyncHandler,
     DeckEvent,
     EncoderPressEvent,
     EncoderTurnEvent,
@@ -69,6 +70,9 @@ class Deck:
         serial_number: str | None = None,
         device_index: int = 0,
         brightness: int = 80,
+        deck_type: str | None = None,
+        auto_reconnect: bool = False,
+        reconnect_poll_interval: float = 2.0,
     ) -> None:
         """
         Args:
@@ -77,10 +81,19 @@ class Deck:
             device_index: If multiple visual decks are found and no
                 serial_number is given, which one to use (0-based).
             brightness: Initial brightness (0-100).
+            deck_type: If set, only connect to devices matching this
+                type string (e.g. ``"Stream Deck +"``).
+            auto_reconnect: If ``True``, automatically attempt to
+                reconnect when the device disconnects.
+            reconnect_poll_interval: Seconds between reconnection
+                attempts (default 2.0).
         """
         self._serial_number = serial_number
         self._device_index = device_index
         self._brightness = brightness
+        self._deck_type = deck_type
+        self._auto_reconnect = auto_reconnect
+        self._reconnect_poll_interval = reconnect_poll_interval
         self._device: Any = None  # low-level StreamDeck object
         self._caps: DeviceCapabilities | None = None
         self._metrics: RenderMetrics | None = None
@@ -91,6 +104,11 @@ class Deck:
         self._executor = ThreadPoolExecutor(max_workers=2)
         self._device_lock = asyncio.Lock()
 
+        # Reconnect state
+        self._reconnecting = False
+        self._on_reconnect_handler: AsyncHandler | None = None
+        self._on_disconnect_handler: AsyncHandler | None = None
+
         # Screens
         self._screens: dict[str, Screen] = {}
         self._active_screen: Screen | None = None
@@ -98,6 +116,47 @@ class Deck:
         self._active_page: Screen | None = None
 
     # -- Async context manager ---------------------------------------------
+
+    @classmethod
+    async def wait_for_device(
+        cls,
+        serial_number: str | None = None,
+        deck_type: str | None = None,
+        poll_interval: float = 2.0,
+        brightness: int = 80,
+        auto_reconnect: bool = False,
+    ) -> Deck:
+        """Wait for a matching device to be connected, then return a started Deck.
+
+        Polls for devices periodically until one matching the given
+        criteria is found.
+
+        Args:
+            serial_number: Wait for a device with this serial.
+            deck_type: Wait for a device of this type.
+            poll_interval: Seconds between discovery attempts.
+            brightness: Initial brightness (0-100).
+            auto_reconnect: Enable auto-reconnect on the returned Deck.
+
+        Returns:
+            A started :class:`Deck` instance.
+        """
+        while True:
+            try:
+                deck = cls(
+                    serial_number=serial_number,
+                    deck_type=deck_type,
+                    brightness=brightness,
+                    auto_reconnect=auto_reconnect,
+                )
+                await deck.start()
+                return deck
+            except DeckError:
+                logger.debug(
+                    "No matching device found, retrying in %.1fs...",
+                    poll_interval,
+                )
+                await asyncio.sleep(poll_interval)
 
     async def __aenter__(self) -> Deck:
         await self.start()
@@ -125,6 +184,14 @@ class Deck:
         visual = [d for d in devices if d.DECK_VISUAL]
         if not visual:
             raise DeckError("No visual Stream Deck devices found")
+
+        # Filter by deck type if specified
+        if self._deck_type is not None:
+            visual = [d for d in visual if d.DECK_TYPE == self._deck_type]
+            if not visual:
+                raise DeckError(
+                    f"No devices of type '{self._deck_type}' found"
+                )
 
         # Select device
         if self._serial_number is not None:
@@ -162,6 +229,10 @@ class Deck:
         # Build capabilities and metrics
         self._caps = DeviceCapabilities.from_device(self._device)
         self._metrics = RenderMetrics(self._caps)
+
+        # Remember serial for reconnection
+        if self._serial_number is None:
+            self._serial_number = self._device.get_serial_number()
 
         logger.info(
             "Opened %s (serial: %s, firmware: %s, keys: %d, dials: %d)",
@@ -220,7 +291,127 @@ class Deck:
         """Block until the deck is closed (e.g. by stop() or disconnect)."""
         await self._closed_event.wait()
 
+    # -- Reconnect / disconnect callbacks ----------------------------------
+
+    def on_reconnect(self, handler: AsyncHandler) -> AsyncHandler:
+        """Register a callback invoked after a successful reconnection.
+
+        Can be used as a decorator::
+
+            @deck.on_reconnect
+            async def handle_reconnect():
+                await deck.set_screen("main")
+        """
+        self._on_reconnect_handler = handler
+        return handler
+
+    def on_disconnect(self, handler: AsyncHandler) -> AsyncHandler:
+        """Register a callback invoked when the device disconnects.
+
+        Can be used as a decorator::
+
+            @deck.on_disconnect
+            async def handle_disconnect():
+                print("Device lost!")
+        """
+        self._on_disconnect_handler = handler
+        return handler
+
+    async def _reconnect_loop(self) -> None:
+        """Poll for the device to reappear and re-open it."""
+        logger.info(
+            "Reconnect loop started (serial=%s, poll=%.1fs)",
+            self._serial_number,
+            self._reconnect_poll_interval,
+        )
+        self._reconnecting = True
+
+        loop = asyncio.get_running_loop()
+
+        while self._running:
+            await asyncio.sleep(self._reconnect_poll_interval)
+            if not self._running:
+                break
+
+            try:
+                devices = await loop.run_in_executor(
+                    self._executor, DeviceManager().enumerate
+                )
+                visual = [d for d in devices if d.DECK_VISUAL]
+
+                if self._deck_type is not None:
+                    visual = [d for d in visual if d.DECK_TYPE == self._deck_type]
+
+                target = None
+                for d in visual:
+                    try:
+                        await loop.run_in_executor(self._executor, d.open)
+                        serial = d.get_serial_number()
+                        if serial == self._serial_number:
+                            target = d
+                            break
+                        await loop.run_in_executor(self._executor, d.close)
+                    except Exception:
+                        continue
+
+                if target is None:
+                    continue
+
+                # Re-open successful
+                self._device = target
+                await loop.run_in_executor(self._executor, self._device.reset)
+                await loop.run_in_executor(
+                    self._executor, self._device.set_brightness, self._brightness
+                )
+
+                self._caps = DeviceCapabilities.from_device(self._device)
+                self._metrics = RenderMetrics(self._caps)
+
+                self._transport = AsyncTransport(self._device, loop, self._caps)
+                self._transport.start()
+
+                self._reconnecting = False
+
+                logger.info(
+                    "Reconnected to %s (serial: %s)",
+                    self._device.deck_type(),
+                    self._serial_number,
+                )
+
+                # Re-render active screen
+                if self._active_screen:
+                    await self._render_all_keys()
+                    if self._active_screen.touch_strip is not None:
+                        await self._render_touchscreen()
+                    if self._active_screen.info_screen is not None:
+                        await self._render_info_screen()
+
+                # Invoke user callback
+                if self._on_reconnect_handler:
+                    try:
+                        await self._on_reconnect_handler()
+                    except Exception:
+                        logger.exception("Error in reconnect handler")
+
+                return  # Exit reconnect loop, resume event loop
+
+            except Exception:
+                logger.debug("Reconnect attempt failed, retrying...")
+                continue
+
+        self._reconnecting = False
+
     # -- Device capabilities -----------------------------------------------
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the device is currently connected and operational."""
+        return self._device is not None and self._running and not self._reconnecting
+
+    @property
+    def is_reconnecting(self) -> bool:
+        """Whether the deck is currently attempting to reconnect."""
+        return self._reconnecting
 
     @property
     def capabilities(self) -> DeviceCapabilities:
@@ -524,7 +715,50 @@ class Deck:
             pass
         except Exception:
             logger.exception("Event loop crashed")
+            if self._auto_reconnect and self._running:
+                await self._handle_disconnect()
+                return
         finally:
+            self._closed_event.set()
+
+    async def _handle_disconnect(self) -> None:
+        """Handle device disconnection: clean up and optionally reconnect."""
+        logger.info("Device disconnected (serial=%s)", self._serial_number)
+
+        # Clean up transport
+        if self._transport:
+            try:
+                self._transport.stop()
+            except Exception:
+                pass
+            self._transport = None
+
+        # Clean up device
+        if self._device:
+            try:
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(self._executor, self._device.close)
+            except Exception:
+                pass
+            self._device = None
+
+        # Invoke user disconnect callback
+        if self._on_disconnect_handler:
+            try:
+                await self._on_disconnect_handler()
+            except Exception:
+                logger.exception("Error in disconnect handler")
+
+        # Attempt reconnection
+        await self._reconnect_loop()
+
+        if self._running and not self._reconnecting:
+            # Reconnected — restart event loop
+            self._closed_event.clear()
+            self._event_task = asyncio.create_task(
+                self._event_loop(), name="deckboard-events"
+            )
+        else:
             self._closed_event.set()
 
     async def _drain_card_callbacks(self, card: Card) -> None:

--- a/src/deckboard/runtime/discovery.py
+++ b/src/deckboard/runtime/discovery.py
@@ -1,0 +1,74 @@
+"""Device discovery utilities for enumerating Stream Deck hardware."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+from StreamDeck.DeviceManager import DeviceManager
+
+from .device_info import DeviceInfo
+
+if TYPE_CHECKING:
+    pass
+
+
+async def list_devices(
+    *,
+    deck_type: str | None = None,
+    visual_only: bool = True,
+) -> list[DeviceInfo]:
+    """Enumerate all connected Stream Deck devices.
+
+    Discovers devices via HID, opens each briefly to read serial and
+    firmware information, then closes them.  Returns a list of
+    :class:`DeviceInfo` snapshots.
+
+    Args:
+        deck_type: If set, only return devices matching this type
+            (e.g. ``"Stream Deck +"``).
+        visual_only: If ``True`` (default), exclude non-visual devices
+            such as the Stream Deck Pedal.
+
+    Returns:
+        A list of :class:`DeviceInfo` for each discovered device.
+    """
+    loop = asyncio.get_running_loop()
+    executor = ThreadPoolExecutor(max_workers=2)
+
+    try:
+        devices = await loop.run_in_executor(executor, DeviceManager().enumerate)
+
+        if visual_only:
+            devices = [d for d in devices if d.DECK_VISUAL]
+
+        results: list[DeviceInfo] = []
+        for d in devices:
+            try:
+                await loop.run_in_executor(executor, d.open)
+                info = DeviceInfo(
+                    deck_type=d.deck_type(),
+                    serial=d.get_serial_number(),
+                    firmware=d.get_firmware_version(),
+                    key_count=d.key_count(),
+                    key_layout=d.key_layout(),
+                    encoder_count=d.dial_count(),
+                    key_pixel_size=(d.KEY_PIXEL_WIDTH, d.KEY_PIXEL_HEIGHT),
+                    touchscreen_size=(
+                        d.TOUCHSCREEN_PIXEL_WIDTH,
+                        d.TOUCHSCREEN_PIXEL_HEIGHT,
+                    ),
+                    key_image_format=d.KEY_IMAGE_FORMAT,
+                )
+                if deck_type is not None and info.deck_type != deck_type:
+                    await loop.run_in_executor(executor, d.close)
+                    continue
+                results.append(info)
+                await loop.run_in_executor(executor, d.close)
+            except Exception:
+                continue
+
+        return results
+    finally:
+        executor.shutdown(wait=False)

--- a/src/deckboard/runtime/manager.py
+++ b/src/deckboard/runtime/manager.py
@@ -1,0 +1,298 @@
+"""DeckManager: multi-device orchestrator with hot-plug detection."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable
+
+from StreamDeck.DeviceManager import DeviceManager
+
+from .deck import Deck, DeckError
+from .device_info import DeviceInfo
+from .events import AsyncHandler
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the connect callback that receives a Deck
+ConnectHandler = Callable[["Deck"], Any]
+
+
+class DeckManager:
+    """Orchestrates multiple Stream Deck devices with hot-plug detection.
+
+    Periodically scans for connected devices, tracks which are claimed,
+    and invokes callbacks when devices appear or disappear.
+
+    Usage::
+
+        manager = DeckManager()
+
+        @manager.on_connect(deck_type="Stream Deck +")
+        async def handle_plus(deck: Deck):
+            screen = deck.screen("main")
+            # set up UI...
+            await deck.set_screen("main")
+
+        @manager.on_disconnect
+        async def handle_lost(info: DeviceInfo):
+            print(f"Lost: {info.serial}")
+
+        async with manager:
+            await manager.wait_closed()
+
+    Args:
+        poll_interval: Seconds between device scans (default 2.0).
+        brightness: Default brightness for new Deck instances.
+        auto_reconnect: Whether individual Deck instances should
+            auto-reconnect (default ``False``; the manager handles
+            reconnection at a higher level).
+    """
+
+    def __init__(
+        self,
+        poll_interval: float = 2.0,
+        brightness: int = 80,
+        auto_reconnect: bool = False,
+    ) -> None:
+        self._poll_interval = poll_interval
+        self._brightness = brightness
+        self._auto_reconnect = auto_reconnect
+        self._running = False
+        self._closed_event = asyncio.Event()
+        self._executor = ThreadPoolExecutor(max_workers=2)
+        self._scan_task: asyncio.Task | None = None
+
+        # Tracked decks keyed by serial number
+        self._decks: dict[str, Deck] = {}
+
+        # Connect handlers: list of (filter_kwargs, handler)
+        self._connect_handlers: list[tuple[dict[str, str | None], AsyncHandler]] = []
+        self._disconnect_handler: AsyncHandler | None = None
+
+    # -- Async context manager ---------------------------------------------
+
+    async def __aenter__(self) -> DeckManager:
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.stop()
+
+    # -- Lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the device scanning loop."""
+        if self._running:
+            return
+        self._running = True
+        self._closed_event.clear()
+        self._scan_task = asyncio.create_task(
+            self._scan_loop(), name="deckmanager-scan"
+        )
+        logger.info("DeckManager started (poll_interval=%.1fs)", self._poll_interval)
+
+    async def stop(self) -> None:
+        """Stop scanning and close all managed decks."""
+        if not self._running:
+            return
+        self._running = False
+
+        # Cancel scan task
+        if self._scan_task and not self._scan_task.done():
+            self._scan_task.cancel()
+            try:
+                await self._scan_task
+            except asyncio.CancelledError:
+                pass
+
+        # Stop all managed decks
+        for serial, deck in list(self._decks.items()):
+            try:
+                await deck.stop()
+            except Exception:
+                logger.warning("Error stopping deck %s", serial)
+        self._decks.clear()
+
+        self._closed_event.set()
+        self._executor.shutdown(wait=False)
+        logger.info("DeckManager stopped")
+
+    async def wait_closed(self) -> None:
+        """Block until the manager is stopped."""
+        await self._closed_event.wait()
+
+    # -- Handler registration ----------------------------------------------
+
+    def on_connect(
+        self,
+        *,
+        serial: str | None = None,
+        deck_type: str | None = None,
+    ) -> Callable[[AsyncHandler], AsyncHandler]:
+        """Register a callback for when a matching device connects.
+
+        Use as a decorator::
+
+            @manager.on_connect(deck_type="Stream Deck +")
+            async def handle(deck: Deck):
+                ...
+
+        Args:
+            serial: Only match this serial number.
+            deck_type: Only match this device type.
+
+        Returns:
+            Decorator that registers the handler.
+        """
+        filters = {"serial": serial, "deck_type": deck_type}
+
+        def decorator(handler: AsyncHandler) -> AsyncHandler:
+            self._connect_handlers.append((filters, handler))
+            return handler
+
+        return decorator
+
+    @property
+    def on_disconnect(self) -> Callable[[AsyncHandler], AsyncHandler]:
+        """Register a callback for when a device disconnects.
+
+        Use as a decorator::
+
+            @manager.on_disconnect
+            async def handle(info: DeviceInfo):
+                ...
+        """
+
+        def decorator(handler: AsyncHandler) -> AsyncHandler:
+            self._disconnect_handler = handler
+            return handler
+
+        return decorator
+
+    # -- Properties --------------------------------------------------------
+
+    @property
+    def decks(self) -> dict[str, Deck]:
+        """Currently managed decks, keyed by serial number."""
+        return dict(self._decks)
+
+    # -- Scanning ----------------------------------------------------------
+
+    async def _scan_loop(self) -> None:
+        """Periodically enumerate devices and manage connections."""
+        # Do an initial scan immediately
+        await self._scan_once()
+
+        try:
+            while self._running:
+                await asyncio.sleep(self._poll_interval)
+                if not self._running:
+                    break
+                await self._scan_once()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Scan loop crashed")
+        finally:
+            self._closed_event.set()
+
+    async def _scan_once(self) -> None:
+        """Single scan: discover devices, handle connects/disconnects."""
+        loop = asyncio.get_running_loop()
+
+        try:
+            devices = await loop.run_in_executor(
+                self._executor, DeviceManager().enumerate
+            )
+        except Exception:
+            logger.debug("Device enumeration failed")
+            return
+
+        visual = [d for d in devices if d.DECK_VISUAL]
+
+        # Read serials from all connected devices
+        connected_serials: set[str] = set()
+        device_by_serial: dict[str, Any] = {}
+
+        for d in visual:
+            try:
+                await loop.run_in_executor(self._executor, d.open)
+                serial = d.get_serial_number()
+                connected_serials.add(serial)
+                device_by_serial[serial] = d
+                await loop.run_in_executor(self._executor, d.close)
+            except Exception:
+                continue
+
+        # Detect disconnections
+        for serial in list(self._decks):
+            if serial not in connected_serials:
+                deck = self._decks.pop(serial)
+                logger.info("Device disconnected: %s", serial)
+                try:
+                    info = deck.info
+                except Exception:
+                    info = DeviceInfo(
+                        deck_type="unknown",
+                        serial=serial,
+                        firmware="",
+                        key_count=0,
+                        key_layout=(0, 0),
+                        encoder_count=0,
+                        key_pixel_size=(0, 0),
+                        touchscreen_size=(0, 0),
+                        key_image_format="",
+                    )
+                try:
+                    await deck.stop()
+                except Exception:
+                    pass
+                if self._disconnect_handler:
+                    try:
+                        await self._disconnect_handler(info)
+                    except Exception:
+                        logger.exception("Error in disconnect handler")
+
+        # Detect new connections
+        for serial in connected_serials:
+            if serial in self._decks:
+                continue
+
+            # New device — find a matching connect handler
+            # Read device type
+            raw_device = device_by_serial.get(serial)
+            if raw_device is None:
+                continue
+            device_type = raw_device.DECK_TYPE
+
+            for filters, handler in self._connect_handlers:
+                if filters["serial"] is not None and filters["serial"] != serial:
+                    continue
+                if (
+                    filters["deck_type"] is not None
+                    and filters["deck_type"] != device_type
+                ):
+                    continue
+
+                # Match found — create and start a Deck
+                try:
+                    deck = Deck(
+                        serial_number=serial,
+                        brightness=self._brightness,
+                        auto_reconnect=self._auto_reconnect,
+                    )
+                    await deck.start()
+                    self._decks[serial] = deck
+                    logger.info("Device connected: %s (%s)", serial, device_type)
+
+                    try:
+                        await handler(deck)
+                    except Exception:
+                        logger.exception("Error in connect handler for %s", serial)
+                except DeckError:
+                    logger.debug("Failed to start deck for %s", serial)
+                except Exception:
+                    logger.exception("Unexpected error starting deck %s", serial)
+                break  # Only first matching handler

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,103 @@
+"""Tests for deckboard.runtime.discovery — list_devices function."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deckboard.runtime.discovery import list_devices
+
+
+def _make_raw_device(
+    deck_type: str = "Stream Deck +",
+    serial: str = "ABC123",
+    visual: bool = True,
+) -> MagicMock:
+    """Create a MagicMock mimicking a raw python-elgato-streamdeck device."""
+    d = MagicMock()
+    d.DECK_VISUAL = visual
+    d.DECK_TYPE = deck_type
+    d.KEY_PIXEL_WIDTH = 120
+    d.KEY_PIXEL_HEIGHT = 120
+    d.KEY_IMAGE_FORMAT = "JPEG"
+    d.TOUCHSCREEN_PIXEL_WIDTH = 800
+    d.TOUCHSCREEN_PIXEL_HEIGHT = 100
+    d.deck_type.return_value = deck_type
+    d.get_serial_number.return_value = serial
+    d.get_firmware_version.return_value = "1.0.0"
+    d.key_count.return_value = 8
+    d.key_layout.return_value = (4, 2)
+    d.dial_count.return_value = 4
+    d.open.return_value = None
+    d.close.return_value = None
+    return d
+
+
+class TestListDevices:
+    async def test_no_devices(self):
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            result = await list_devices()
+            assert result == []
+
+    async def test_returns_device_info(self):
+        dev = _make_raw_device()
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            result = await list_devices()
+            assert len(result) == 1
+            assert result[0].serial == "ABC123"
+            assert result[0].deck_type == "Stream Deck +"
+            assert result[0].key_count == 8
+
+    async def test_filters_non_visual(self):
+        dev = _make_raw_device(visual=False)
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            result = await list_devices()
+            assert result == []
+
+    async def test_visual_only_false_includes_all(self):
+        dev = _make_raw_device(visual=False, serial="PEDAL1")
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            result = await list_devices(visual_only=False)
+            assert len(result) == 1
+            assert result[0].serial == "PEDAL1"
+
+    async def test_filter_by_deck_type(self):
+        plus = _make_raw_device(deck_type="Stream Deck +", serial="PLUS1")
+        mini = _make_raw_device(deck_type="Stream Deck Mini", serial="MINI1")
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [plus, mini]
+            result = await list_devices(deck_type="Stream Deck +")
+            assert len(result) == 1
+            assert result[0].serial == "PLUS1"
+
+    async def test_filter_by_deck_type_no_match(self):
+        dev = _make_raw_device(deck_type="Stream Deck Mini")
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            result = await list_devices(deck_type="Stream Deck XL")
+            assert result == []
+
+    async def test_multiple_devices(self):
+        d1 = _make_raw_device(serial="DEV1")
+        d2 = _make_raw_device(serial="DEV2")
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [d1, d2]
+            result = await list_devices()
+            assert len(result) == 2
+            serials = {r.serial for r in result}
+            assert serials == {"DEV1", "DEV2"}
+
+    async def test_device_open_error_skipped(self):
+        d1 = _make_raw_device(serial="OK1")
+        d2 = _make_raw_device(serial="BAD1")
+        d2.open.side_effect = OSError("HID error")
+        with patch("deckboard.runtime.discovery.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [d1, d2]
+            result = await list_devices()
+            assert len(result) == 1
+            assert result[0].serial == "OK1"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,7 @@ class TestPublicAPI:
             "Deck",
             "DeckError",
             "DeckEvent",
+            "DeckManager",
             "DeviceCapabilities",
             "DeviceInfo",
             "DsuiCard",
@@ -33,6 +34,7 @@ class TestPublicAPI:
             "Screen",
             "TouchEvent",
             "TouchStrip",
+            "list_devices",
             "load_all_packages",
             "load_package",
         }

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,362 @@
+"""Tests for deckboard.runtime.manager — DeckManager class."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deckboard.runtime.manager import DeckManager
+
+
+def _make_raw_device(
+    deck_type: str = "Stream Deck +",
+    serial: str = "MGR_DEV1",
+    visual: bool = True,
+) -> MagicMock:
+    """Create a mock raw device for enumeration."""
+    d = MagicMock()
+    d.DECK_TYPE = deck_type
+    d.DECK_VISUAL = visual
+    d.DECK_TOUCH = True
+    d.KEY_PIXEL_WIDTH = 120
+    d.KEY_PIXEL_HEIGHT = 120
+    d.KEY_IMAGE_FORMAT = "JPEG"
+    d.KEY_FLIP = [False, False]
+    d.KEY_ROTATION = 0
+    d.TOUCHSCREEN_PIXEL_WIDTH = 800
+    d.TOUCHSCREEN_PIXEL_HEIGHT = 100
+    d.TOUCHSCREEN_IMAGE_FORMAT = "JPEG"
+    d.TOUCHSCREEN_FLIP = [False, False]
+    d.TOUCHSCREEN_ROTATION = 0
+    d.SCREEN_PIXEL_WIDTH = 0
+    d.SCREEN_PIXEL_HEIGHT = 0
+    d.SCREEN_IMAGE_FORMAT = ""
+    d.SCREEN_FLIP = [False, False]
+    d.SCREEN_ROTATION = 0
+    d.TOUCH_KEY_COUNT = 0
+
+    d.deck_type.return_value = deck_type
+    d.get_serial_number.return_value = serial
+    d.get_firmware_version.return_value = "1.0.0"
+    d.key_count.return_value = 8
+    d.key_layout.return_value = (4, 2)
+    d.dial_count.return_value = 4
+
+    d.open.return_value = None
+    d.close.return_value = None
+    d.reset.return_value = None
+    d.set_brightness.return_value = None
+    d.set_key_image.return_value = None
+    d.set_touchscreen_image.return_value = None
+    d.set_screen_image.return_value = None
+    d.set_key_callback.return_value = None
+    d.set_dial_callback.return_value = None
+    d.set_touchscreen_callback.return_value = None
+    return d
+
+
+# ── DeckManager.__init__ ─────────────────────────────────────────────────
+
+
+class TestDeckManagerInit:
+    def test_defaults(self):
+        m = DeckManager()
+        assert m._poll_interval == 2.0
+        assert m._brightness == 80
+        assert m._auto_reconnect is False
+        assert m._running is False
+        assert m._decks == {}
+
+    def test_custom_params(self):
+        m = DeckManager(poll_interval=5.0, brightness=50, auto_reconnect=True)
+        assert m._poll_interval == 5.0
+        assert m._brightness == 50
+        assert m._auto_reconnect is True
+
+
+# ── DeckManager.on_connect / on_disconnect ───────────────────────────────
+
+
+class TestDeckManagerHandlers:
+    def test_on_connect_decorator(self):
+        m = DeckManager()
+
+        @m.on_connect(deck_type="Stream Deck +")
+        async def handler(deck):
+            pass
+
+        assert len(m._connect_handlers) == 1
+        filters, h = m._connect_handlers[0]
+        assert filters["deck_type"] == "Stream Deck +"
+        assert filters["serial"] is None
+        assert h is handler
+
+    def test_on_connect_serial_filter(self):
+        m = DeckManager()
+
+        @m.on_connect(serial="ABC123")
+        async def handler(deck):
+            pass
+
+        filters, _ = m._connect_handlers[0]
+        assert filters["serial"] == "ABC123"
+
+    def test_on_disconnect_decorator(self):
+        m = DeckManager()
+
+        @m.on_disconnect
+        async def handler(info):
+            pass
+
+        assert m._disconnect_handler is handler
+
+    def test_multiple_connect_handlers(self):
+        m = DeckManager()
+
+        @m.on_connect(deck_type="Stream Deck +")
+        async def plus_handler(deck):
+            pass
+
+        @m.on_connect(deck_type="Stream Deck Mini")
+        async def mini_handler(deck):
+            pass
+
+        assert len(m._connect_handlers) == 2
+
+
+# ── DeckManager lifecycle ────────────────────────────────────────────────
+
+
+class TestDeckManagerLifecycle:
+    async def test_start_stop(self):
+        m = DeckManager(poll_interval=0.05)
+
+        # Register a dummy handler so scan works
+        @m.on_connect()
+        async def handler(deck):
+            pass
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            await m.start()
+            assert m._running is True
+            await asyncio.sleep(0.1)
+            await m.stop()
+            assert m._running is False
+            assert m._closed_event.is_set()
+
+    async def test_start_already_running(self):
+        m = DeckManager(poll_interval=0.05)
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            await m.start()
+            await m.start()  # no-op
+            await m.stop()
+
+    async def test_stop_when_not_running(self):
+        m = DeckManager()
+        await m.stop()  # no-op, should not raise
+
+    async def test_context_manager(self):
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            async with DeckManager(poll_interval=0.05) as m:
+                assert m._running is True
+            assert m._running is False
+
+
+# ── DeckManager._scan_once ───────────────────────────────────────────────
+
+
+class TestDeckManagerScanOnce:
+    async def test_scan_detects_new_device(self):
+        m = DeckManager(poll_interval=10.0)
+        connected_decks = []
+
+        @m.on_connect()
+        async def handler(deck):
+            connected_decks.append(deck)
+
+        dev = _make_raw_device(serial="SCAN1")
+
+        # Patch both the manager's enumeration and the Deck's enumeration
+        with patch("deckboard.runtime.manager.DeviceManager") as mgr_dm:
+            mgr_dm.return_value.enumerate.return_value = [dev]
+            with patch("deckboard.runtime.deck.DeviceManager") as deck_dm:
+                deck_dm.return_value.enumerate.return_value = [dev]
+                await m._scan_once()
+
+        assert len(connected_decks) == 1
+        assert "SCAN1" in m._decks
+
+        # Clean up
+        for d in m._decks.values():
+            await d.stop()
+
+    async def test_scan_detects_disconnect(self):
+        m = DeckManager(poll_interval=10.0)
+        disconnected = []
+
+        @m.on_disconnect
+        async def handler(info):
+            disconnected.append(info)
+
+        # Pre-populate a managed deck
+        mock_deck = MagicMock()
+        mock_deck.stop = AsyncMock()
+        mock_deck.info = MagicMock()
+        mock_deck.info.serial = "GONE1"
+        m._decks["GONE1"] = mock_deck
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            await m._scan_once()
+
+        assert "GONE1" not in m._decks
+        assert len(disconnected) == 1
+        mock_deck.stop.assert_awaited_once()
+
+    async def test_scan_ignores_already_managed(self):
+        m = DeckManager(poll_interval=10.0)
+        connect_count = 0
+
+        @m.on_connect()
+        async def handler(deck):
+            nonlocal connect_count
+            connect_count += 1
+
+        # Pre-populate
+        m._decks["EXISTING"] = MagicMock()
+
+        dev = _make_raw_device(serial="EXISTING")
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            await m._scan_once()
+
+        assert connect_count == 0
+
+    async def test_scan_filters_by_deck_type(self):
+        m = DeckManager(poll_interval=10.0)
+        connected_types = []
+
+        @m.on_connect(deck_type="Stream Deck +")
+        async def plus_handler(deck):
+            connected_types.append("plus")
+
+        dev_mini = _make_raw_device(deck_type="Stream Deck Mini", serial="MINI1")
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev_mini]
+            await m._scan_once()
+
+        assert connected_types == []  # Mini doesn't match Plus filter
+
+    async def test_scan_filters_by_serial(self):
+        m = DeckManager(poll_interval=10.0)
+        connected_serials = []
+
+        @m.on_connect(serial="WANTED")
+        async def handler(deck):
+            connected_serials.append("WANTED")
+
+        dev = _make_raw_device(serial="UNWANTED")
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            await m._scan_once()
+
+        assert connected_serials == []
+
+    async def test_scan_enumeration_failure(self):
+        m = DeckManager(poll_interval=10.0)
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.side_effect = OSError("HID error")
+            await m._scan_once()  # Should not raise
+
+    async def test_scan_device_open_error_skipped(self):
+        m = DeckManager(poll_interval=10.0)
+
+        @m.on_connect()
+        async def handler(deck):
+            pass
+
+        dev = _make_raw_device(serial="BAD_OPEN")
+        dev.open.side_effect = OSError("HID error")
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            await m._scan_once()
+
+        assert m._decks == {}
+
+
+# ── DeckManager.decks property ──────────────────────────────────────────
+
+
+class TestDeckManagerDecks:
+    def test_decks_returns_copy(self):
+        m = DeckManager()
+        m._decks["X"] = MagicMock()
+        d = m.decks
+        assert "X" in d
+        # Modifying the copy should not affect internal state
+        d.pop("X")
+        assert "X" in m._decks
+
+
+# ── DeckManager disconnect with info error ──────────────────────────────
+
+
+class TestDeckManagerDisconnectInfoError:
+    async def test_disconnect_info_error_fallback(self):
+        """When deck.info raises, a fallback DeviceInfo is used."""
+        m = DeckManager(poll_interval=10.0)
+        disconnected = []
+
+        @m.on_disconnect
+        async def handler(info):
+            disconnected.append(info)
+
+        mock_deck = MagicMock()
+        mock_deck.stop = AsyncMock()
+        type(mock_deck).info = property(lambda self: (_ for _ in ()).throw(Exception("no device")))
+        m._decks["FALLBACK1"] = mock_deck
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            await m._scan_once()
+
+        assert len(disconnected) == 1
+        assert disconnected[0].serial == "FALLBACK1"
+        assert disconnected[0].deck_type == "unknown"
+
+
+# ── DeckManager connect handler error ────────────────────────────────────
+
+
+class TestDeckManagerConnectHandlerError:
+    async def test_connect_handler_error_logged(self):
+        """Error in connect handler is caught, doesn't crash manager."""
+        m = DeckManager(poll_interval=10.0)
+
+        @m.on_connect()
+        async def handler(deck):
+            raise ValueError("handler error")
+
+        dev = _make_raw_device(serial="ERR1")
+
+        with patch("deckboard.runtime.manager.DeviceManager") as mgr_dm:
+            mgr_dm.return_value.enumerate.return_value = [dev]
+            with patch("deckboard.runtime.deck.DeviceManager") as deck_dm:
+                deck_dm.return_value.enumerate.return_value = [dev]
+                await m._scan_once()
+
+        # Deck was still added despite handler error
+        assert "ERR1" in m._decks
+        for d in m._decks.values():
+            await d.stop()

--- a/tests/test_multi_device.py
+++ b/tests/test_multi_device.py
@@ -1,0 +1,407 @@
+"""Tests for multi-device and reconnect features in deckboard.runtime.deck."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deckboard.runtime.deck import Deck, DeckError
+from deckboard.runtime.capabilities import STREAM_DECK_PLUS
+
+
+def _make_mock_device(
+    deck_type: str = "Stream Deck +",
+    serial: str = "TEST123",
+    visual: bool = True,
+) -> MagicMock:
+    """Create a mock device matching STREAM_DECK_PLUS defaults."""
+    device = MagicMock()
+    device.DECK_TYPE = deck_type
+    device.DECK_VISUAL = visual
+    device.DECK_TOUCH = True
+    device.KEY_PIXEL_WIDTH = 120
+    device.KEY_PIXEL_HEIGHT = 120
+    device.KEY_IMAGE_FORMAT = "JPEG"
+    device.KEY_FLIP = [False, False]
+    device.KEY_ROTATION = 0
+    device.TOUCHSCREEN_PIXEL_WIDTH = 800
+    device.TOUCHSCREEN_PIXEL_HEIGHT = 100
+    device.TOUCHSCREEN_IMAGE_FORMAT = "JPEG"
+    device.TOUCHSCREEN_FLIP = [False, False]
+    device.TOUCHSCREEN_ROTATION = 0
+    device.SCREEN_PIXEL_WIDTH = 0
+    device.SCREEN_PIXEL_HEIGHT = 0
+    device.SCREEN_IMAGE_FORMAT = ""
+    device.SCREEN_FLIP = [False, False]
+    device.SCREEN_ROTATION = 0
+    device.TOUCH_KEY_COUNT = 0
+
+    device.deck_type.return_value = deck_type
+    device.get_serial_number.return_value = serial
+    device.get_firmware_version.return_value = "1.0.0"
+    device.key_count.return_value = 8
+    device.key_layout.return_value = (4, 2)
+    device.dial_count.return_value = 4
+
+    device.open.return_value = None
+    device.close.return_value = None
+    device.reset.return_value = None
+    device.set_brightness.return_value = None
+    device.set_key_image.return_value = None
+    device.set_touchscreen_image.return_value = None
+    device.set_screen_image.return_value = None
+    device.set_key_callback.return_value = None
+    device.set_dial_callback.return_value = None
+    device.set_touchscreen_callback.return_value = None
+    return device
+
+
+# ── Deck constructor new params ─────────────────────────────────────────
+
+
+class TestDeckNewParams:
+    def test_deck_type_default(self):
+        d = Deck()
+        assert d._deck_type is None
+
+    def test_deck_type_set(self):
+        d = Deck(deck_type="Stream Deck +")
+        assert d._deck_type == "Stream Deck +"
+
+    def test_auto_reconnect_default(self):
+        d = Deck()
+        assert d._auto_reconnect is False
+
+    def test_auto_reconnect_set(self):
+        d = Deck(auto_reconnect=True)
+        assert d._auto_reconnect is True
+
+    def test_reconnect_poll_interval_default(self):
+        d = Deck()
+        assert d._reconnect_poll_interval == 2.0
+
+    def test_reconnect_poll_interval_set(self):
+        d = Deck(reconnect_poll_interval=5.0)
+        assert d._reconnect_poll_interval == 5.0
+
+
+# ── Deck.is_connected / is_reconnecting ─────────────────────────────────
+
+
+class TestDeckConnectionState:
+    def test_not_connected_initially(self):
+        d = Deck()
+        assert d.is_connected is False
+        assert d.is_reconnecting is False
+
+    def test_connected_after_start(self, mock_streamdeck_device):
+        d = Deck()
+        d._device = mock_streamdeck_device
+        d._running = True
+        d._reconnecting = False
+        assert d.is_connected is True
+
+    def test_not_connected_during_reconnect(self, mock_streamdeck_device):
+        d = Deck()
+        d._device = mock_streamdeck_device
+        d._running = True
+        d._reconnecting = True
+        assert d.is_connected is False
+        assert d.is_reconnecting is True
+
+
+# ── Deck type filter on start ───────────────────────────────────────────
+
+
+class TestDeckTypeFilter:
+    async def test_start_filters_by_deck_type(self):
+        d = Deck(deck_type="Stream Deck +")
+        plus = _make_mock_device(deck_type="Stream Deck +", serial="PLUS1")
+        mini = _make_mock_device(deck_type="Stream Deck Mini", serial="MINI1")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [plus, mini]
+            await d.start()
+            assert d._device is plus
+            await d.stop()
+
+    async def test_start_no_matching_type_raises(self):
+        d = Deck(deck_type="Stream Deck XL")
+        plus = _make_mock_device(deck_type="Stream Deck +")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [plus]
+            with pytest.raises(DeckError, match="No devices of type"):
+                await d.start()
+
+    async def test_start_remembers_serial(self):
+        """After start(), serial_number is stored for reconnect."""
+        d = Deck()
+        dev = _make_mock_device(serial="AUTO_SERIAL")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            await d.start()
+            assert d._serial_number == "AUTO_SERIAL"
+            await d.stop()
+
+
+# ── on_reconnect / on_disconnect decorators ─────────────────────────────
+
+
+class TestDeckReconnectDisconnectHandlers:
+    def test_on_reconnect_decorator(self):
+        d = Deck()
+
+        @d.on_reconnect
+        async def handler():
+            pass
+
+        assert d._on_reconnect_handler is handler
+
+    def test_on_disconnect_decorator(self):
+        d = Deck()
+
+        @d.on_disconnect
+        async def handler():
+            pass
+
+        assert d._on_disconnect_handler is handler
+
+
+# ── Deck._handle_disconnect ─────────────────────────────────────────────
+
+
+class TestDeckHandleDisconnect:
+    async def test_handle_disconnect_calls_handler(self):
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.1)
+        d._running = True
+        d._serial_number = "TEST123"
+        d._device = _make_mock_device()
+        d._transport = MagicMock()
+
+        disconnect_called = asyncio.Event()
+
+        @d.on_disconnect
+        async def on_disc():
+            disconnect_called.set()
+
+        # Make reconnect loop fail immediately by stopping
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            d._running = False
+
+        asyncio.create_task(stop_soon())
+        await d._handle_disconnect()
+        assert disconnect_called.is_set()
+
+    async def test_handle_disconnect_cleans_transport(self):
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.1)
+        d._running = True
+        d._serial_number = "TEST123"
+        d._device = _make_mock_device()
+        transport = MagicMock()
+        d._transport = transport
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            d._running = False
+
+        asyncio.create_task(stop_soon())
+        await d._handle_disconnect()
+        transport.stop.assert_called_once()
+        assert d._transport is None
+
+
+# ── Deck._reconnect_loop ────────────────────────────────────────────────
+
+
+class TestDeckReconnectLoop:
+    async def test_reconnect_finds_device(self):
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.05)
+        d._running = True
+        d._serial_number = "RECON1"
+        d._executor.__class__ = type(d._executor)  # keep executor alive
+
+        dev = _make_mock_device(serial="RECON1")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            await d._reconnect_loop()
+
+        assert d._device is dev
+        assert d._reconnecting is False
+        # Clean up
+        d._running = False
+        if d._transport:
+            d._transport.stop()
+
+    async def test_reconnect_exits_when_stopped(self):
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.05)
+        d._running = True
+        d._serial_number = "GONE"
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+
+            async def stop_soon():
+                await asyncio.sleep(0.1)
+                d._running = False
+
+            asyncio.create_task(stop_soon())
+            await d._reconnect_loop()
+
+        assert d._reconnecting is False
+
+    async def test_reconnect_calls_reconnect_handler(self):
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.05)
+        d._running = True
+        d._serial_number = "RECON2"
+
+        reconnect_called = asyncio.Event()
+
+        @d.on_reconnect
+        async def on_recon():
+            reconnect_called.set()
+
+        dev = _make_mock_device(serial="RECON2")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            await d._reconnect_loop()
+
+        assert reconnect_called.is_set()
+        d._running = False
+        if d._transport:
+            d._transport.stop()
+
+    async def test_reconnect_re_renders_active_screen(self):
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.05)
+        d._running = True
+        d._serial_number = "RECON3"
+
+        # Set up an active screen
+        screen = d.screen("main")
+        d._active_screen = screen
+        d._active_page = screen
+
+        dev = _make_mock_device(serial="RECON3")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            with patch.object(
+                d, "_render_all_keys", new_callable=AsyncMock
+            ) as mock_render:
+                with patch.object(
+                    d, "_render_touchscreen", new_callable=AsyncMock
+                ):
+                    await d._reconnect_loop()
+                    mock_render.assert_awaited_once()
+
+        d._running = False
+        if d._transport:
+            d._transport.stop()
+
+
+# ── Deck.wait_for_device ────────────────────────────────────────────────
+
+
+class TestDeckWaitForDevice:
+    async def test_wait_for_device_immediate(self):
+        dev = _make_mock_device(serial="WAIT1")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            deck = await Deck.wait_for_device(poll_interval=0.05)
+            assert deck._device is dev
+            assert deck._running is True
+            await deck.stop()
+
+    async def test_wait_for_device_retries(self):
+        dev = _make_mock_device(serial="WAIT2")
+        call_count = 0
+
+        def enumerate_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return []
+            return [dev]
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.side_effect = enumerate_side_effect
+            deck = await asyncio.wait_for(
+                Deck.wait_for_device(poll_interval=0.05), timeout=5.0
+            )
+            assert deck._device is dev
+            assert call_count >= 3
+            await deck.stop()
+
+    async def test_wait_for_device_with_serial(self):
+        dev = _make_mock_device(serial="SPECIFIC")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            deck = await Deck.wait_for_device(
+                serial_number="SPECIFIC", poll_interval=0.05
+            )
+            assert deck._serial_number == "SPECIFIC"
+            await deck.stop()
+
+    async def test_wait_for_device_with_deck_type(self):
+        dev = _make_mock_device(deck_type="Stream Deck +", serial="TYPED")
+
+        with patch("deckboard.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+            deck = await Deck.wait_for_device(
+                deck_type="Stream Deck +", poll_interval=0.05
+            )
+            assert deck._deck_type == "Stream Deck +"
+            await deck.stop()
+
+
+# ── Event loop auto-reconnect trigger ────────────────────────────────────
+
+
+class TestEventLoopAutoReconnect:
+    async def test_event_loop_crash_triggers_reconnect(self):
+        """When auto_reconnect is True and event loop crashes, _handle_disconnect is called."""
+        d = Deck(auto_reconnect=True, reconnect_poll_interval=0.05)
+        d._running = True
+        d._serial_number = "CRASH1"
+
+        transport = MagicMock()
+        q = MagicMock()
+
+        async def exploding_get():
+            raise RuntimeError("HID disconnected")
+
+        q.get = exploding_get
+        transport.queue = q
+        d._transport = transport
+
+        with patch.object(
+            d, "_handle_disconnect", new_callable=AsyncMock
+        ) as mock_handle:
+            await d._event_loop()
+            mock_handle.assert_awaited_once()
+
+    async def test_event_loop_crash_without_reconnect_sets_closed(self):
+        """Without auto_reconnect, crash sets closed_event normally."""
+        d = Deck(auto_reconnect=False)
+        d._running = True
+
+        transport = MagicMock()
+        q = MagicMock()
+
+        async def exploding_get():
+            raise RuntimeError("HID disconnected")
+
+        q.get = exploding_get
+        transport.queue = q
+        d._transport = transport
+
+        await d._event_loop()
+        assert d._closed_event.is_set()


### PR DESCRIPTION
## Summary

- Add `list_devices()` async function for standalone device enumeration with optional `deck_type` and `visual_only` filters
- Add `deck_type` filter parameter to `Deck` constructor to target specific hardware models
- Add `auto_reconnect` support to `Deck` with `on_reconnect`/`on_disconnect` decorator callbacks
- Add `Deck.wait_for_device()` class method that polls until a matching device appears
- Add `is_connected` and `is_reconnecting` properties to `Deck`
- Add `DeckManager` class for multi-device orchestration with hot-plug detection via periodic HID scanning
- Add `examples/multi_device.py` demonstrating all new features
- Update README with documentation for all new APIs
- 54 new tests across 3 test files (933 total, 96.77% coverage)

## New modules

- `src/deckboard/runtime/discovery.py` — `list_devices()` function
- `src/deckboard/runtime/manager.py` — `DeckManager` class