### PR TITLE
Fix gitleaks badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DeckUI
 
 [![CI](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml/badge.svg)](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml)
-[![Gitleaks](https://github.com/graphras-com/DeckUI/actions/workflows/python-gitleaks.yml/badge.svg)](https://github.com/graphras-com/DeckUI/actions/workflows/python-gitleaks.yml)
+[![gitleaks](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml/badge.svg)](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/graphras-com/DeckUI/network/updates)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)


### PR DESCRIPTION
## Summary
- Replace broken gitleaks badge that pointed to the reusable workflow (`python-gitleaks.yml`) with a working badge pointing to `ci.yml` which actually runs the gitleaks scan
- Badge now shows the real status of the gitleaks scan