### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # DeckUI
 
 [![CI](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml/badge.svg)](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml)
-[![gitleaks](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml/badge.svg)](https://github.com/graphras-com/DeckUI/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
+[![gitleaks](https://img.shields.io/badge/protected%20by-gitleaks-blue)](https://github.com/gitleaks/gitleaks)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/graphras-com/DeckUI/network/updates)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 
 A high-level, asyncio-native Python library for Elgato Stream Deck devices. Define screen layouts, key actions, encoder controls, and touchscreen card UIs using a declarative, event-driven API.
 


### PR DESCRIPTION
## Summary
- Replace gitleaks badge with shields.io static badge linking to gitleaks repo
- Reorder badges: CI, Python, gitleaks, Dependabot, License