### PR TITLE
Add --watch flag to preview tool for auto-reload on SVG changes

### DIFF
--- a/src/deckui/tools/preview.py
+++ b/src/deckui/tools/preview.py
@@ -8,6 +8,10 @@ Examples
         --card0 my_card.svg --key0 my_key.svg \\
         --background "#1a2b3c"
 
+    # Auto-reload when SVG files change:
+    python -m deckui.tools.preview \\
+        --card0 my_card.svg --key0 my_key.svg --watch
+
 Only the specified slots are updated; unspecified keys and cards are
 left blank (black unless ``--background`` is given).  SVGs are scaled to
 fit the target area while preserving aspect ratio and centred on the
@@ -15,6 +19,10 @@ background colour.
 
 The tool auto-detects the first connected visual Stream Deck device
 and adapts key/card counts and dimensions to the hardware.
+
+With ``--watch``, the tool monitors all specified SVG files and
+automatically re-renders and re-pushes images when any file changes.
+The poll interval can be tuned with ``--poll-interval`` (default 0.5s).
 """
 
 from __future__ import annotations
@@ -275,6 +283,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Background colour for the touchstrip in hex (e.g. '#1a2b3c' or '1a2b3c')",
     )
     parser.add_argument(
+        "-w",
+        "--watch",
+        action="store_true",
+        help="Watch SVG files for changes and auto-reload",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=0.5,
+        metavar="SECS",
+        help="File poll interval in seconds when --watch is active (default: 0.5)",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -317,12 +338,20 @@ async def push_to_device(
     key_images: dict[int, bytes],
     touchstrip_bytes: bytes,
     brightness: int = 80,
+    *,
+    watch_args: argparse.Namespace | None = None,
+    poll_interval: float = 0.5,
 ) -> None:
     """Push rendered images to the physical Stream Deck+.
 
     *key_images* maps key indices to JPEG bytes.  *touchstrip_bytes* is
     the full 800x100 touchscreen JPEG.  *brightness* sets the screen
     brightness (0-100).
+
+    When *watch_args* is provided, the tool watches the SVG files
+    specified in those args and automatically re-renders and re-pushes
+    when changes are detected.  *poll_interval* controls how often files
+    are polled (in seconds).
     """
     loop = asyncio.get_running_loop()
     deck = await loop.run_in_executor(None, _find_and_open_device)
@@ -355,8 +384,15 @@ async def push_to_device(
             TOUCHSCREEN_HEIGHT,
         )
 
-        print("Preview pushed — press Ctrl+C to exit", file=sys.stderr)  # noqa: T201
-        await _wait_for_interrupt()
+        if watch_args is not None:
+            print(  # noqa: T201
+                "Preview pushed — watching for changes (Ctrl+C to exit)",
+                file=sys.stderr,
+            )
+            await _watch_and_reload(watch_args, deck, poll_interval)
+        else:
+            print("Preview pushed — press Ctrl+C to exit", file=sys.stderr)  # noqa: T201
+            await _wait_for_interrupt()
     finally:
         await loop.run_in_executor(None, deck.reset)
         await loop.run_in_executor(None, deck.close)
@@ -373,6 +409,99 @@ async def _wait_for_interrupt() -> None:
     loop.add_signal_handler(signal.SIGINT, stop.set)
     try:
         await stop.wait()
+    finally:
+        loop.remove_signal_handler(signal.SIGINT)
+
+
+def collect_svg_paths(args: argparse.Namespace) -> list[Path]:
+    """Return the list of SVG file paths specified in *args*."""
+    paths: list[Path] = []
+    for i in range(_KEY_COUNT):
+        p: Path | None = getattr(args, f"key{i}", None)
+        if p is not None:
+            paths.append(p)
+    for i in range(PANEL_COUNT):
+        p = getattr(args, f"card{i}", None)
+        if p is not None:
+            paths.append(p)
+    return paths
+
+
+def get_mtimes(paths: list[Path]) -> dict[Path, float]:
+    """Return a mapping of *paths* to their modification times.
+
+    Missing files are silently assigned mtime ``0.0``.
+    """
+    mtimes: dict[Path, float] = {}
+    for p in paths:
+        try:
+            mtimes[p] = p.stat().st_mtime
+        except OSError:
+            mtimes[p] = 0.0
+    return mtimes
+
+
+async def _watch_and_reload(
+    args: argparse.Namespace,
+    deck: PreviewDeckDevice,
+    poll_interval: float,
+) -> None:
+    """Poll SVG files for changes and re-push to *deck* on modification.
+
+    Runs until SIGINT (Ctrl+C) is received.
+    """
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    loop.add_signal_handler(signal.SIGINT, stop.set)
+
+    svg_paths = collect_svg_paths(args)
+    last_mtimes = get_mtimes(svg_paths)
+
+    try:
+        while not stop.is_set():
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=poll_interval)
+                break  # stop was set
+            except TimeoutError:
+                pass  # poll interval elapsed, check files
+
+            current_mtimes = get_mtimes(svg_paths)
+            if current_mtimes != last_mtimes:
+                changed = [
+                    p for p in svg_paths if current_mtimes[p] != last_mtimes.get(p, 0.0)
+                ]
+                logger.info("Detected changes: %s", [str(p) for p in changed])
+                print(  # noqa: T201
+                    f"Reloading {len(changed)} changed file(s)...",
+                    file=sys.stderr,
+                )
+                last_mtimes = current_mtimes
+                try:
+                    key_images, touchstrip_bytes = render_preview(args)
+                except Exception as exc:
+                    print(f"Render error: {exc}", file=sys.stderr)  # noqa: T201
+                    continue
+
+                for key_index in range(_KEY_COUNT):
+                    jpeg = key_images.get(key_index)
+                    if jpeg is not None:
+                        await loop.run_in_executor(
+                            None,
+                            deck.set_key_image,
+                            key_index,
+                            jpeg,
+                        )
+
+                await loop.run_in_executor(
+                    None,
+                    deck.set_touchscreen_image,
+                    touchstrip_bytes,
+                    0,
+                    0,
+                    TOUCHSCREEN_WIDTH,
+                    TOUCHSCREEN_HEIGHT,
+                )
+                print("Preview updated", file=sys.stderr)  # noqa: T201
     finally:
         loop.remove_signal_handler(signal.SIGINT)
 
@@ -426,7 +555,17 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
 
     key_images, touchstrip_bytes = render_preview(args)
-    asyncio.run(push_to_device(key_images, touchstrip_bytes, args.brightness))
+    watch_args = args if args.watch else None
+    poll_interval: float = args.poll_interval
+    asyncio.run(
+        push_to_device(
+            key_images,
+            touchstrip_bytes,
+            args.brightness,
+            watch_args=watch_args,
+            poll_interval=poll_interval,
+        )
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import io
 import os
+import signal
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,10 +35,13 @@ if TYPE_CHECKING:
 from deckui.tools.preview import (
     _KEY_COUNT,
     _svg_to_png_fit,
+    _watch_and_reload,
     build_parser,
+    collect_svg_paths,
     compose_card_image,
     compose_key_image,
     compose_touchstrip,
+    get_mtimes,
     load_svg,
     main,
     parse_args,
@@ -459,10 +463,12 @@ class TestMain:
     def test_main_calls_push(self, mock_push: AsyncMock, square_svg: Path):
         main(["--key0", str(square_svg)])
         mock_push.assert_awaited_once()
-        key_images, touchstrip, brightness = mock_push.call_args[0]
+        kwargs = mock_push.call_args
+        key_images, touchstrip, brightness = kwargs[0]
         assert 0 in key_images
         assert isinstance(touchstrip, bytes)
         assert brightness == 80
+        assert kwargs[1]["watch_args"] is None
 
     @patch("deckui.tools.preview.push_to_device", new_callable=AsyncMock)
     def test_main_default_brightness(self, mock_push: AsyncMock):
@@ -491,6 +497,19 @@ class TestMain:
         assert px[0] > 150
         assert px[1] > 160
         assert px[2] > 180
+
+    @patch("deckui.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_watch_passes_args(self, mock_push: AsyncMock, square_svg: Path):
+        main(["--key0", str(square_svg), "--watch"])
+        kwargs = mock_push.call_args
+        assert kwargs[1]["watch_args"] is not None
+        assert kwargs[1]["watch_args"].watch is True
+
+    @patch("deckui.tools.preview.push_to_device", new_callable=AsyncMock)
+    def test_main_poll_interval(self, mock_push: AsyncMock):
+        main(["--watch", "--poll-interval", "1.5"])
+        kwargs = mock_push.call_args
+        assert kwargs[1]["poll_interval"] == 1.5
 
 
 class TestPushToDevice:
@@ -677,3 +696,150 @@ class TestMainModule:
 
         importlib.reload(deckui.tools.__main__)
         mock_main.assert_called()
+
+
+class TestCollectSvgPaths:
+    def test_empty_args(self):
+        args = parse_args([])
+        assert collect_svg_paths(args) == []
+
+    def test_collects_keys_and_cards(self, tmp_path: Path):
+        k = tmp_path / "k.svg"
+        c = tmp_path / "c.svg"
+        args = parse_args(["--key0", str(k), "--card2", str(c)])
+        paths = collect_svg_paths(args)
+        assert k in paths
+        assert c in paths
+        assert len(paths) == 2
+
+    def test_order_keys_before_cards(self, tmp_path: Path):
+        k = tmp_path / "k.svg"
+        c = tmp_path / "c.svg"
+        args = parse_args(["--card0", str(c), "--key0", str(k)])
+        paths = collect_svg_paths(args)
+        assert paths[0] == k
+        assert paths[1] == c
+
+
+class TestGetMtimes:
+    def test_existing_file(self, tiny_svg: Path):
+        mtimes = get_mtimes([tiny_svg])
+        assert tiny_svg in mtimes
+        assert mtimes[tiny_svg] > 0
+
+    def test_missing_file(self, tmp_path: Path):
+        missing = tmp_path / "gone.svg"
+        mtimes = get_mtimes([missing])
+        assert mtimes[missing] == 0.0
+
+    def test_empty_list(self):
+        assert get_mtimes([]) == {}
+
+
+class TestParserWatch:
+    def test_watch_default_false(self):
+        args = parse_args([])
+        assert args.watch is False
+
+    def test_watch_flag(self):
+        args = parse_args(["--watch"])
+        assert args.watch is True
+
+    def test_watch_short(self):
+        args = parse_args(["-w"])
+        assert args.watch is True
+
+    def test_poll_interval_default(self):
+        args = parse_args([])
+        assert args.poll_interval == 0.5
+
+    def test_poll_interval_custom(self):
+        args = parse_args(["--poll-interval", "2.0"])
+        assert args.poll_interval == 2.0
+
+
+class TestWatchAndReload:
+    async def test_detects_change_and_reloads(
+        self, square_svg: Path, mock_streamdeck_device: MagicMock
+    ):
+        """When an SVG file mtime changes, _watch_and_reload re-pushes."""
+        args = parse_args(["--key0", str(square_svg), "--watch"])
+
+        call_count = 0
+
+        def counting_set_key(key: int, image: bytes) -> None:
+            nonlocal call_count
+            call_count += 1
+
+        mock_streamdeck_device.set_key_image.side_effect = counting_set_key
+
+        loop = asyncio.get_running_loop()
+        # Schedule: touch file after 0.1s, then SIGINT after 0.8s
+        loop.call_later(0.1, square_svg.write_bytes, square_svg.read_bytes())
+        loop.call_later(1.0, os.kill, os.getpid(), signal.SIGINT)
+
+        await asyncio.wait_for(
+            _watch_and_reload(args, mock_streamdeck_device, poll_interval=0.2),
+            timeout=3.0,
+        )
+        assert call_count >= 1
+
+    async def test_exits_on_sigint(self, mock_streamdeck_device: MagicMock):
+        """_watch_and_reload exits cleanly on SIGINT."""
+        args = parse_args(["--watch"])
+
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.1, os.kill, os.getpid(), signal.SIGINT)
+
+        await asyncio.wait_for(
+            _watch_and_reload(args, mock_streamdeck_device, poll_interval=0.2),
+            timeout=2.0,
+        )
+
+    async def test_render_error_continues(
+        self, square_svg: Path, mock_streamdeck_device: MagicMock
+    ):
+        """A render error during watch should not crash the watcher."""
+        args = parse_args(["--key0", str(square_svg), "--watch"])
+
+        loop = asyncio.get_running_loop()
+        # Write invalid SVG to trigger render error, then SIGINT
+        loop.call_later(0.1, square_svg.write_bytes, b"not valid svg")
+        loop.call_later(1.0, os.kill, os.getpid(), signal.SIGINT)
+
+        # Should not raise
+        await asyncio.wait_for(
+            _watch_and_reload(args, mock_streamdeck_device, poll_interval=0.2),
+            timeout=3.0,
+        )
+
+
+class TestPushToDeviceWatch:
+    async def test_push_with_watch_calls_watch_and_reload(
+        self, mock_streamdeck_device: MagicMock, square_svg: Path
+    ):
+        """When watch_args is provided, push_to_device enters watch mode."""
+        from deckui.tools.preview import push_to_device
+
+        blank_ts = Image.new("RGB", (TOUCHSCREEN_WIDTH, TOUCHSCREEN_HEIGHT), "black")
+        buf = io.BytesIO()
+        blank_ts.save(buf, format="JPEG")
+        ts_jpeg = buf.getvalue()
+
+        args = parse_args(["--key0", str(square_svg), "--watch"])
+
+        with (
+            patch(
+                "deckui.tools.preview._find_and_open_device",
+                return_value=mock_streamdeck_device,
+            ),
+            patch(
+                "deckui.tools.preview._watch_and_reload",
+                new_callable=AsyncMock,
+            ) as mock_watch,
+        ):
+            await push_to_device(
+                {}, ts_jpeg, brightness=80, watch_args=args, poll_interval=0.5
+            )
+
+        mock_watch.assert_awaited_once_with(args, mock_streamdeck_device, 0.5)


### PR DESCRIPTION
## Summary

- Adds `--watch` / `-w` flag to the preview tool that monitors SVG files for changes and automatically re-renders and re-pushes to the Stream Deck device
- Uses mtime-based polling with no external dependencies; poll interval is configurable via `--poll-interval` (default 0.5s)
- Render errors during watch mode are printed to stderr and do not crash the watcher, so you can save mid-edit without losing the preview session

## Usage

```bash
python -m deckui.tools.preview     --card0 my_card.svg --key0 my_key.svg --watch

# Custom poll interval:
python -m deckui.tools.preview     --card0 my_card.svg --watch --poll-interval 1.0
```

## Testing

Full test suite passes (919 tests, 97.69% coverage). New tests cover:
- `collect_svg_paths` and `get_mtimes` helpers
- Parser `--watch` and `--poll-interval` flags
- Watch loop detecting file changes and re-pushing
- Watch loop handling render errors gracefully
- Watch loop exiting cleanly on SIGINT
- `push_to_device` integration with watch mode