### PR TITLE
docs: convert all docstrings to NumPy style

### DIFF
--- a/src/deckui/__init__.py
+++ b/src/deckui/__init__.py
@@ -1,6 +1,8 @@
 """deckui - A high-level, asyncio-native library for Elgato Stream Deck devices.
 
-Example::
+Examples
+--------
+::
 
     import asyncio
     from deckui import DeckManager

--- a/src/deckui/dsui/__init__.py
+++ b/src/deckui/dsui/__init__.py
@@ -3,7 +3,9 @@
 Load SVG + YAML packages and use them as touchscreen cards or physical keys
 without writing any Python rendering code.
 
-Example::
+Examples
+--------
+::
 
     from deckui.dsui import DsuiCard, load_package
 

--- a/src/deckui/dsui/card.py
+++ b/src/deckui/dsui/card.py
@@ -28,7 +28,9 @@ class DsuiCard(Card):
     loads the package, lets you set binding values, and renders the SVG
     into a PIL Image for the Stream Deck touchscreen.
 
-    Usage::
+    Examples
+    --------
+    ::
 
         from deckui.dsui import load_package, DsuiCard
 
@@ -43,8 +45,10 @@ class DsuiCard(Card):
     The card index is assigned automatically when you install the card
     on a screen with :meth:`~deckui.ui.screen.Screen.set_card`.
 
-    Args:
-        spec: A validated :class:`~deckui.dsui.schema.PackageSpec`.
+    Parameters
+    ----------
+    spec
+        A validated :class:`~deckui.dsui.schema.PackageSpec`.
     """
 
     def __init__(self, spec: PackageSpec) -> None:
@@ -61,15 +65,22 @@ class DsuiCard(Card):
     def set(self, name: str, value: Any) -> DsuiCard:
         """Set a binding value.  Marks the card dirty if changed.
 
-        Args:
-            name: Binding name as defined in the manifest.
-            value: New value (type depends on binding kind).
+        Parameters
+        ----------
+        name
+            Binding name as defined in the manifest.
+        value
+            New value (type depends on binding kind).
 
-        Returns:
+        Returns
+        -------
+        DsuiCard
             self, for method chaining.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
         """
         if self._renderer.set(name, value):
             self.mark_dirty()
@@ -78,7 +89,9 @@ class DsuiCard(Card):
     def set_many(self, **kwargs: Any) -> DsuiCard:
         """Set multiple binding values at once.
 
-        Returns:
+        Returns
+        -------
+        DsuiCard
             self, for method chaining.
         """
         if self._renderer.set_many(**kwargs):
@@ -88,8 +101,10 @@ class DsuiCard(Card):
     def get(self, name: str) -> Any:
         """Get the current value of a binding.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
         """
         return self._renderer.get(name)
 
@@ -101,18 +116,28 @@ class DsuiCard(Card):
         Normalises *value* from ``[min_val, max_val]`` to ``[0.0, 1.0]``
         and delegates to :meth:`set`.
 
-        Args:
-            name: Binding name (must be a ``range`` or ``slider`` binding).
-            value: Value in domain units (e.g. 0–100 for a percentage).
-            min_val: Lower bound of the domain range.
-            max_val: Upper bound of the domain range.
+        Parameters
+        ----------
+        name
+            Binding name (must be a ``range`` or ``slider`` binding).
+        value
+            Value in domain units (e.g. 0–100 for a percentage).
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
 
-        Returns:
+        Returns
+        -------
+        DsuiCard
             self, for method chaining.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
-            ValueError: If *min_val* equals *max_val*.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
+        ValueError
+            If *min_val* equals *max_val*.
         """
         if min_val == max_val:
             raise ValueError("min_val and max_val must not be equal")
@@ -128,20 +153,30 @@ class DsuiCard(Card):
         Reads the current normalised value, denormalises it, adds *delta*,
         clamps, re-normalises, and calls :meth:`set`.
 
-        Args:
-            name: Binding name (must be a ``range`` or ``slider`` binding).
-            delta: Amount to add in domain units (negative to decrease).
-            min_val: Lower bound of the domain range.
-            max_val: Upper bound of the domain range.
+        Parameters
+        ----------
+        name
+            Binding name (must be a ``range`` or ``slider`` binding).
+        delta
+            Amount to add in domain units (negative to decrease).
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
 
-        Returns:
+        Returns
+        -------
+        float
             The new value in domain units (clamped to
             ``[min_val, max_val]``), so callers can use it for display
             without back-computing.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
-            ValueError: If *min_val* equals *max_val*.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
+        ValueError
+            If *min_val* equals *max_val*.
         """
         if min_val == max_val:
             raise ValueError("min_val and max_val must not be equal")
@@ -157,17 +192,26 @@ class DsuiCard(Card):
     ) -> float:
         """Get a range/slider binding denormalised to domain units.
 
-        Args:
-            name: Binding name.
-            min_val: Lower bound of the domain range.
-            max_val: Upper bound of the domain range.
+        Parameters
+        ----------
+        name
+            Binding name.
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
 
-        Returns:
+        Returns
+        -------
+        float
             The current value in domain units.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
-            ValueError: If *min_val* equals *max_val*.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
+        ValueError
+            If *min_val* equals *max_val*.
         """
         if min_val == max_val:
             raise ValueError("min_val and max_val must not be equal")
@@ -177,16 +221,22 @@ class DsuiCard(Card):
     def on(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
         """Decorator to register a handler for a named semantic event.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @card.on("toggle_play_pause")
             async def handle():
                 ...
 
-        Args:
-            event_name: Semantic event name from the manifest.
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
 
-        Returns:
+        Returns
+        -------
+        Callable
             A decorator that registers the handler and returns it unchanged.
         """
 
@@ -199,16 +249,21 @@ class DsuiCard(Card):
     def bind_event(self, event_name: str, handler: AsyncHandler) -> None:
         """Imperatively register a handler for a named semantic event.
 
-        Args:
-            event_name: Semantic event name from the manifest.
-            handler: The async callable to invoke.
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
+        handler
+            The async callable to invoke.
         """
         self._events.on(event_name, handler)
 
     def render(self) -> Image.Image:
         """Render the SVG layout with current bindings to a PIL Image.
 
-        Returns:
+        Returns
+        -------
+        Image.Image
             A PANEL_WIDTH x PANEL_HEIGHT RGB :class:`~PIL.Image.Image`.
         """
         return self._renderer.render()

--- a/src/deckui/dsui/event_map.py
+++ b/src/deckui/dsui/event_map.py
@@ -31,9 +31,12 @@ class EventMap:
     - Direction filtering: ``encoder_turn`` with ``direction: left``
       only fires for counter-clockwise turns.
 
-    Args:
-        events: Event mappings from the package manifest.
-        regions: Touch regions from the package manifest.
+    Parameters
+    ----------
+    events
+        Event mappings from the package manifest.
+    regions
+        Touch regions from the package manifest.
     """
 
     def __init__(
@@ -58,12 +61,17 @@ class EventMap:
     def on(self, event_name: str, handler: AsyncHandler) -> None:
         """Register a handler for a named semantic event.
 
-        Args:
-            event_name: The semantic event name (as defined in the manifest).
-            handler: An async callable to invoke when the event fires.
+        Parameters
+        ----------
+        event_name
+            The semantic event name (as defined in the manifest).
+        handler
+            An async callable to invoke when the event fires.
 
-        Raises:
-            KeyError: If *event_name* is not defined in the manifest.
+        Raises
+        ------
+        KeyError
+            If *event_name* is not defined in the manifest.
         """
         known = {m.name for m in self._mappings}
         if event_name not in known:
@@ -80,8 +88,10 @@ class EventMap:
     def _start_hold_timer(self, source: str) -> None:
         """Start a hold timer for the first matching hold mapping.
 
-        Args:
-            source: ``"key_hold"`` or ``"encoder_hold"``.
+        Parameters
+        ----------
+        source
+            ``"key_hold"`` or ``"encoder_hold"``.
         """
         for mapping in self._by_source.get(source, []):
             handler = self._handlers.get(mapping.name)
@@ -111,10 +121,14 @@ class EventMap:
     def handle_encoder_turn(self, direction: int) -> AsyncHandler | None:
         """Match an encoder turn to a semantic event.
 
-        Args:
-            direction: Positive for clockwise, negative for counter-clockwise.
+        Parameters
+        ----------
+        direction
+            Positive for clockwise, negative for counter-clockwise.
 
-        Returns:
+        Returns
+        -------
+        AsyncHandler or None
             The handler to call, or ``None`` if no mapping matched.
         """
         if self._pressed:
@@ -136,7 +150,9 @@ class EventMap:
         Records the press timestamp for gesture detection and starts
         a hold timer if an ``encoder_hold`` mapping exists.
 
-        Returns:
+        Returns
+        -------
+        list[AsyncHandler]
             A list of handlers to call (may be empty).
         """
         self._press_time = time.monotonic()
@@ -161,7 +177,9 @@ class EventMap:
         fired for this press–release cycle (since the interaction was
         a hold, not a press-release gesture).
 
-        Returns:
+        Returns
+        -------
+        list[AsyncHandler]
             A list of handlers to call (may be empty).
         """
         self._pressed = False
@@ -199,7 +217,9 @@ class EventMap:
         Records the press timestamp and starts a hold timer if a
         ``key_hold`` mapping exists.
 
-        Returns:
+        Returns
+        -------
+        list[AsyncHandler]
             A list of handlers to call (may be empty).
         """
         self._press_time = time.monotonic()
@@ -224,7 +244,9 @@ class EventMap:
         fired for this press–release cycle (since the interaction was
         a hold, not a press-release gesture).
 
-        Returns:
+        Returns
+        -------
+        list[AsyncHandler]
             A list of handlers to call (may be empty).
         """
         self._pressed = False
@@ -259,12 +281,18 @@ class EventMap:
     ) -> AsyncHandler | None:
         """Match a touch event to a semantic event via regions.
 
-        Args:
-            event_type: The touch event type (TOUCH_SHORT or TOUCH_LONG).
-            x: Touch x coordinate (relative to card origin).
-            y: Touch y coordinate (relative to card origin).
+        Parameters
+        ----------
+        event_type
+            The touch event type (TOUCH_SHORT or TOUCH_LONG).
+        x
+            Touch x coordinate (relative to card origin).
+        y
+            Touch y coordinate (relative to card origin).
 
-        Returns:
+        Returns
+        -------
+        AsyncHandler or None
             The handler to call, or ``None`` if no region/mapping matched.
         """
         from ..runtime.events import EventType as ET_Enum

--- a/src/deckui/dsui/iconify.py
+++ b/src/deckui/dsui/iconify.py
@@ -33,8 +33,10 @@ class IconifyError(Exception):
 def _parse_name(name: str) -> tuple[str, str]:
     """Split a ``"prefix:icon"`` name into its parts.
 
-    Raises:
-        IconifyError: If *name* is empty or not in ``prefix:icon`` form.
+    Raises
+    ------
+    IconifyError
+        If *name* is empty or not in ``prefix:icon`` form.
     """
     if not isinstance(name, str) or not name.strip():
         raise IconifyError(f"Iconify name must be a non-empty string, got {name!r}")
@@ -71,16 +73,22 @@ def fetch_icon(name: str) -> str:
     failure) are also cached so we do not retry broken references on
     every render.
 
-    Args:
-        name: Icon identifier in ``"prefix:icon"`` form, e.g.
-            ``"line-md:home"``.
+    Parameters
+    ----------
+    name
+        Icon identifier in ``"prefix:icon"`` form, e.g.
+        ``"line-md:home"``.
 
-    Returns:
+    Returns
+    -------
+    str
         The raw SVG source string as served by the Iconify API.
 
-    Raises:
-        IconifyError: If the name is malformed, the icon does not
-            exist, or the network request fails.
+    Raises
+    ------
+    IconifyError
+        If the name is malformed, the icon does not
+        exist, or the network request fails.
     """
     prefix, icon = _parse_name(name)
     key = f"{prefix}:{icon}"

--- a/src/deckui/dsui/key.py
+++ b/src/deckui/dsui/key.py
@@ -30,7 +30,9 @@ class DsuiKey(KeySlot):
     replaces the icon + label rendering with SVG-based rendering from
     a ``.dui`` package.
 
-    Usage::
+    Examples
+    --------
+    ::
 
         from deckui.dsui import load_package, DsuiKey
 
@@ -45,8 +47,10 @@ class DsuiKey(KeySlot):
     The key index is assigned automatically when you install the key
     on a screen with :meth:`~deckui.ui.screen.Screen.set_key`.
 
-    Args:
-        spec: A validated :class:`~deckui.dsui.schema.PackageSpec`.
+    Parameters
+    ----------
+    spec
+        A validated :class:`~deckui.dsui.schema.PackageSpec`.
     """
 
     def __init__(self, spec: PackageSpec) -> None:
@@ -64,15 +68,22 @@ class DsuiKey(KeySlot):
     def set(self, name: str, value: Any) -> DsuiKey:
         """Set a binding value.  Marks the key dirty if changed.
 
-        Args:
-            name: Binding name as defined in the manifest.
-            value: New value (type depends on binding kind).
+        Parameters
+        ----------
+        name
+            Binding name as defined in the manifest.
+        value
+            New value (type depends on binding kind).
 
-        Returns:
+        Returns
+        -------
+        DsuiKey
             self, for method chaining.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
         """
         if self._renderer.set(name, value):
             self._dirty = True
@@ -81,7 +92,9 @@ class DsuiKey(KeySlot):
     def set_many(self, **kwargs: Any) -> DsuiKey:
         """Set multiple binding values at once.
 
-        Returns:
+        Returns
+        -------
+        DsuiKey
             self, for method chaining.
         """
         if self._renderer.set_many(**kwargs):
@@ -91,8 +104,10 @@ class DsuiKey(KeySlot):
     def get(self, name: str) -> Any:
         """Get the current value of a binding.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
         """
         return self._renderer.get(name)
 
@@ -104,18 +119,28 @@ class DsuiKey(KeySlot):
         Normalises *value* from ``[min_val, max_val]`` to ``[0.0, 1.0]``
         and delegates to :meth:`set`.
 
-        Args:
-            name: Binding name (must be a ``range`` or ``slider`` binding).
-            value: Value in domain units (e.g. 0–100 for a percentage).
-            min_val: Lower bound of the domain range.
-            max_val: Upper bound of the domain range.
+        Parameters
+        ----------
+        name
+            Binding name (must be a ``range`` or ``slider`` binding).
+        value
+            Value in domain units (e.g. 0–100 for a percentage).
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
 
-        Returns:
+        Returns
+        -------
+        DsuiKey
             self, for method chaining.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
-            ValueError: If *min_val* equals *max_val*.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
+        ValueError
+            If *min_val* equals *max_val*.
         """
         if min_val == max_val:
             raise ValueError("min_val and max_val must not be equal")
@@ -131,20 +156,30 @@ class DsuiKey(KeySlot):
         Reads the current normalised value, denormalises it, adds *delta*,
         clamps, re-normalises, and calls :meth:`set`.
 
-        Args:
-            name: Binding name (must be a ``range`` or ``slider`` binding).
-            delta: Amount to add in domain units (negative to decrease).
-            min_val: Lower bound of the domain range.
-            max_val: Upper bound of the domain range.
+        Parameters
+        ----------
+        name
+            Binding name (must be a ``range`` or ``slider`` binding).
+        delta
+            Amount to add in domain units (negative to decrease).
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
 
-        Returns:
+        Returns
+        -------
+        float
             The new value in domain units (clamped to
             ``[min_val, max_val]``), so callers can use it for display
             without back-computing.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
-            ValueError: If *min_val* equals *max_val*.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
+        ValueError
+            If *min_val* equals *max_val*.
         """
         if min_val == max_val:
             raise ValueError("min_val and max_val must not be equal")
@@ -160,17 +195,26 @@ class DsuiKey(KeySlot):
     ) -> float:
         """Get a range/slider binding denormalised to domain units.
 
-        Args:
-            name: Binding name.
-            min_val: Lower bound of the domain range.
-            max_val: Upper bound of the domain range.
+        Parameters
+        ----------
+        name
+            Binding name.
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
 
-        Returns:
+        Returns
+        -------
+        float
             The current value in domain units.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
-            ValueError: If *min_val* equals *max_val*.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
+        ValueError
+            If *min_val* equals *max_val*.
         """
         if min_val == max_val:
             raise ValueError("min_val and max_val must not be equal")
@@ -180,16 +224,22 @@ class DsuiKey(KeySlot):
     def on_event(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
         """Decorator to register a handler for a named semantic event.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @key.on_event("activate")
             async def handle():
                 ...
 
-        Args:
-            event_name: Semantic event name from the manifest.
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
 
-        Returns:
+        Returns
+        -------
+        Callable
             A decorator that registers the handler and returns it unchanged.
         """
 
@@ -202,9 +252,12 @@ class DsuiKey(KeySlot):
     def bind_event(self, event_name: str, handler: AsyncHandler) -> None:
         """Imperatively register a handler for a named semantic event.
 
-        Args:
-            event_name: Semantic event name from the manifest.
-            handler: The async callable to invoke.
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
+        handler
+            The async callable to invoke.
         """
         self._events.on(event_name, handler)
 
@@ -218,12 +271,17 @@ class DsuiKey(KeySlot):
         The SVG is rasterised and scaled to the device's key size,
         then encoded in the device's image format.
 
-        Args:
-            key_size: Target key dimensions ``(width, height)``.
-                Defaults to ``KEY_SIZE`` (120x120 for Stream Deck+).
-            image_format: Image encoding format (``"JPEG"`` or ``"BMP"``).
+        Parameters
+        ----------
+        key_size
+            Target key dimensions ``(width, height)``.
+            Defaults to ``KEY_SIZE`` (120x120 for Stream Deck+).
+        image_format
+            Image encoding format (``"JPEG"`` or ``"BMP"``).
 
-        Returns:
+        Returns
+        -------
+        bytes
             Encoded image bytes.
         """
         size = key_size or KEY_SIZE

--- a/src/deckui/dsui/loader.py
+++ b/src/deckui/dsui/loader.py
@@ -333,16 +333,22 @@ def _parse_region(name: str, raw: dict[str, Any]) -> Region:
 def load_package(path: str | Path) -> PackageSpec:
     """Load a .dui package directory into a validated PackageSpec.
 
-    Args:
-        path: Path to the ``.dui`` directory.
+    Parameters
+    ----------
+    path
+        Path to the ``.dui`` directory.
 
-    Returns:
+    Returns
+    -------
+    PackageSpec
         A frozen :class:`PackageSpec` ready to be used by
         :class:`~deckui.dsui.card.DsuiCard` or
         :class:`~deckui.dsui.key.DsuiKey`.
 
-    Raises:
-        PackageError: If the package is invalid or incomplete.
+    Raises
+    ------
+    PackageError
+        If the package is invalid or incomplete.
     """
     pkg_dir = Path(path)
     if not pkg_dir.is_dir():
@@ -486,14 +492,20 @@ def load_package(path: str | Path) -> PackageSpec:
 def load_all_packages(directory: str | Path) -> dict[str, PackageSpec]:
     """Load all .dui packages from a directory.
 
-    Args:
-        directory: Path to scan for ``.dui`` subdirectories.
+    Parameters
+    ----------
+    directory
+        Path to scan for ``.dui`` subdirectories.
 
-    Returns:
+    Returns
+    -------
+    dict[str, PackageSpec]
         A dict mapping package names to their specs.
 
-    Raises:
-        PackageError: If any package fails validation.
+    Raises
+    ------
+    PackageError
+        If any package fails validation.
     """
     base = Path(directory)
     if not base.is_dir():

--- a/src/deckui/dsui/svg_renderer.py
+++ b/src/deckui/dsui/svg_renderer.py
@@ -121,7 +121,9 @@ def _resolve_font_attrs(root: ET.Element, elem: ET.Element) -> tuple[str, float]
     and ``font-size`` attributes.  Falls back to sensible defaults if
     neither the element nor any ancestor declares them.
 
-    Returns:
+    Returns
+    -------
+    tuple[str, float]
         A ``(font_family, font_size)`` tuple.
     """
     family: str | None = None
@@ -160,9 +162,12 @@ def _load_font(family: str, size: int) -> ImageFont.FreeTypeFont | ImageFont.Ima
     Tries several name variations.  If all fail, logs a warning and
     returns Pillow's built-in default font.  Results are cached.
 
-    Args:
-        family: Font family name (e.g. ``"ArialMT"``).
-        size: Font size in pixels (integer for cache-key hashability).
+    Parameters
+    ----------
+    family
+        Font family name (e.g. ``"ArialMT"``).
+    size
+        Font size in pixels (integer for cache-key hashability).
     """
     candidates: list[str] = [family]
     for suffix in ("MT", "Bold", "Italic", "-Regular", "-Bold"):
@@ -209,15 +214,24 @@ def _wrap_text(
     than fit, the last visible line is truncated with an ellipsis
     character (if *overflow* is :attr:`~OverflowMode.ELLIPSIS`).
 
-    Args:
-        text: The text string to wrap.
-        max_width: Maximum line width in pixels.
-        font: A Pillow font object for measurement.
-        overflow: How to handle text that doesn't fit.
-        max_height: Optional vertical pixel budget.
-        line_height: Vertical spacing between lines in pixels.
+    Parameters
+    ----------
+    text
+        The text string to wrap.
+    max_width
+        Maximum line width in pixels.
+    font
+        A Pillow font object for measurement.
+    overflow
+        How to handle text that doesn't fit.
+    max_height
+        Optional vertical pixel budget.
+    line_height
+        Vertical spacing between lines in pixels.
 
-    Returns:
+    Returns
+    -------
+    list[str]
         A list of line strings, one per wrapped line.
     """
     if not text or not text.strip():
@@ -265,8 +279,10 @@ class SvgRenderer:
     values, inlines image assets, and rasterises to a PIL Image via
     CairoSVG.
 
-    Args:
-        spec: The validated package specification.
+    Parameters
+    ----------
+    spec
+        The validated package specification.
     """
 
     def __init__(self, spec: PackageSpec) -> None:
@@ -294,17 +310,24 @@ class SvgRenderer:
     def set(self, name: str, value: Any) -> bool:
         """Set a binding value.
 
-        Args:
-            name: Binding name as defined in the manifest.
-            value: The new value.  Type depends on the binding:
-                   text → ``str``, image → ``PIL.Image.Image`` or ``bytes``,
-                   visibility → ``bool``, color → ``str``.
+        Parameters
+        ----------
+        name
+            Binding name as defined in the manifest.
+        value
+            The new value.  Type depends on the binding:
+            text → ``str``, image → ``PIL.Image.Image`` or ``bytes``,
+            visibility → ``bool``, color → ``str``.
 
-        Returns:
+        Returns
+        -------
+        bool
             ``True`` if the value actually changed (triggers dirty flag).
 
-        Raises:
-            KeyError: If *name* is not a known binding.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
         """
         if name not in self._spec.bindings:
             raise KeyError(
@@ -326,7 +349,9 @@ class SvgRenderer:
     def set_many(self, **kwargs: Any) -> bool:
         """Set multiple binding values at once.
 
-        Returns:
+        Returns
+        -------
+        bool
             ``True`` if any value changed.
         """
         changed = False
@@ -338,8 +363,10 @@ class SvgRenderer:
     def get(self, name: str) -> Any:
         """Get the current value of a binding.
 
-        Raises:
-            KeyError: If *name* is not a known binding.
+        Raises
+        ------
+        KeyError
+            If *name* is not a known binding.
         """
         if name not in self._spec.bindings:
             raise KeyError(
@@ -350,7 +377,9 @@ class SvgRenderer:
     def render(self) -> Image.Image:
         """Rasterise the SVG with current binding values to a PIL Image.
 
-        Returns:
+        Returns
+        -------
+        Image.Image
             An RGB :class:`~PIL.Image.Image` at the SVG's native dimensions.
         """
         root = copy.deepcopy(self._base_root)

--- a/src/deckui/render/key_renderer.py
+++ b/src/deckui/render/key_renderer.py
@@ -20,12 +20,17 @@ def render_key_image(
 ) -> bytes:
     """Render an image for a Stream Deck key.
 
-    Args:
-        icon: Optional icon image to render on the key.
-        background: Background colour name.
-        key_size: Key dimensions ``(width, height)``.  Defaults to
-            the Stream Deck+ size ``(120, 120)``.
-        image_format: Image encoding format (``"JPEG"`` or ``"BMP"``).
+    Parameters
+    ----------
+    icon
+        Optional icon image to render on the key.
+    background
+        Background colour name.
+    key_size
+        Key dimensions ``(width, height)``.  Defaults to
+        the Stream Deck+ size ``(120, 120)``.
+    image_format
+        Image encoding format (``"JPEG"`` or ``"BMP"``).
     """
     size = key_size or KEY_SIZE
     icon_px = min(size[0], size[1]) * ICON_SIZE // KEY_SIZE[0]

--- a/src/deckui/render/metrics.py
+++ b/src/deckui/render/metrics.py
@@ -21,8 +21,10 @@ class RenderMetrics:
     info-screen dimensions) are derived from the device's
     :class:`~deckui.runtime.capabilities.DeviceCapabilities`.
 
-    Args:
-        caps: Device capabilities to derive metrics from.
+    Parameters
+    ----------
+    caps
+        Device capabilities to derive metrics from.
     """
 
     def __init__(self, caps: DeviceCapabilities) -> None:

--- a/src/deckui/render/screen_renderer.py
+++ b/src/deckui/render/screen_renderer.py
@@ -16,15 +16,23 @@ def render_info_screen(
 ) -> bytes:
     """Render an info screen image.
 
-    Args:
-        image: Optional PIL Image to display. If ``None``, a blank
-            black screen is rendered.
-        width: Screen width in pixels.
-        height: Screen height in pixels.
-        background: Background colour.
-        image_format: Encoding format (``"JPEG"`` or ``"BMP"``).
+    Parameters
+    ----------
+    image
+        Optional PIL Image to display. If ``None``, a blank
+        black screen is rendered.
+    width
+        Screen width in pixels.
+    height
+        Screen height in pixels.
+    background
+        Background colour.
+    image_format
+        Encoding format (``"JPEG"`` or ``"BMP"``).
 
-    Returns:
+    Returns
+    -------
+    bytes
         Encoded image bytes.
     """
     canvas = Image.new("RGB", (width, height), background)

--- a/src/deckui/render/touch_renderer.py
+++ b/src/deckui/render/touch_renderer.py
@@ -33,17 +33,28 @@ def compose_touchstrip(
     All dimension parameters default to Stream Deck+ values when
     not specified.
 
-    Args:
-        cards: Card images (or ``None`` for blank slots).
-        background: Fill colour for the canvas (margins and gaps).
-        touchscreen_width: Total touchscreen width in pixels.
-        touchscreen_height: Total touchscreen height in pixels.
-        panel_count: Number of card zones.
-        panel_width: Width of each card panel in pixels.
-        margin_left: Left margin in pixels.
-        margin_top: Top margin in pixels.
-        panel_gap: Gap between panels in pixels.
-        image_format: Image encoding format (``"JPEG"`` or ``"BMP"``).
+    Parameters
+    ----------
+    cards
+        Card images (or ``None`` for blank slots).
+    background
+        Fill colour for the canvas (margins and gaps).
+    touchscreen_width
+        Total touchscreen width in pixels.
+    touchscreen_height
+        Total touchscreen height in pixels.
+    panel_count
+        Number of card zones.
+    panel_width
+        Width of each card panel in pixels.
+    margin_left
+        Left margin in pixels.
+    margin_top
+        Top margin in pixels.
+    panel_gap
+        Gap between panels in pixels.
+    image_format
+        Image encoding format (``"JPEG"`` or ``"BMP"``).
     """
     ts_w = touchscreen_width if touchscreen_width is not None else TOUCHSCREEN_WIDTH
     ts_h = touchscreen_height if touchscreen_height is not None else TOUCHSCREEN_HEIGHT

--- a/src/deckui/runtime/capabilities.py
+++ b/src/deckui/runtime/capabilities.py
@@ -54,10 +54,14 @@ class DeviceCapabilities:
     def from_device(cls, device: StreamDeck) -> DeviceCapabilities:
         """Build capabilities from a connected (opened) device.
 
-        Args:
-            device: An open ``StreamDeck`` device object.
+        Parameters
+        ----------
+        device
+            An open ``StreamDeck`` device object.
 
-        Returns:
+        Returns
+        -------
+        DeviceCapabilities
             A frozen :class:`DeviceCapabilities` instance.
         """
         key_layout = device.key_layout()

--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -54,9 +54,12 @@ class Deck:
         brightness: int = 80,
     ) -> None:
         """
-        Args:
-            serial_number: The serial number of the target device.
-            brightness: Initial brightness (0-100).
+        Parameters
+        ----------
+        serial_number
+            The serial number of the target device.
+        brightness
+            Initial brightness (0-100).
         """
         self._serial_number = serial_number
         self._brightness = brightness
@@ -180,8 +183,10 @@ class Deck:
     def capabilities(self) -> DeviceCapabilities:
         """The device capabilities for the connected device.
 
-        Raises:
-            DeckError: If the device is not opened.
+        Raises
+        ------
+        DeckError
+            If the device is not opened.
         """
         if self._caps is None:
             raise DeckError("Device not opened")
@@ -191,8 +196,10 @@ class Deck:
     def metrics(self) -> RenderMetrics:
         """Rendering metrics for the connected device.
 
-        Raises:
-            DeckError: If the device is not opened.
+        Raises
+        ------
+        DeckError
+            If the device is not opened.
         """
         if self._metrics is None:
             raise DeckError("Device not opened")
@@ -222,7 +229,13 @@ class Deck:
         return self._brightness
 
     async def set_brightness(self, percent: int) -> None:
-        """Set screen brightness (0-100)."""
+        """Set screen brightness.
+
+        Parameters
+        ----------
+        percent
+            Brightness level (0-100).
+        """
         self._brightness = max(0, min(100, percent))
         if self._device:
             loop = asyncio.get_running_loop()
@@ -234,10 +247,14 @@ class Deck:
     def screen(self, name: str) -> Screen:
         """Get or create a screen by name.
 
-        Args:
-            name: Screen name.
+        Parameters
+        ----------
+        name
+            Screen name.
 
-        Returns:
+        Returns
+        -------
+        Screen
             The Screen instance.
         """
         from ..ui.screen import Screen
@@ -249,8 +266,10 @@ class Deck:
     async def set_screen(self, name: str) -> None:
         """Switch to a named screen, rendering all keys and cards.
 
-        Args:
-            name: Screen name (must already exist via ``deck.screen(name)``).
+        Parameters
+        ----------
+        name
+            Screen name (must already exist via ``deck.screen(name)``).
         """
         if name not in self._screens:
             raise DeckError(f"Screen '{name}' does not exist")

--- a/src/deckui/runtime/discovery.py
+++ b/src/deckui/runtime/discovery.py
@@ -22,13 +22,18 @@ async def list_devices(
     firmware information, then closes them.  Returns a list of
     :class:`DeviceInfo` snapshots.
 
-    Args:
-        deck_type: If set, only return devices matching this type
-            (e.g. ``"Stream Deck +"``).
-        visual_only: If ``True`` (default), exclude non-visual devices
-            such as the Stream Deck Pedal.
+    Parameters
+    ----------
+    deck_type
+        If set, only return devices matching this type
+        (e.g. ``"Stream Deck +"``).
+    visual_only
+        If ``True`` (default), exclude non-visual devices
+        such as the Stream Deck Pedal.
 
-    Returns:
+    Returns
+    -------
+    list[DeviceInfo]
         A list of :class:`DeviceInfo` for each discovered device.
     """
     loop = asyncio.get_running_loop()

--- a/src/deckui/runtime/events.py
+++ b/src/deckui/runtime/events.py
@@ -59,10 +59,14 @@ class TouchEvent:
     def compute_zone(self, metrics: RenderMetrics) -> int:
         """Compute which touch-strip zone this touch falls in.
 
-        Args:
-            metrics: The render metrics for the connected device.
+        Parameters
+        ----------
+        metrics
+            The render metrics for the connected device.
 
-        Returns:
+        Returns
+        -------
+        int
             Zone index (0 to panel_count-1).
         """
         if metrics.panel_count == 0:

--- a/src/deckui/runtime/manager.py
+++ b/src/deckui/runtime/manager.py
@@ -29,7 +29,9 @@ class DeckManager:
     hot-plug detection, and reconnection.  Register ``on_connect`` and
     ``on_disconnect`` handlers, then start the manager.
 
-    Usage::
+    Examples
+    --------
+    ::
 
         manager = DeckManager()
 
@@ -50,12 +52,16 @@ class DeckManager:
         async with manager:
             await manager.wait_closed()
 
-    Args:
-        poll_interval: Seconds between device scans (default 2.0).
-        brightness: Default brightness for new Deck instances (0-100).
-        auto_reconnect: If ``True`` (default), automatically reconnect
-            devices that disconnect.  The ``on_connect`` handler is
-            called again on reconnection.
+    Parameters
+    ----------
+    poll_interval
+        Seconds between device scans (default 2.0).
+    brightness
+        Default brightness for new Deck instances (0-100).
+    auto_reconnect
+        If ``True`` (default), automatically reconnect
+        devices that disconnect.  The ``on_connect`` handler is
+        called again on reconnection.
     """
 
     def __init__(
@@ -129,20 +135,27 @@ class DeckManager:
     ) -> Callable[[AsyncHandler], AsyncHandler]:
         """Register a callback for when a matching device connects.
 
-        Use as a decorator::
+        The handler is also called on reconnection when
+        ``auto_reconnect`` is enabled.
+
+        Examples
+        --------
+        ::
 
             @manager.on_connect(deck_type="Stream Deck +")
             async def handle(deck: Deck):
                 ...
 
-        The handler is also called on reconnection when
-        ``auto_reconnect`` is enabled.
+        Parameters
+        ----------
+        serial
+            Only match this serial number.
+        deck_type
+            Only match this device type.
 
-        Args:
-            serial: Only match this serial number.
-            deck_type: Only match this device type.
-
-        Returns:
+        Returns
+        -------
+        Callable
             Decorator that registers the handler.
         """
         filters = {"serial": serial, "deck_type": deck_type}
@@ -157,7 +170,9 @@ class DeckManager:
     def on_disconnect(self) -> Callable[[AsyncHandler], AsyncHandler]:
         """Register a callback for when a device disconnects.
 
-        Use as a decorator::
+        Examples
+        --------
+        ::
 
             @manager.on_disconnect
             async def handle(info: DeviceInfo):

--- a/src/deckui/runtime/transport.py
+++ b/src/deckui/runtime/transport.py
@@ -43,10 +43,14 @@ class AsyncTransport:
     Conditionally registers dial and touchscreen callbacks only when
     the device supports those features.
 
-    Args:
-        device: An open Stream Deck device.
-        loop: The running asyncio event loop.
-        caps: Device capabilities (used to determine which callbacks to register).
+    Parameters
+    ----------
+    device
+        An open Stream Deck device.
+    loop
+        The running asyncio event loop.
+    caps
+        Device capabilities (used to determine which callbacks to register).
     """
 
     def __init__(

--- a/src/deckui/tools/preview.py
+++ b/src/deckui/tools/preview.py
@@ -1,6 +1,8 @@
 """Preview SVG designs on a physical Stream Deck device.
 
-Run with::
+Examples
+--------
+::
 
     python -m deckui.tools.preview \\
         --card0 my_card.svg --key0 my_key.svg \\

--- a/src/deckui/ui/cards/base.py
+++ b/src/deckui/ui/cards/base.py
@@ -26,7 +26,9 @@ class Card(ABC):
     :meth:`render`.  Override the ``handle_encoder_*`` and
     ``check_selection_timeout`` hooks to react to encoder events.
 
-    Usage::
+    Examples
+    --------
+    ::
 
         class MyCard(Card):
             def render(self) -> Image.Image:
@@ -61,7 +63,9 @@ class Card(ABC):
     def on_tap(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for short tap events in this zone.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @widget.on_tap
             async def handle():
@@ -73,7 +77,9 @@ class Card(ABC):
     def on_long_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for long press events in this zone.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @widget.on_long_press
             async def handle():
@@ -88,7 +94,9 @@ class Card(ABC):
         The handler receives ``x``, ``y``, ``x_out``, ``y_out`` arguments
         describing the start and end coordinates of the drag gesture.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @widget.on_drag
             async def handle(x: int, y: int, x_out: int, y_out: int):
@@ -103,7 +111,9 @@ class Card(ABC):
         The handler receives a single ``direction`` argument:
         positive = clockwise, negative = counter-clockwise.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @widget.on_encoder_turn
             async def handle(direction: int):
@@ -115,7 +125,9 @@ class Card(ABC):
     def on_encoder_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder press events on this widget.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @widget.on_encoder_press
             async def handle():
@@ -127,7 +139,9 @@ class Card(ABC):
     def on_encoder_release(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder release events on this widget.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @widget.on_encoder_release
             async def handle():
@@ -163,16 +177,21 @@ class Card(ABC):
         synchronously.  The queued callbacks are drained and awaited by
         :class:`~deckui.runtime.deck.Deck` during event dispatch or refresh.
 
-        Args:
-            handler: The async callback to invoke.
-            args: Positional arguments to pass to the callback.
+        Parameters
+        ----------
+        handler
+            The async callback to invoke.
+        args
+            Positional arguments to pass to the callback.
         """
         self._pending_callbacks.append((handler, args))
 
     def drain_pending_callbacks(self) -> list[tuple[AsyncHandler, tuple[object, ...]]]:
         """Remove and return all pending callbacks.
 
-        Returns:
+        Returns
+        -------
+        list[tuple[AsyncHandler, tuple[object, ...]]]
             A list of ``(handler, args)`` tuples.  The list is empty if
             no callbacks are pending.
         """
@@ -241,7 +260,9 @@ class Card(ABC):
         Return ``None`` to let the touchstrip background colour show
         through (used by :class:`~deckui.ui.cards.blank.BlankCard`).
 
-        Returns:
+        Returns
+        -------
+        Image.Image or None
             A PANEL_WIDTH x PANEL_HEIGHT RGB :class:`~PIL.Image.Image`,
             or ``None`` for a transparent/empty slot.
         """
@@ -274,7 +295,9 @@ class Card(ABC):
         Override to implement timeout logic (e.g. for slider cycling).
         The default always returns ``False``.
 
-        Returns:
+        Returns
+        -------
+        bool
             ``True`` if the widget state changed and needs re-rendering.
         """
         return False

--- a/src/deckui/ui/controls/encoder_slot.py
+++ b/src/deckui/ui/controls/encoder_slot.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 class EncoderSlot:
     """Represents a single physical rotary encoder on the Stream Deck+.
 
+    Examples
+    --------
     Use decorators to register event handlers::
 
         @encoder.on_turn
@@ -37,7 +39,9 @@ class EncoderSlot:
         The handler receives a single ``direction`` argument:
         positive = clockwise, negative = counter-clockwise.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @encoder.on_turn
             async def handle(direction: int):
@@ -49,7 +53,9 @@ class EncoderSlot:
     def on_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder press events.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @encoder.on_press
             async def handle():
@@ -61,7 +67,9 @@ class EncoderSlot:
     def on_release(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder release events.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @encoder.on_release
             async def handle():

--- a/src/deckui/ui/controls/key_slot.py
+++ b/src/deckui/ui/controls/key_slot.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 class KeySlot:
     """Represents a single physical key on the Stream Deck.
 
+    Examples
+    --------
     Use decorators to register event handlers::
 
         @key.on_press
@@ -35,7 +37,9 @@ class KeySlot:
     def on_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for key press events.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @key.on_press
             async def handle():
@@ -47,7 +51,9 @@ class KeySlot:
     def on_release(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for key release events.
 
-        Usage::
+        Examples
+        --------
+        ::
 
             @key.on_release
             async def handle():

--- a/src/deckui/ui/info_screen.py
+++ b/src/deckui/ui/info_screen.py
@@ -14,10 +14,14 @@ class InfoScreen:
     It does not support touch events or interactive cards — it is a
     simple image buffer with dirty tracking.
 
-    Args:
-        width: Screen width in pixels.
-        height: Screen height in pixels.
-        image_format: Image format for encoding (``"JPEG"`` or ``"BMP"``).
+    Parameters
+    ----------
+    width
+        Screen width in pixels.
+    height
+        Screen height in pixels.
+    image_format
+        Image format for encoding (``"JPEG"`` or ``"BMP"``).
     """
 
     def __init__(
@@ -58,8 +62,10 @@ class InfoScreen:
 
         The image is resized to fit the screen dimensions if needed.
 
-        Args:
-            image: A PIL Image to display.
+        Parameters
+        ----------
+        image
+            A PIL Image to display.
         """
         if image.size != (self._width, self._height):
             image = image.resize((self._width, self._height), Image.Resampling.LANCZOS)
@@ -84,7 +90,9 @@ class InfoScreen:
     def render_bytes(self) -> bytes:
         """Encode the current image to bytes in the device's format.
 
-        Returns:
+        Returns
+        -------
+        bytes
             Encoded image bytes. If no image has been set, returns
             a blank black image.
         """

--- a/src/deckui/ui/screen.py
+++ b/src/deckui/ui/screen.py
@@ -29,7 +29,9 @@ class Screen:
     touchscreen, those features are unavailable and accessing them raises
     :class:`~deckui.runtime.deck.DeckError`.
 
-    Usage::
+    Examples
+    --------
+    ::
 
         main = deck.screen("main")
 
@@ -77,10 +79,14 @@ class Screen:
     def key(self, index: int) -> KeySlot:
         """Get or create a key slot by index.
 
-        Args:
-            index: Key index (0 to key_count-1).
+        Parameters
+        ----------
+        index
+            Key index (0 to key_count-1).
 
-        Returns:
+        Returns
+        -------
+        KeySlot
             The KeySlot instance for this key on this screen.
         """
         key_count = self._caps.key_count
@@ -96,9 +102,12 @@ class Screen:
     def set_key(self, index: int, key: KeySlot) -> None:
         """Replace the key slot at *index* with a custom key.
 
-        Args:
-            index: Key index.
-            key: The key slot to install.
+        Parameters
+        ----------
+        index
+            Key index.
+        key
+            The key slot to install.
         """
         key_count = self._caps.key_count
         if not 0 <= index < key_count:
@@ -113,14 +122,20 @@ class Screen:
     def encoder(self, index: int) -> EncoderSlot:
         """Get or create an encoder slot by index.
 
-        Args:
-            index: Encoder index (0 to dial_count-1).
+        Parameters
+        ----------
+        index
+            Encoder index (0 to dial_count-1).
 
-        Returns:
+        Returns
+        -------
+        EncoderSlot
             The EncoderSlot instance for this encoder on this screen.
 
-        Raises:
-            IndexError: If index is out of range or device has no encoders.
+        Raises
+        ------
+        IndexError
+            If index is out of range or device has no encoders.
         """
         dial_count = self._caps.dial_count
         if dial_count == 0:

--- a/src/deckui/ui/touch_strip.py
+++ b/src/deckui/ui/touch_strip.py
@@ -17,9 +17,12 @@ class TouchStrip:
     owns its own ``TouchStrip``, so different screens can use different
     background colours.
 
-    Args:
-        panel_count: Number of card zones.
-        background_color: Initial background colour.
+    Parameters
+    ----------
+    panel_count
+        Number of card zones.
+    background_color
+        Initial background colour.
     """
 
     def __init__(
@@ -59,13 +62,19 @@ class TouchStrip:
     def set_card(self, index: int, card: Card) -> None:
         """Replace the card at *index* with a custom card.
 
-        Args:
-            index: Card zone index.
-            card: A :class:`Card` subclass instance.
+        Parameters
+        ----------
+        index
+            Card zone index.
+        card
+            A :class:`Card` subclass instance.
 
-        Raises:
-            IndexError: If *index* is out of range.
-            TypeError: If *card* is not a :class:`Card` instance.
+        Raises
+        ------
+        IndexError
+            If *index* is out of range.
+        TypeError
+            If *card* is not a :class:`Card` instance.
         """
         if not 0 <= index < self._panel_count:
             raise IndexError(


### PR DESCRIPTION
## Summary

- Converted all Python docstrings across 25 source files from Google-style to NumPy-style
- Replaced `Args:`/`Returns:`/`Raises:` sections with `Parameters`/`Returns`/`Raises` NumPy sections
- Converted `Usage::` code blocks to `Examples` sections
- Compatible with `mkdocstrings` using `docstring_style: numpy`

## Files changed

### runtime/
- `capabilities.py`, `deck.py`, `discovery.py`, `events.py`, `manager.py`, `transport.py`

### ui/
- `screen.py`, `controls/key_slot.py`, `controls/encoder_slot.py`, `touch_strip.py`, `info_screen.py`, `cards/base.py`

### dsui/
- `card.py`, `key.py`, `loader.py`, `event_map.py`, `iconify.py`, `svg_renderer.py`

### render/
- `key_renderer.py`, `metrics.py`, `screen_renderer.py`, `touch_renderer.py`

### other
- `__init__.py`, `dsui/__init__.py`, `tools/preview.py`

## Verification

- All 902 tests pass
- Coverage: 97.64% (above 95% threshold)
- ruff: all checks passed
- mypy: no issues found

## Notes

- No runtime behavior changes
- Test docstrings (fixture descriptions) were already concise one-liners and did not need conversion
- No public objects lack docstrings
- No behavior was unclear requiring intentionally omitted documentation