### PR TITLE
Update repository URLs to DeckUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Graphras-com/deckui"
-Repository = "https://github.com/Graphras-com/deckui"
-Issues = "https://github.com/Graphras-com/deckui/issues"
+Homepage = "https://github.com/Graphras-com/DeckUI"
+Repository = "https://github.com/Graphras-com/DeckUI"
+Issues = "https://github.com/Graphras-com/DeckUI/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/deckui"]

--- a/src/deckui/dsui/iconify.py
+++ b/src/deckui/dsui/iconify.py
@@ -26,7 +26,7 @@ _REQUEST_TIMEOUT = 10.0
 # the default ``Python-urllib/x.y`` UA, so we identify ourselves with
 # the library name.  Exposed as a module attribute so tests and users
 # can override it if needed.
-USER_AGENT = "deckui/0.1.0 (+https://github.com/graphras-com/deckui)"
+USER_AGENT = "deckui/0.1.0 (+https://github.com/graphras-com/DeckUI)"
 
 # In-process cache: maps "prefix:name" -> SVG source bytes.  ``None``
 # marks a name that has been looked up and failed to load, so we do not


### PR DESCRIPTION
## Summary
- Update GitHub URLs in pyproject.toml and User-Agent string in iconify.py to match the renamed repository (Graphras-com/DeckUI)