### PR TITLE
Fix DeckManager scan loop stealing HID handles from active Decks

### DIFF
--- a/src/deckboard/runtime/deck.py
+++ b/src/deckboard/runtime/deck.py
@@ -183,6 +183,13 @@ class Deck:
     # -- Device capabilities -----------------------------------------------
 
     @property
+    def device_path(self) -> str | None:
+        """HID device path, or ``None`` if not opened."""
+        if self._device is None:
+            return None
+        return self._device.id()
+
+    @property
     def is_connected(self) -> bool:
         """Whether the device is currently connected and operational."""
         return self._device is not None and self._running

--- a/src/deckboard/runtime/manager.py
+++ b/src/deckboard/runtime/manager.py
@@ -220,11 +220,28 @@ class DeckManager:
 
         visual = [d for d in devices if d.DECK_VISUAL]
 
-        # Read serials from all connected devices
+        # Build a set of HID device paths owned by running Decks.  We must
+        # never re-open these — opening an HID device that is already held by
+        # a running Deck steals the file descriptor and causes an immediate
+        # disconnect / reconnect loop.
+        managed_paths: dict[str, str] = {}  # path -> serial
+        for serial, deck in self._decks.items():
+            path = deck.device_path
+            if path is not None:
+                managed_paths[path] = serial
+
+        # Match enumerated devices to tracked decks by HID path, and only
+        # open unknown devices to read their serial.
         connected_serials: set[str] = set()
         device_by_serial: dict[str, Any] = {}
 
         for d in visual:
+            dev_path = d.id()
+            if dev_path in managed_paths:
+                # Device is already managed — mark as still connected
+                # without touching the HID handle.
+                connected_serials.add(managed_paths[dev_path])
+                continue
             try:
                 await loop.run_in_executor(self._executor, d.open)
                 serial = d.get_serial_number()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -44,6 +44,7 @@ def _make_raw_device(
     d.key_layout.return_value = (4, 2)
     d.dial_count.return_value = 4
 
+    d.id.return_value = f"/dev/hid/{serial}"
     d.open.return_value = None
     d.close.return_value = None
     d.reset.return_value = None
@@ -209,6 +210,7 @@ class TestDeckManagerScanOnce:
         mock_deck.stop = AsyncMock()
         mock_deck.info = MagicMock()
         mock_deck.info.serial = "GONE1"
+        mock_deck.device_path = "/dev/hid/GONE1"
         m._decks["GONE1"] = mock_deck
 
         with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
@@ -229,7 +231,9 @@ class TestDeckManagerScanOnce:
             connect_count += 1
 
         # Pre-populate
-        m._decks["EXISTING"] = MagicMock()
+        mock_existing = MagicMock()
+        mock_existing.device_path = "/dev/hid/EXISTING"
+        m._decks["EXISTING"] = mock_existing
 
         dev = _make_raw_device(serial="EXISTING")
 
@@ -325,6 +329,7 @@ class TestDeckManagerDisconnectInfoError:
         mock_deck = MagicMock()
         mock_deck.stop = AsyncMock()
         type(mock_deck).info = property(lambda self: (_ for _ in ()).throw(Exception("no device")))
+        mock_deck.device_path = "/dev/hid/FALLBACK1"
         m._decks["FALLBACK1"] = mock_deck
 
         with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:
@@ -450,6 +455,7 @@ class TestDeckManagerReconnect:
         mock_deck.stop = AsyncMock()
         mock_deck.info = MagicMock()
         mock_deck.info.serial = "DISC_ERR"
+        mock_deck.device_path = "/dev/hid/DISC_ERR"
         m._decks["DISC_ERR"] = mock_deck
 
         with patch("deckboard.runtime.manager.DeviceManager") as mock_dm:


### PR DESCRIPTION
## Summary
- `_scan_once()` was opening every enumerated HID device each poll cycle to read its serial — including devices already held by a running `Deck`. This stole the HID file descriptor, causing an immediate disconnect/reconnect loop.
- Now tracks managed HID device paths via `Deck.device_path` and skips re-opening devices whose path is already owned by a running Deck.
- All 908 tests pass, coverage 97.42%.