### PR TITLE
Remove dead code, legacy aliases, and redundant patterns for v1.0

### DIFF
--- a/src/deckui/dsui/key.py
+++ b/src/deckui/dsui/key.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import io
 import logging
 from typing import TYPE_CHECKING, Any
 
 from PIL import Image
 
+from ..render.key_renderer import _encode_image
 from ..render.metrics import KEY_SIZE
 from ..ui.controls.key_slot import KeySlot
 from .event_map import EventMap
@@ -239,7 +239,9 @@ class DsuiKey(KeySlot):
         img = self._renderer.render()
         if img.size != size:
             img = img.resize(size, Image.Resampling.LANCZOS)
-        return self._encode_image(img, image_format)
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        return _encode_image(img, image_format)
 
     @property
     def has_dsui_content(self) -> bool:
@@ -267,20 +269,3 @@ class DsuiKey(KeySlot):
         else:
             # Fall back to base KeySlot on_press/on_release decorators
             await super().dispatch(pressed)
-
-    # -- Private helpers ---------------------------------------------------
-
-    @staticmethod
-    def _encode_image(
-        img: Image.Image, image_format: str = "JPEG", quality: int = 90
-    ) -> bytes:
-        """Encode a PIL image in the specified format."""
-        buf = io.BytesIO()
-        if img.mode != "RGB":
-            img = img.convert("RGB")
-        fmt = image_format.upper()
-        if fmt == "BMP":
-            img.save(buf, format="BMP")
-        else:
-            img.save(buf, format="JPEG", quality=quality)
-        return buf.getvalue()

--- a/src/deckui/render/key_renderer.py
+++ b/src/deckui/render/key_renderer.py
@@ -56,13 +56,6 @@ def render_blank_key(
     return render_key_image(key_size=key_size, image_format=image_format)
 
 
-def _encode_jpeg(img: Image.Image, quality: int = 90) -> bytes:
-    """Encode a PIL image as JPEG bytes."""
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=quality)
-    return buf.getvalue()
-
-
 def _encode_image(
     img: Image.Image, image_format: str = "JPEG", quality: int = 90
 ) -> bytes:

--- a/src/deckui/render/metrics.py
+++ b/src/deckui/render/metrics.py
@@ -1,9 +1,9 @@
 """Rendering metrics derived from device capabilities.
 
-Instead of hardcoded constants, all metrics are computed from a
+All metrics are computed from a
 :class:`~deckui.runtime.capabilities.DeviceCapabilities` instance.
-Default module-level constants are provided for backward compatibility
-with the Stream Deck+ profile.
+Default module-level constants are provided as convenience aliases
+for the Stream Deck+ profile.
 """
 
 from __future__ import annotations
@@ -87,8 +87,8 @@ def _default_metrics() -> RenderMetrics:
     return RenderMetrics(STREAM_DECK_PLUS)
 
 
-# Module-level constants for backward compatibility.
-# These match the original Stream Deck+ hardcoded values.
+# Module-level constants for the Stream Deck+ profile.
+# Used by the preview tool and as convenient defaults.
 _DEFAULT = _default_metrics()
 
 KEY_SIZE = _DEFAULT.key_size

--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -73,8 +73,6 @@ class Deck:
         # Screens
         self._screens: dict[str, Screen] = {}
         self._active_screen: Screen | None = None
-        self._pages = self._screens
-        self._active_page: Screen | None = None
 
     # -- Lifecycle ---------------------------------------------------------
 
@@ -278,7 +276,6 @@ class Deck:
             raise DeckError(f"Screen '{name}' does not exist")
 
         self._active_screen = self._screens[name]
-        self._active_page = self._active_screen
         logger.info("Switching to screen: %s", name)
 
         # Render all keys and cards for this screen
@@ -293,7 +290,7 @@ class Deck:
         return self._active_screen
 
     def _current_screen(self) -> Screen | None:
-        return self._active_screen or self._active_page
+        return self._active_screen
 
     # -- Rendering ---------------------------------------------------------
 

--- a/src/deckui/runtime/device_info.py
+++ b/src/deckui/runtime/device_info.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class DeviceInfo:
     """Information about a connected Stream Deck device."""
 

--- a/src/deckui/runtime/events.py
+++ b/src/deckui/runtime/events.py
@@ -76,19 +76,4 @@ class TouchEvent:
         zone = rel // stride
         return max(0, min(zone, metrics.panel_count - 1))
 
-    @property
-    def zone(self) -> int:
-        """Which touch-strip zone (0-3) this touch falls in.
-
-        Uses default Stream Deck+ metrics. For multi-device support,
-        use :meth:`compute_zone` with the device's render metrics.
-        """
-        from ..render.metrics import MARGIN_LEFT, PANEL_GAP, PANEL_WIDTH
-
-        rel = self.x - MARGIN_LEFT
-        stride = PANEL_WIDTH + PANEL_GAP
-        zone = rel // stride
-        return max(0, min(zone, 3))
-
-
 DeckEvent = KeyEvent | EncoderTurnEvent | EncoderPressEvent | TouchEvent

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -45,8 +45,8 @@ class TestDeckInit:
         assert deck._device is None
         assert deck._transport is None
         assert deck._running is False
-        assert deck._active_page is None
-        assert deck._pages == {}
+        assert deck._active_screen is None
+        assert deck._screens == {}
 
     def test_custom_brightness(self):
         d = Deck(serial_number="ABC123", brightness=50)
@@ -73,7 +73,7 @@ class TestDeckPage:
         b = deck.screen("main")
         assert a is b
 
-    def test_different_pages(self, deck):
+    def test_different_screens(self, deck):
         a = deck.screen("main")
         b = deck.screen("settings")
         assert a is not b
@@ -123,7 +123,7 @@ class TestDeckSetPage:
         with pytest.raises(DeckError, match="Screen 'missing' does not exist"):
             await deck.set_screen("missing")
 
-    async def test_sets_active_page(self, deck):
+    async def test_sets_active_screen(self, deck):
         deck.screen("main")
         # Patch rendering methods since no device
         deck._render_all_keys = AsyncMock()
@@ -155,14 +155,14 @@ class TestDeckActivePage:
 
 
 class TestDeckRefresh:
-    async def test_no_active_page(self, deck):
+    async def test_no_active_screen(self, deck):
         """refresh() is a no-op when no active page."""
         await deck.refresh()  # Should not raise
 
     async def test_renders_dirty_touchscreen(self, deck):
         p = deck.screen("main")
         # BlankCards start dirty, so touch strip is dirty by default
-        deck._active_page = p
+        deck._active_screen = p
         deck._render_touchscreen = AsyncMock()
 
         await deck.refresh()
@@ -173,7 +173,7 @@ class TestDeckRefresh:
         for w in p.cards:
             w.mark_clean()
 
-        deck._active_page = p
+        deck._active_screen = p
         deck._render_touchscreen = AsyncMock()
 
         await deck.refresh()
@@ -184,7 +184,7 @@ class TestDeckRefresh:
 
 
 class TestDeckDispatch:
-    async def test_no_active_page(self, deck):
+    async def test_no_active_screen(self, deck):
         """_dispatch is a no-op with no active page."""
         event = KeyEvent(key=0, pressed=True)
         await deck._dispatch(event)  # Should not raise
@@ -193,7 +193,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.key(0).on_press(handler)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(KeyEvent(key=0, pressed=True))
         handler.assert_awaited_once()
@@ -202,7 +202,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.key(0).on_release(handler)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(KeyEvent(key=0, pressed=False))
         handler.assert_awaited_once()
@@ -211,14 +211,14 @@ class TestDeckDispatch:
         """No error when key has no handler."""
         p = deck.screen("main")
         p.key(0)  # No handler registered
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(KeyEvent(key=0, pressed=True))  # Should not raise
 
     async def test_key_event_unknown_key(self, deck):
         """No error when event targets a key that doesn't exist on the page."""
         p = deck.screen("main")
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(KeyEvent(key=7, pressed=True))  # No key 7
 
@@ -231,7 +231,7 @@ class TestDeckDispatch:
             key_slot._dirty = True
 
         key_slot.on_press(mark_dirty)
-        deck._active_page = p
+        deck._active_screen = p
         key_slot._dirty = False
 
         with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
@@ -243,7 +243,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         key_slot = p.key(0)
         key_slot.on_press(AsyncMock())
-        deck._active_page = p
+        deck._active_screen = p
         key_slot._dirty = False
 
         with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
@@ -254,7 +254,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.encoder(1).on_turn(handler)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderTurnEvent(encoder=1, direction=3))
         handler.assert_awaited_once_with(3)
@@ -262,13 +262,13 @@ class TestDeckDispatch:
     async def test_encoder_turn_no_handler(self, deck):
         p = deck.screen("main")
         p.encoder(1)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderTurnEvent(encoder=1, direction=1))
 
     async def test_encoder_turn_unknown_encoder(self, deck):
         p = deck.screen("main")
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderTurnEvent(encoder=2, direction=1))
 
@@ -277,7 +277,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         card = _TestCard(1)
         p.set_card(1, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         turn_handler = AsyncMock()
         card.on_encoder_turn(turn_handler)
@@ -291,7 +291,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.encoder(0).on_press(handler)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderPressEvent(encoder=0, pressed=True))
         handler.assert_awaited_once()
@@ -300,7 +300,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.encoder(0).on_release(handler)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderPressEvent(encoder=0, pressed=False))
         handler.assert_awaited_once()
@@ -308,13 +308,13 @@ class TestDeckDispatch:
     async def test_encoder_press_no_handler(self, deck):
         p = deck.screen("main")
         p.encoder(0)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderPressEvent(encoder=0, pressed=True))
 
     async def test_encoder_press_unknown_encoder(self, deck):
         p = deck.screen("main")
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._dispatch(EncoderPressEvent(encoder=3, pressed=True))
 
@@ -323,7 +323,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         press_handler = AsyncMock()
         card.on_encoder_press(press_handler)
@@ -338,7 +338,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         release_handler = AsyncMock()
         card.on_encoder_release(release_handler)
@@ -351,7 +351,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         handler = AsyncMock()
         card.on_encoder_press(handler)
@@ -363,7 +363,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.card(0).on_tap(handler)
-        deck._active_page = p
+        deck._active_screen = p
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
 
         await deck._dispatch(TouchEvent(event_type=EventType.TOUCH_SHORT, x=50, y=50))
@@ -373,7 +373,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.card(1).on_long_press(handler)
-        deck._active_page = p
+        deck._active_screen = p
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
 
         await deck._dispatch(TouchEvent(event_type=EventType.TOUCH_LONG, x=300, y=50))
@@ -383,7 +383,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.card(2).on_drag(handler)
-        deck._active_page = p
+        deck._active_screen = p
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
 
         await deck._dispatch(
@@ -399,7 +399,7 @@ class TestDeckDispatch:
 
     async def test_touch_no_handler(self, deck):
         p = deck.screen("main")
-        deck._active_page = p
+        deck._active_screen = p
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
 
         await deck._dispatch(TouchEvent(event_type=EventType.TOUCH_SHORT, x=50, y=50))
@@ -409,7 +409,7 @@ class TestDeckDispatch:
         p = deck.screen("main")
         handler = AsyncMock()
         p.card(3).on_tap(handler)
-        deck._active_page = p
+        deck._active_screen = p
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
 
         await deck._dispatch(TouchEvent(event_type=EventType.TOUCH_SHORT, x=700, y=50))
@@ -427,7 +427,7 @@ class TestDeckDispatchCardCallbacks:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         handler = AsyncMock()
         card.on_encoder_turn(handler)
@@ -442,7 +442,7 @@ class TestDeckDispatchCardCallbacks:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         call_order = []
 
@@ -481,7 +481,7 @@ class TestDeckDispatchCardCallbacks:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
         deck._render_touchscreen = AsyncMock()
 
         change_handler = AsyncMock()
@@ -497,7 +497,7 @@ class TestDeckDispatchCardCallbacks:
 class TestDeckRenderAllKeys:
     async def test_no_device(self, deck):
         """No-op when device is None."""
-        deck._active_page = deck.screen("main")
+        deck._active_screen = deck.screen("main")
         await deck._render_all_keys()  # Should not raise
 
     async def test_renders_with_device(self, deck, mock_streamdeck_device):
@@ -505,7 +505,7 @@ class TestDeckRenderAllKeys:
         deck._caps = STREAM_DECK_PLUS
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
         p = deck.screen("main")
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._render_all_keys()
         # Should have called set_key_image for all 8 keys (all blank)
@@ -518,7 +518,7 @@ class TestDeckRenderAllKeys:
 class TestDeckRenderTouchscreen:
     async def test_no_device(self, deck):
         """No-op when device is None."""
-        deck._active_page = deck.screen("main")
+        deck._active_screen = deck.screen("main")
         await deck._render_touchscreen()  # Should not raise
 
     async def test_renders_with_device(self, deck, mock_streamdeck_device):
@@ -526,7 +526,7 @@ class TestDeckRenderTouchscreen:
         deck._caps = STREAM_DECK_PLUS
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
         p = deck.screen("main")
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._render_touchscreen()
         mock_streamdeck_device.set_touchscreen_image.assert_called_once()
@@ -538,7 +538,7 @@ class TestDeckRenderTouchscreen:
         p = deck.screen("main")
         card = _TestCard(0)
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         await deck._render_touchscreen()
         mock_streamdeck_device.set_touchscreen_image.assert_called_once()
@@ -716,16 +716,16 @@ class TestDeckIsConnected:
 class TestDeckCheckTimeouts:
     """Tests for _check_timeouts — periodic card selection timeout checks."""
 
-    async def test_no_active_page_is_noop(self, deck):
+    async def test_no_active_screen_is_noop(self, deck):
         """_check_timeouts does nothing when no page is active."""
-        deck._active_page = None
+        deck._active_screen = None
         await deck._check_timeouts()  # Should not raise
 
     async def test_no_expired_timeouts_no_refresh(self, deck):
         """No refresh when no card has an expired timeout."""
         p = deck.screen("main")
         # Default BlankCards always return False for check_selection_timeout
-        deck._active_page = p
+        deck._active_screen = p
 
         with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
             await deck._check_timeouts()
@@ -738,7 +738,7 @@ class TestDeckCheckTimeouts:
         # Override check_selection_timeout to return True (simulating expiry)
         card.check_selection_timeout = lambda: True  # type: ignore[assignment]
         p.set_card(0, card)
-        deck._active_page = p
+        deck._active_screen = p
 
         with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
             await deck._check_timeouts()
@@ -774,13 +774,13 @@ class TestDeckEventLoop:
             mock_check.assert_awaited()
         assert deck._closed_event.is_set()
 
-    async def test_event_loop_no_active_page_continues(self, deck):
+    async def test_event_loop_no_active_screen_continues(self, deck):
         """Event received but no active page -> continue."""
         transport = MagicMock()
         transport.queue = asyncio.Queue()
         deck._transport = transport
         deck._running = True
-        deck._active_page = None
+        deck._active_screen = None
 
         await transport.queue.put(KeyEvent(key=0, pressed=True))
 
@@ -798,7 +798,7 @@ class TestDeckEventLoop:
         transport.queue = asyncio.Queue()
         deck._transport = transport
         deck._running = True
-        deck._active_page = deck.screen("main")
+        deck._active_screen = deck.screen("main")
 
         deck._dispatch = AsyncMock(side_effect=ValueError("handler error"))
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -7,7 +7,7 @@ import io
 from PIL import Image
 
 from deckui.render.key_renderer import (
-    _encode_jpeg,
+    _encode_image,
     render_blank_key,
     render_key_image,
 )
@@ -234,22 +234,29 @@ class TestRenderBlankTouchscreen:
         assert b < 50
 
 
-# ── _encode_jpeg ────────────────────────────────────────────────────────
+# ── _encode_image ───────────────────────────────────────────────────────
 
 
-class TestEncodeJpeg:
+class TestEncodeImage:
     def test_returns_bytes(self):
         img = Image.new("RGB", (10, 10), "red")
-        result = _encode_jpeg(img)
+        result = _encode_image(img)
         assert isinstance(result, bytes)
 
-    def test_is_jpeg(self):
+    def test_is_jpeg_by_default(self):
         img = Image.new("RGB", (10, 10))
-        assert _encode_jpeg(img)[:2] == b"\xff\xd8"
+        assert _encode_image(img)[:2] == b"\xff\xd8"
 
     def test_quality_parameter(self):
         img = Image.new("RGB", (100, 100), "red")
-        low = _encode_jpeg(img, quality=10)
-        high = _encode_jpeg(img, quality=95)
+        low = _encode_image(img, quality=10)
+        high = _encode_image(img, quality=95)
         # Lower quality should produce smaller file
         assert len(low) < len(high)
+
+    def test_bmp_format(self):
+        img = Image.new("RGB", (10, 10), "red")
+        result = _encode_image(img, image_format="BMP")
+        assert isinstance(result, bytes)
+        # BMP magic bytes: "BM"
+        assert result[:2] == b"BM"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,6 +6,8 @@ import dataclasses
 
 import pytest
 
+from deckui.render.metrics import RenderMetrics
+from deckui.runtime.capabilities import STREAM_DECK_PLUS
 from deckui.runtime.device_info import DeviceInfo
 from deckui.runtime.events import (
     EncoderPressEvent,
@@ -132,30 +134,35 @@ class TestTouchEvent:
 
     def test_zone_first_widget(self):
         """Touches within the first widget zone (left margin to end of widget 0)."""
+        metrics = RenderMetrics(STREAM_DECK_PLUS)
         # Left edge of screen (within left margin) still maps to zone 0
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=0, y=0).zone == 0
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=0, y=0).compute_zone(metrics) == 0
         # Inside widget 0 area
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=4, y=0).zone == 0
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=198, y=0).zone == 0
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=4, y=0).compute_zone(metrics) == 0
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=198, y=0).compute_zone(metrics) == 0
 
     def test_zone_second_widget(self):
         """Touches within the second widget zone."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=203, y=0).zone == 1
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=397, y=0).zone == 1
+        metrics = RenderMetrics(STREAM_DECK_PLUS)
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=203, y=0).compute_zone(metrics) == 1
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=397, y=0).compute_zone(metrics) == 1
 
     def test_zone_third_widget(self):
         """Touches within the third widget zone."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=402, y=0).zone == 2
+        metrics = RenderMetrics(STREAM_DECK_PLUS)
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=402, y=0).compute_zone(metrics) == 2
 
     def test_zone_fourth_widget(self):
         """Touches within the fourth widget zone."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=601, y=0).zone == 3
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=799, y=0).zone == 3
+        metrics = RenderMetrics(STREAM_DECK_PLUS)
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=601, y=0).compute_zone(metrics) == 3
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=799, y=0).compute_zone(metrics) == 3
 
     def test_zone_capped_at_3(self):
         """x >= 800 should still return zone 3 (capped)."""
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=1000, y=0).zone == 3
-        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=800, y=0).zone == 3
+        metrics = RenderMetrics(STREAM_DECK_PLUS)
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=1000, y=0).compute_zone(metrics) == 3
+        assert TouchEvent(event_type=EventType.TOUCH_SHORT, x=800, y=0).compute_zone(metrics) == 3
 
 
 # ── DeviceInfo ──────────────────────────────────────────────────────────
@@ -184,8 +191,8 @@ class TestDeviceInfo:
         assert info.touchscreen_size == (800, 100)
         assert info.key_image_format == "JPEG"
 
-    def test_is_mutable(self):
-        """DeviceInfo is a regular (non-frozen) dataclass."""
+    def test_is_frozen(self):
+        """DeviceInfo is a frozen dataclass."""
         info = DeviceInfo(
             deck_type="x",
             serial="x",
@@ -197,8 +204,8 @@ class TestDeviceInfo:
             touchscreen_size=(0, 0),
             key_image_format="x",
         )
-        info.deck_type = "changed"
-        assert info.deck_type == "changed"
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            info.deck_type = "changed"  # type: ignore[misc]
 
 
 # ── DeckEvent union ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pre-release cleanup audit: removes dead code, legacy compatibility layers, and redundant patterns. No backward compatibility preserved — this targets a fresh v1.0 public release.

## Changes by category

### Dead code removal
- **`key_renderer._encode_jpeg()`** — unused function superseded by `_encode_image()`. Tests updated to cover `_encode_image()` directly (including BMP format).

### Legacy / backward compatibility removal
- **`Deck._pages` and `Deck._active_page`** — legacy aliases for `_screens` / `_active_screen`. Removed the aliases and simplified `_current_screen()` to return `_active_screen` directly instead of `_active_screen or _active_page`.
- **`TouchEvent.zone` property** — hardcoded for Stream Deck+ only. Removed in favor of the device-aware `compute_zone(metrics)` method that already existed. Tests updated to use `compute_zone()` with `RenderMetrics(STREAM_DECK_PLUS)`.
- **`metrics.py` docstring** — removed "backward compatibility" framing; constants are now documented as "convenience aliases for the Stream Deck+ profile".

### Duplicated logic elimination
- **`DsuiKey._encode_image()`** — identical to `key_renderer._encode_image()`. Replaced with a direct import. The RGB conversion is now done inline before calling the shared function.

### Consistency improvements
- **`DeviceInfo`** — changed from mutable `@dataclass` to `@dataclass(frozen=True, slots=True)` for consistency with every other dataclass in the codebase (`KeyEvent`, `EncoderTurnEvent`, `TouchEvent`, `DeviceCapabilities`, etc.). Test updated to verify frozen behavior.

## Test results
- All 908 tests pass
- Coverage: 97.64% (threshold: 95%)

## Items for manual review
- The `DeviceInfo` freeze is a behavioral change — any code that mutates a `DeviceInfo` after construction will break. No such code exists in the repo, but downstream users should be aware.
- `TouchEvent.zone` removal is a public API deletion. The replacement `compute_zone(metrics)` requires a `RenderMetrics` argument. This is intentional for multi-device support.