### PR TITLE
Add package metadata and verify tool for DUI repository support

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -14,7 +14,7 @@ MyPackage.dui/
 
 ## The Manifest
 
-`manifest.yaml` is the heart of every package. It has four required top-level fields and three optional sections.
+`manifest.yaml` is the heart of every package. It has four required top-level fields, optional metadata for repository publishing, and three optional sections for bindings, events, and regions.
 
 ### Required Fields
 
@@ -24,6 +24,26 @@ MyPackage.dui/
 | `type` | `str` | `"TouchStripCard"` (touchscreen panel) or `"Key"` (physical key) |
 | `version` | `int` | Positive integer (>= 1) |
 | `layout` | `str` | Relative path to the SVG file (e.g. `layout.svg`) |
+
+### Metadata Fields
+
+These fields are optional for local use but required when publishing to a DUI package repository. The `verify --strict` tool enforces `description` and `author`.
+
+| Field | Type | Required for repo | Description |
+|-------|------|:-----------------:|-------------|
+| `description` | `str` | yes | One-line summary for search and display |
+| `author` | `str` | yes | Author name and optional email (`"Jane Doe <jane@example.com>"`) |
+| `license` | `str` | no | SPDX license identifier (`MIT`, `Apache-2.0`, `CC-BY-4.0`) |
+| `tags` | `list[str]` | no | Free-form lowercase labels for search (`[music, media, spotify]`) |
+| `category` | `str` | no | Primary category from a controlled vocabulary (see below) |
+| `url` | `str` | no | Project or source URL |
+| `icon` | `str` | no | Path to a thumbnail in `assets/` for repository listings |
+| `min_deckui` | `str` | no | Minimum DeckUI version required (e.g. `"0.5.0"`) |
+| `device` | `list[str]` | no | Explicit device compatibility (`[StreamDeckPlus, StreamDeckXL]`) |
+
+#### Valid Categories
+
+`media` · `productivity` · `system` · `gaming` · `social` · `development` · `utilities` · `streaming` · `home-automation` · `communication`
 
 ### Optional Sections
 
@@ -46,6 +66,31 @@ bindings:
     type: text
     node: label
     default: "Hello"
+```
+
+### Repository-Ready Example
+
+```yaml
+name: NowPlaying
+type: TouchStripCard
+version: 2
+layout: layout.svg
+description: "Media player card with album art, progress bar, and transport controls"
+author: "Jane Doe <jane@example.com>"
+license: MIT
+category: media
+tags: [music, spotify, media-player]
+url: https://github.com/jane/nowplaying-dui
+icon: assets/icon.png
+min_deckui: "0.5.0"
+
+bindings:
+  title:
+    type: text
+    node: title
+    default: "No Track"
+    max_width: 90
+    overflow: ellipsis
 ```
 
 ---
@@ -449,5 +494,51 @@ Packages are validated on load. Common errors:
 - Duplicate event names
 - `hold_ms` used on a non-hold source
 - Invalid region coordinates (negative values)
+- Invalid `category` value (must be from the controlled vocabulary)
+- Invalid `tags` entries (must be non-empty strings)
 
 All validation errors raise `PackageError` with a descriptive message.
+
+---
+
+## Package Verification Tool
+
+Use the verify tool to check packages before publishing to a repository.
+
+### Basic verification
+
+```bash
+python -m deckui.tools.verify path/to/MyPackage.dui
+```
+
+Checks that the package loads correctly and reports warnings for missing metadata, oversized assets, uppercase tags, and unknown manifest keys.
+
+### Strict mode (for repository submission)
+
+```bash
+python -m deckui.tools.verify --strict path/to/MyPackage.dui
+```
+
+Promotes all warnings to errors. Use this as a gate for repository submissions — packages must have `description` and `author` to pass.
+
+### Build a repository index
+
+```bash
+python -m deckui.tools.verify --index path/to/packages/
+```
+
+Verifies all `.dui` packages in a directory and emits a `repository.json` to stdout containing metadata from every valid package. This JSON index is all a repository needs — no external database required.
+
+### Verification checks
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| Package loads | error | All `load_package` validation passes |
+| `description` present | warning | Non-empty string |
+| `author` present | warning | Non-empty string |
+| `category` valid | error | Must be from the controlled vocabulary (if set) |
+| Tags are lowercase | warning | Each tag should be lowercase |
+| `icon` exists | warning | If declared, file must exist in `assets/` |
+| Unknown manifest keys | warning | Catches typos like `desciption` |
+| Package size | warning | Total assets + SVG under 2 MB |
+| `license` is SPDX | warning | No spaces in the license identifier |

--- a/src/deckui/dui/__init__.py
+++ b/src/deckui/dui/__init__.py
@@ -27,6 +27,7 @@ from .iconify import clear_cache as clear_iconify_cache
 from .key import DuiKey
 from .loader import PackageError, load_all_packages, load_package
 from .schema import (
+    VALID_CATEGORIES,
     Binding,
     BindingType,
     ColorBinding,
@@ -70,6 +71,7 @@ __all__ = [
     "SvgRenderer",
     "TextBinding",
     "ToggleBinding",
+    "VALID_CATEGORIES",
     "VisibilityBinding",
     "clear_iconify_cache",
     "fetch_icon",

--- a/src/deckui/dui/loader.py
+++ b/src/deckui/dui/loader.py
@@ -13,6 +13,8 @@ from .schema import (
     DEFAULT_HOLD_MS,
     DEFAULT_MAX_DURATION_MS,
     HOLD_SOURCES,
+    KNOWN_MANIFEST_KEYS,
+    VALID_CATEGORIES,
     VALID_DIRECTIONS,
     VALID_REGION_EVENTS,
     VALID_SOURCES,
@@ -399,6 +401,69 @@ def load_package(path: str | Path) -> PackageSpec:
     svg_source = layout_path.read_text(encoding="utf-8")
     svg_ids = _find_svg_ids(svg_source)
 
+    # ── Optional metadata fields ──────────────────────────────────────
+    unknown_keys = set(manifest.keys()) - KNOWN_MANIFEST_KEYS
+    if unknown_keys:
+        logger.warning(
+            "Package '%s': unknown manifest keys: %s", name, sorted(unknown_keys)
+        )
+
+    description = manifest.get("description")
+    if description is not None and not isinstance(description, str):
+        raise PackageError("'description' must be a string")
+
+    author = manifest.get("author")
+    if author is not None and not isinstance(author, str):
+        raise PackageError("'author' must be a string")
+
+    pkg_license = manifest.get("license")
+    if pkg_license is not None and not isinstance(pkg_license, str):
+        raise PackageError("'license' must be a string")
+
+    tags: tuple[str, ...] = ()
+    raw_tags = manifest.get("tags")
+    if raw_tags is not None:
+        if not isinstance(raw_tags, list):
+            raise PackageError("'tags' must be a list")
+        for tag in raw_tags:
+            if not isinstance(tag, str) or not tag.strip():
+                raise PackageError(f"Each tag must be a non-empty string, got {tag!r}")
+        tags = tuple(raw_tags)
+
+    category = manifest.get("category")
+    if category is not None:
+        if not isinstance(category, str):
+            raise PackageError("'category' must be a string")
+        if category not in VALID_CATEGORIES:
+            raise PackageError(
+                f"Invalid category '{category}'. "
+                f"Valid categories: {sorted(VALID_CATEGORIES)}"
+            )
+
+    url = manifest.get("url")
+    if url is not None and not isinstance(url, str):
+        raise PackageError("'url' must be a string")
+
+    icon = manifest.get("icon")
+    if icon is not None and not isinstance(icon, str):
+        raise PackageError("'icon' must be a string")
+
+    min_deckui = manifest.get("min_deckui")
+    if min_deckui is not None and not isinstance(min_deckui, str):
+        raise PackageError("'min_deckui' must be a string")
+
+    device: tuple[str, ...] = ()
+    raw_device = manifest.get("device")
+    if raw_device is not None:
+        if not isinstance(raw_device, list):
+            raise PackageError("'device' must be a list")
+        for d in raw_device:
+            if not isinstance(d, str) or not d.strip():
+                raise PackageError(
+                    f"Each device must be a non-empty string, got {d!r}"
+                )
+        device = tuple(raw_device)
+
     bindings: dict[str, Binding] = {}
     raw_bindings = manifest.get("bindings", {})
     if raw_bindings and not isinstance(raw_bindings, dict):
@@ -486,6 +551,15 @@ def load_package(path: str | Path) -> PackageSpec:
         events=tuple(events),
         regions=tuple(regions),
         assets=assets,
+        description=description,
+        author=author,
+        license=pkg_license,
+        tags=tags,
+        category=category,
+        url=url,
+        icon=icon,
+        min_deckui=min_deckui,
+        device=device,
     )
 
 

--- a/src/deckui/dui/schema.py
+++ b/src/deckui/dui/schema.py
@@ -222,6 +222,45 @@ class Region:
     events: tuple[str, ...] = ()
 
 
+VALID_CATEGORIES = frozenset(
+    {
+        "media",
+        "productivity",
+        "system",
+        "gaming",
+        "social",
+        "development",
+        "utilities",
+        "streaming",
+        "home-automation",
+        "communication",
+    }
+)
+"""Controlled vocabulary for the ``category`` manifest field."""
+
+KNOWN_MANIFEST_KEYS = frozenset(
+    {
+        "name",
+        "type",
+        "version",
+        "layout",
+        "description",
+        "author",
+        "license",
+        "tags",
+        "category",
+        "url",
+        "icon",
+        "min_deckui",
+        "device",
+        "bindings",
+        "events",
+        "regions",
+    }
+)
+"""All recognised top-level keys in a manifest.yaml file."""
+
+
 @dataclass(frozen=True, slots=True)
 class PackageSpec:
     """Fully validated, immutable representation of a loaded .dui package."""
@@ -234,3 +273,12 @@ class PackageSpec:
     events: tuple[EventMapping, ...] = ()
     regions: tuple[Region, ...] = ()
     assets: dict[str, bytes] = field(default_factory=dict)
+    description: str | None = None
+    author: str | None = None
+    license: str | None = None
+    tags: tuple[str, ...] = ()
+    category: str | None = None
+    url: str | None = None
+    icon: str | None = None
+    min_deckui: str | None = None
+    device: tuple[str, ...] = ()

--- a/src/deckui/tools/verify.py
+++ b/src/deckui/tools/verify.py
@@ -1,0 +1,272 @@
+"""Verify .dui packages for correctness and repository readiness.
+
+Usage::
+
+    python -m deckui.tools.verify path/to/MyPackage.dui
+    python -m deckui.tools.verify --strict path/to/MyPackage.dui
+    python -m deckui.tools.verify --index path/to/packages/
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+import yaml
+
+from deckui.dui.loader import PackageError, load_package
+from deckui.dui.schema import KNOWN_MANIFEST_KEYS, VALID_CATEGORIES, PackageSpec
+
+logger = logging.getLogger(__name__)
+
+MAX_PACKAGE_SIZE_BYTES = 2 * 1024 * 1024  # 2 MB
+
+
+class Severity(Enum):
+    """Diagnostic severity level."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass(frozen=True, slots=True)
+class Diagnostic:
+    """A single verification finding."""
+
+    severity: Severity
+    message: str
+
+
+@dataclass(slots=True)
+class VerifyResult:
+    """Aggregated verification result for a single package."""
+
+    path: Path
+    package_name: str | None = None
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+    spec: PackageSpec | None = None
+
+    @property
+    def errors(self) -> list[Diagnostic]:
+        return [d for d in self.diagnostics if d.severity == Severity.ERROR]
+
+    @property
+    def warnings(self) -> list[Diagnostic]:
+        return [d for d in self.diagnostics if d.severity == Severity.WARNING]
+
+    @property
+    def ok(self) -> bool:
+        return len(self.errors) == 0
+
+
+def verify_package(path: str | Path, *, strict: bool = False) -> VerifyResult:
+    """Verify a .dui package directory.
+
+    Parameters
+    ----------
+    path
+        Path to the ``.dui`` directory.
+    strict
+        When ``True``, warnings are promoted to errors. Use this for
+        repository submission gates.
+
+    Returns
+    -------
+    VerifyResult
+        Contains all diagnostics and the loaded spec (if loading succeeded).
+    """
+    pkg_dir = Path(path)
+    result = VerifyResult(path=pkg_dir)
+
+    # 1. Try loading the package (validates structure, bindings, events, regions)
+    try:
+        spec = load_package(pkg_dir)
+    except PackageError as exc:
+        result.diagnostics.append(Diagnostic(Severity.ERROR, f"Load failed: {exc}"))
+        return result
+
+    result.spec = spec
+    result.package_name = spec.name
+
+    def _add(severity: Severity, message: str) -> None:
+        if strict and severity == Severity.WARNING:
+            severity = Severity.ERROR
+        result.diagnostics.append(Diagnostic(severity, message))
+
+    # 2. Required metadata for repository
+    if not spec.description:
+        _add(Severity.WARNING, "Missing 'description' — required for repository listing")
+    if not spec.author:
+        _add(Severity.WARNING, "Missing 'author' — required for repository listing")
+
+    # 3. Category validation (already validated in loader, but check presence)
+    if spec.category is not None and spec.category not in VALID_CATEGORIES:
+        _add(Severity.ERROR, f"Invalid category '{spec.category}'")
+
+    # 4. Tags validation
+    for tag in spec.tags:
+        if tag != tag.lower():
+            _add(Severity.WARNING, f"Tag '{tag}' should be lowercase")
+
+    # 5. Icon exists if declared
+    if spec.icon:
+        icon_name = spec.icon.removeprefix("assets/")
+        if icon_name not in spec.assets:
+            _add(Severity.WARNING, f"Declared icon '{spec.icon}' not found in assets/")
+
+    # 6. Unknown manifest keys (typo detection)
+    manifest_path = pkg_dir / "manifest.yaml"
+    if manifest_path.exists():
+        with manifest_path.open("r", encoding="utf-8") as f:
+            raw_manifest = yaml.safe_load(f)
+        if isinstance(raw_manifest, dict):
+            unknown = set(raw_manifest.keys()) - KNOWN_MANIFEST_KEYS
+            for key in sorted(unknown):
+                _add(Severity.WARNING, f"Unknown manifest key '{key}' — possible typo?")
+
+    # 7. Package size budget
+    total_size = 0
+    for asset_bytes in spec.assets.values():
+        total_size += len(asset_bytes)
+    total_size += len(spec.svg_source.encode("utf-8"))
+    if total_size > MAX_PACKAGE_SIZE_BYTES:
+        size_mb = total_size / (1024 * 1024)
+        _add(Severity.WARNING, f"Package size {size_mb:.1f}MB exceeds 2MB budget")
+
+    # 8. License SPDX hint
+    if spec.license and " " in spec.license:
+        _add(
+            Severity.WARNING,
+            f"License '{spec.license}' contains spaces — use an SPDX identifier "
+            "(e.g. 'MIT', 'Apache-2.0', 'CC-BY-4.0')",
+        )
+
+    return result
+
+
+def _spec_to_index_entry(spec: PackageSpec) -> dict[str, object]:
+    """Convert a PackageSpec to a JSON-serializable index entry."""
+    return {
+        "name": spec.name,
+        "type": spec.type.value,
+        "version": spec.version,
+        "description": spec.description,
+        "author": spec.author,
+        "license": spec.license,
+        "tags": list(spec.tags),
+        "category": spec.category,
+        "url": spec.url,
+        "icon": spec.icon,
+        "min_deckui": spec.min_deckui,
+        "device": list(spec.device),
+        "bindings": sorted(spec.bindings.keys()),
+        "events": [e.name for e in spec.events],
+    }
+
+
+def verify_directory(
+    directory: str | Path, *, strict: bool = False
+) -> tuple[list[VerifyResult], dict[str, object]]:
+    """Verify all .dui packages in a directory and build a repository index.
+
+    Returns
+    -------
+    tuple[list[VerifyResult], dict]
+        A list of per-package results and a JSON-serializable index dict.
+    """
+    base = Path(directory)
+    if not base.is_dir():
+        msg = f"Not a directory: {base}"
+        raise PackageError(msg)
+
+    results: list[VerifyResult] = []
+    index_entries: list[dict[str, object]] = []
+
+    for entry in sorted(base.iterdir()):
+        if entry.is_dir() and entry.suffix == ".dui":
+            result = verify_package(entry, strict=strict)
+            results.append(result)
+            if result.spec:
+                index_entries.append(_spec_to_index_entry(result.spec))
+
+    return results, {"packages": index_entries}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for package verification."""
+    parser = argparse.ArgumentParser(
+        prog="deckui-verify",
+        description="Verify .dui packages for correctness and repository readiness.",
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .dui package directory, or a parent directory with --index",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Promote warnings to errors (use for repository submission gates)",
+    )
+    parser.add_argument(
+        "--index",
+        action="store_true",
+        help="Verify all packages in the directory and emit a JSON index to stdout",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+
+    if args.index:
+        try:
+            results, index = verify_directory(args.path, strict=args.strict)
+        except PackageError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+
+        any_errors = False
+        for result in results:
+            _print_result(result)
+            if not result.ok:
+                any_errors = True
+
+        if not any_errors:
+            json.dump(index, sys.stdout, indent=2)
+            print()  # trailing newline
+
+        return 1 if any_errors else 0
+
+    result = verify_package(args.path, strict=args.strict)
+    _print_result(result)
+    return 0 if result.ok else 1
+
+
+def _print_result(result: VerifyResult) -> None:
+    """Print verification diagnostics to stderr."""
+    label = result.package_name or str(result.path)
+    if not result.diagnostics:
+        print(f"  {label}: OK", file=sys.stderr)
+        return
+    for diag in result.diagnostics:
+        prefix = diag.severity.value.upper()
+        print(f"  {label}: {prefix}: {diag.message}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,10 @@ name: TestCard
 type: TouchStripCard
 version: 1
 layout: layout.svg
+description: "A test card for audio playback"
+author: "Test Author <test@example.com>"
+category: media
+tags: [music, test]
 
 bindings:
   title:
@@ -219,6 +223,8 @@ name: TestKey
 type: Key
 version: 1
 layout: layout.svg
+description: "A test key for status indication"
+author: "Test Author <test@example.com>"
 
 bindings:
   label:

--- a/tests/test_dui_loader.py
+++ b/tests/test_dui_loader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from deckui.dui.loader import PackageError, load_all_packages, load_package
@@ -30,6 +32,10 @@ class TestLoadPackageValid:
         assert spec.type == PackageType.TOUCH_STRIP_CARD
         assert spec.version == 1
         assert "<svg" in spec.svg_source
+        assert spec.description == "A test card for audio playback"
+        assert spec.author == "Test Author <test@example.com>"
+        assert spec.category == "media"
+        assert spec.tags == ("music", "test")
 
     def test_loads_key_package(self, key_dui_path):
         spec = load_package(key_dui_path)
@@ -1284,3 +1290,112 @@ class TestLoadPackageNoBindingsOrEvents:
         assert spec.events == ()
         assert spec.regions == ()
         assert spec.assets == {}
+
+
+class TestLoadPackageMetadata:
+    """Test parsing of optional metadata fields."""
+
+    _SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"/>'
+    _BASE = "name: M\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+
+    def _make_pkg(self, tmp_path, extra_yaml: str) -> str:
+        pkg = tmp_path / "M.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(self._BASE + extra_yaml, encoding="utf-8")
+        return str(pkg)
+
+    def test_metadata_defaults_to_none(self, tmp_path):
+        spec = load_package(self._make_pkg(tmp_path, ""))
+        assert spec.description is None
+        assert spec.author is None
+        assert spec.license is None
+        assert spec.tags == ()
+        assert spec.category is None
+        assert spec.url is None
+        assert spec.icon is None
+        assert spec.min_deckui is None
+        assert spec.device == ()
+
+    def test_all_metadata_parsed(self, tmp_path):
+        extra = (
+            'description: "A great package"\n'
+            'author: "Jane Doe"\n'
+            'license: MIT\n'
+            "tags: [media, music]\n"
+            "category: media\n"
+            'url: "https://example.com"\n'
+            'icon: "assets/icon.png"\n'
+            'min_deckui: "0.5.0"\n'
+            "device: [StreamDeckPlus]\n"
+        )
+        pkg = tmp_path / "M.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(self._BASE + extra, encoding="utf-8")
+        assets = pkg / "assets"
+        assets.mkdir()
+        (assets / "icon.png").write_bytes(b"PNG")
+        spec = load_package(pkg)
+        assert spec.description == "A great package"
+        assert spec.author == "Jane Doe"
+        assert spec.license == "MIT"
+        assert spec.tags == ("media", "music")
+        assert spec.category == "media"
+        assert spec.url == "https://example.com"
+        assert spec.icon == "assets/icon.png"
+        assert spec.min_deckui == "0.5.0"
+        assert spec.device == ("StreamDeckPlus",)
+
+    def test_invalid_category(self, tmp_path):
+        with pytest.raises(PackageError, match="Invalid category"):
+            load_package(self._make_pkg(tmp_path, "category: invalid_cat"))
+
+    def test_description_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'description' must be a string"):
+            load_package(self._make_pkg(tmp_path, "description: 123"))
+
+    def test_author_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'author' must be a string"):
+            load_package(self._make_pkg(tmp_path, "author: 123"))
+
+    def test_tags_not_list(self, tmp_path):
+        with pytest.raises(PackageError, match="'tags' must be a list"):
+            load_package(self._make_pkg(tmp_path, "tags: bad"))
+
+    def test_tags_empty_string(self, tmp_path):
+        with pytest.raises(PackageError, match="non-empty string"):
+            load_package(self._make_pkg(tmp_path, 'tags: [""]'))
+
+    def test_device_not_list(self, tmp_path):
+        with pytest.raises(PackageError, match="'device' must be a list"):
+            load_package(self._make_pkg(tmp_path, "device: StreamDeckPlus"))
+
+    def test_device_empty_string(self, tmp_path):
+        with pytest.raises(PackageError, match="non-empty string"):
+            load_package(self._make_pkg(tmp_path, 'device: [""]'))
+
+    def test_license_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'license' must be a string"):
+            load_package(self._make_pkg(tmp_path, "license: 123"))
+
+    def test_url_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'url' must be a string"):
+            load_package(self._make_pkg(tmp_path, "url: 123"))
+
+    def test_icon_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'icon' must be a string"):
+            load_package(self._make_pkg(tmp_path, "icon: 123"))
+
+    def test_min_deckui_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'min_deckui' must be a string"):
+            load_package(self._make_pkg(tmp_path, "min_deckui: 1"))
+
+    def test_category_not_string(self, tmp_path):
+        with pytest.raises(PackageError, match="'category' must be a string"):
+            load_package(self._make_pkg(tmp_path, "category: 123"))
+
+    def test_unknown_keys_logged(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING):
+            load_package(self._make_pkg(tmp_path, "desciption: typo"))
+        assert "unknown manifest keys" in caplog.text

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,208 @@
+"""Tests for deckui.tools.verify — package verification and index generation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from deckui.tools.verify import (
+    main,
+    verify_directory,
+    verify_package,
+)
+
+
+class TestVerifyPackageValid:
+    """Verify passes for well-formed packages with metadata."""
+
+    def test_card_package_ok(self, card_dui_path):
+        result = verify_package(card_dui_path)
+        assert result.ok
+        assert result.package_name == "TestCard"
+        assert result.spec is not None
+        assert len(result.errors) == 0
+
+    def test_key_package_ok(self, key_dui_path):
+        result = verify_package(key_dui_path)
+        assert result.ok
+        assert result.package_name == "TestKey"
+
+    def test_no_diagnostics_for_complete_package(self, card_dui_path):
+        result = verify_package(card_dui_path)
+        assert result.diagnostics == []
+
+
+class TestVerifyPackageMissingMetadata:
+    """Verify warns (not errors) when optional metadata is missing."""
+
+    _SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"/>'
+
+    def _make_minimal(self, tmp_path):
+        pkg = tmp_path / "Bare.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bare\ntype: Key\nversion: 1\nlayout: layout.svg",
+            encoding="utf-8",
+        )
+        return pkg
+
+    def test_warns_missing_description(self, tmp_path):
+        result = verify_package(self._make_minimal(tmp_path))
+        assert result.ok  # warnings don't fail
+        msgs = [d.message for d in result.warnings]
+        assert any("description" in m for m in msgs)
+
+    def test_warns_missing_author(self, tmp_path):
+        result = verify_package(self._make_minimal(tmp_path))
+        msgs = [d.message for d in result.warnings]
+        assert any("author" in m for m in msgs)
+
+    def test_strict_promotes_warnings(self, tmp_path):
+        result = verify_package(self._make_minimal(tmp_path), strict=True)
+        assert not result.ok
+        assert len(result.errors) >= 2
+
+
+class TestVerifyPackageChecks:
+    """Test specific verification checks."""
+
+    _SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"/>'
+
+    def test_unknown_manifest_key(self, tmp_path):
+        pkg = tmp_path / "Typo.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Typo\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            'desciption: "typo"\nauthor: "A"',
+            encoding="utf-8",
+        )
+        result = verify_package(pkg)
+        msgs = [d.message for d in result.warnings]
+        assert any("desciption" in m for m in msgs)
+
+    def test_uppercase_tag_warning(self, tmp_path):
+        pkg = tmp_path / "Tags.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Tags\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            'description: "d"\nauthor: "a"\ntags: [Media, MUSIC]',
+            encoding="utf-8",
+        )
+        result = verify_package(pkg)
+        tag_warnings = [d for d in result.warnings if "lowercase" in d.message]
+        assert len(tag_warnings) == 2
+
+    def test_icon_not_found_warning(self, tmp_path):
+        pkg = tmp_path / "Icon.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Icon\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            'description: "d"\nauthor: "a"\nicon: "assets/missing.png"',
+            encoding="utf-8",
+        )
+        result = verify_package(pkg)
+        msgs = [d.message for d in result.warnings]
+        assert any("missing.png" in m for m in msgs)
+
+    def test_license_with_spaces_warning(self, tmp_path):
+        pkg = tmp_path / "Lic.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Lic\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            'description: "d"\nauthor: "a"\nlicense: "MIT License"',
+            encoding="utf-8",
+        )
+        result = verify_package(pkg)
+        msgs = [d.message for d in result.warnings]
+        assert any("SPDX" in m for m in msgs)
+
+    def test_load_failure_is_error(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        (pkg / "manifest.yaml").write_text("name: Bad", encoding="utf-8")
+        result = verify_package(pkg)
+        assert not result.ok
+        assert result.spec is None
+
+    def test_large_package_warning(self, tmp_path):
+        pkg = tmp_path / "Big.dui"
+        pkg.mkdir()
+        (pkg / "layout.svg").write_text(self._SVG, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Big\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            'description: "d"\nauthor: "a"',
+            encoding="utf-8",
+        )
+        assets = pkg / "assets"
+        assets.mkdir()
+        (assets / "huge.bin").write_bytes(b"\x00" * (3 * 1024 * 1024))
+        result = verify_package(pkg)
+        msgs = [d.message for d in result.warnings]
+        assert any("2MB" in m for m in msgs)
+
+
+class TestVerifyDirectory:
+    """Test directory-level verification and index generation."""
+
+    def test_verify_all_packages(self, dui_packages_dir):
+        results, index = verify_directory(dui_packages_dir)
+        assert len(results) == 2
+        assert all(r.ok for r in results)
+        assert len(index["packages"]) == 2
+
+    def test_index_contains_metadata(self, dui_packages_dir):
+        _, index = verify_directory(dui_packages_dir)
+        names = {p["name"] for p in index["packages"]}
+        assert "TestCard" in names
+        assert "TestKey" in names
+        card = next(p for p in index["packages"] if p["name"] == "TestCard")
+        assert card["description"] == "A test card for audio playback"
+        assert card["category"] == "media"
+        assert card["tags"] == ["music", "test"]
+
+    def test_not_a_directory(self, tmp_path):
+        from deckui.dui.loader import PackageError
+
+        with pytest.raises(PackageError, match="Not a directory"):
+            verify_directory(tmp_path / "nope")
+
+    def test_empty_directory(self, tmp_path):
+        results, index = verify_directory(tmp_path)
+        assert results == []
+        assert index["packages"] == []
+
+
+class TestVerifyCLI:
+    """Test the CLI entry point."""
+
+    def test_verify_single_package(self, card_dui_path):
+        assert main([str(card_dui_path)]) == 0
+
+    def test_verify_strict_fails_without_metadata(self, tmp_path):
+        pkg = tmp_path / "Bare.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bare\ntype: Key\nversion: 1\nlayout: layout.svg",
+            encoding="utf-8",
+        )
+        assert main(["--strict", str(pkg)]) == 1
+
+    def test_verify_index(self, dui_packages_dir, capsys):
+        assert main(["--index", str(dui_packages_dir)]) == 0
+        captured = capsys.readouterr()
+        index = json.loads(captured.out)
+        assert len(index["packages"]) == 2
+
+    def test_verify_invalid_path(self, tmp_path):
+        assert main([str(tmp_path / "nope.dui")]) == 1
+
+    def test_verify_index_invalid_path(self, tmp_path):
+        assert main(["--index", str(tmp_path / "nope")]) == 1


### PR DESCRIPTION
## Summary

- Add optional metadata fields to the DUI manifest schema: `description`, `author`, `license`, `tags`, `category`, `url`, `icon`, `min_deckui`, `device`
- The loader parses and validates these fields but does **not** require them — backward compatible for local use
- Add `python -m deckui.tools.verify` CLI tool with `--strict` mode (promotes warnings to errors for repo submission) and `--index` mode (generates a JSON repository index from package metadata)
- Add `VALID_CATEGORIES` controlled vocabulary and `KNOWN_MANIFEST_KEYS` for typo detection
- Update DUI package guide with metadata documentation and verify tool usage

## Metadata Schema

| Field | Type | Required for repo | Description |
|-------|------|:-:|---|
| `description` | str | yes | One-line summary |
| `author` | str | yes | Attribution |
| `license` | str | no | SPDX identifier |
| `tags` | list[str] | no | Free-form search labels |
| `category` | str | no | Controlled vocabulary |
| `url` | str | no | Project URL |
| `icon` | str | no | Thumbnail in assets/ |
| `min_deckui` | str | no | Minimum version |
| `device` | list[str] | no | Device compatibility |

## Verify Tool

```bash
python -m deckui.tools.verify MyPackage.dui          # basic check
python -m deckui.tools.verify --strict MyPackage.dui  # repo gate
python -m deckui.tools.verify --index packages/       # build JSON index
```

## Test Results

- 955 tests pass, 97.75% coverage (threshold: 95%)
- Lint and typecheck clean