### PR TITLE
chore: sync DeckUI Ruff lint config with HaClient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,20 @@ target-version = "py311"
 src = ["src"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "UP", "B", "SIM", "TCH"]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+    "C4",  # comprehensions
+    "SIM", # simplify
+]
+ignore = ["B008"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B011"]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## Summary
- align `tool.ruff.lint` in `DeckUI` with the `HaClient` configuration
- replace the old rule set with the expanded select list from `HaClient`
- add the matching `ignore` and `per-file-ignores` entries

## Verification
- parse `pyproject.toml` with `python3` `tomllib`
