### PR TITLE
Add spinner animation and busy guard for DUI packages

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -260,6 +260,7 @@ events:
 | `direction` | `str` | no | `"left"` or `"right"` (turn events only) |
 | `max_duration_ms` | `int` | no | Max press duration for `*_press_release` (default 500) |
 | `hold_ms` | `int` | no | Hold threshold for `*_hold` (default 500) |
+| `busy` | `bool` | no | Enable spinner animation and event suppression (default `false`) |
 
 ### Sources
 
@@ -314,6 +315,175 @@ regions:
 ```
 
 All coordinates are non-negative integers. The `events` list is optional and restricts which touch gestures the region responds to.
+
+---
+
+## Spinner & Busy State
+
+When an event handler takes time to complete (e.g. making an API call), users get no immediate visual feedback and may press the button again. The **spinner** system solves this by:
+
+1. Showing an animation immediately when the event fires
+2. Suppressing duplicate events while the handler is running
+3. Restoring the normal UI when the handler completes
+
+### Defining a Spinner
+
+Add a `spinner` section to your manifest and mark events with `busy: true`:
+
+```yaml
+spinner:
+  type: rotation        # "rotation", "pulse", or "custom"
+  node: spinner_icon    # SVG element ID to animate (required for rotation/pulse)
+  frames: 12            # frames per cycle (default 12, minimum 2)
+  interval_ms: 80       # ms between frames (default 80, minimum 10)
+
+events:
+  - name: toggle_play
+    source: encoder_press_release
+    busy: true           # enable spinner + event guard for this event
+```
+
+Your SVG must include an element with the spinner node ID. It's typically hidden by default and made visible during animation:
+
+```xml
+<rect id="spinner_icon" x="80" y="30" width="30" height="30"
+      display="none" fill="#ffffff"/>
+```
+
+### Spinner Types
+
+#### `rotation`
+
+Rotates the SVG node by `360/frames` degrees each frame around its centre. Good for loading spinners.
+
+```yaml
+spinner:
+  type: rotation
+  node: spinner_icon
+  frames: 12
+  interval_ms: 80
+```
+
+#### `pulse`
+
+Cycles the node's opacity between 0.2 and 1.0 in a triangle wave. Good for subtle "working" indicators.
+
+```yaml
+spinner:
+  type: pulse
+  node: spinner_glow
+  frames: 8
+  interval_ms: 100
+```
+
+#### `custom`
+
+Use your own pre-rendered frames. Place them in one of two formats:
+
+**Numbered PNGs** in `assets/spinner/`:
+
+```
+MyPackage.dui/
+  assets/
+    spinner/
+      frame_00.png
+      frame_01.png
+      frame_02.png
+      ...
+```
+
+**Animated GIF** at `assets/spinner.gif`:
+
+```
+MyPackage.dui/
+  assets/
+    spinner.gif
+```
+
+For custom spinners, the `node` field is optional (ignored).
+
+```yaml
+spinner:
+  type: custom
+  interval_ms: 60
+```
+
+### How It Works
+
+When an event marked `busy: true` fires:
+
+1. The library sets the card/key to **busy** state — further events for that slot are suppressed
+2. The spinner animation starts, pushing pre-rendered frames directly to the device at `interval_ms` intervals
+3. For touchscreen cards, only the affected panel region is updated (not the entire strip)
+4. The normal refresh cycle skips animating slots to avoid overwriting frames
+5. When the handler returns, the animation stops, the slot is marked dirty, and a normal re-render occurs
+
+Frames are generated **lazily on first use** and cached for the lifetime of the card/key.
+
+### Busy Events
+
+The `busy` field is opt-in per event. Only events you mark with `busy: true` get the spinner and event suppression. Non-busy events on the same card/key still fire normally.
+
+```yaml
+events:
+  - name: toggle_play
+    source: encoder_press_release
+    busy: true           # gets spinner + suppression
+  - name: next_track
+    source: encoder_turn
+    direction: right     # no busy — fires immediately, no spinner
+```
+
+**Validation rules:**
+- If any event has `busy: true`, the manifest must define a `spinner` section
+- For `rotation` and `pulse` types, the `node` must exist in the SVG
+- For `custom` type, either `assets/spinner.gif` or `assets/spinner/frame_*.png` files must exist
+
+### Complete Example
+
+```yaml
+name: SmartLight
+type: Key
+version: 1
+layout: layout.svg
+
+spinner:
+  type: rotation
+  node: loading_ring
+  frames: 8
+  interval_ms: 100
+
+bindings:
+  label:
+    type: text
+    node: label
+    default: "Light"
+  status_color:
+    type: color
+    node: indicator
+    attribute: fill
+    default: "#333333"
+
+events:
+  - name: toggle
+    source: key_press_release
+    max_duration_ms: 300
+    busy: true
+```
+
+```python
+from deckui.dui import DuiKey, load_package
+
+spec = load_package("./SmartLight.dui")
+key = DuiKey(spec)
+
+@key.on_event("toggle")
+async def handle():
+    # This takes 2 seconds — spinner plays during this time,
+    # and duplicate presses are ignored
+    new_state = await smart_home_api.toggle_light()
+    key.set("status_color", "#00ff00" if new_state else "#333333")
+```
 
 ---
 

--- a/src/deckui/dui/__init__.py
+++ b/src/deckui/dui/__init__.py
@@ -20,6 +20,7 @@ Examples
 
 from __future__ import annotations
 
+from .animator import SpinnerAnimator
 from .card import DuiCard
 from .event_map import EventMap
 from .iconify import IconifyError, fetch_icon
@@ -42,10 +43,13 @@ from .schema import (
     RangeDirection,
     Region,
     SliderBinding,
+    SpinnerSpec,
+    SpinnerType,
     TextBinding,
     ToggleBinding,
     VisibilityBinding,
 )
+from .spinner import SpinnerFrames
 from .svg_renderer import SvgRenderer
 
 __all__ = [
@@ -68,6 +72,10 @@ __all__ = [
     "RangeDirection",
     "Region",
     "SliderBinding",
+    "SpinnerAnimator",
+    "SpinnerFrames",
+    "SpinnerSpec",
+    "SpinnerType",
     "SvgRenderer",
     "TextBinding",
     "ToggleBinding",

--- a/src/deckui/dui/animator.py
+++ b/src/deckui/dui/animator.py
@@ -1,0 +1,91 @@
+"""Asyncio-based frame animator for spinner animations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from contextlib import suppress
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PushFn = Callable[[bytes], Coroutine[Any, Any, None]]
+"""Async callable that pushes a single image frame to the device."""
+
+
+class SpinnerAnimator:
+    """Drive frame-by-frame spinner animation on an asyncio event loop.
+
+    The animator cycles through pre-rendered frames at a fixed interval,
+    pushing each frame to the device via the provided *push_fn*.
+
+    Parameters
+    ----------
+    frames
+        List of encoded image bytes (one per frame).
+    interval_ms
+        Milliseconds between frame updates.
+    push_fn
+        Async callable ``(frame_bytes) -> None`` that sends a frame
+        to the hardware.
+    """
+
+    def __init__(
+        self,
+        frames: list[bytes],
+        interval_ms: int,
+        push_fn: PushFn,
+    ) -> None:
+        if not frames:
+            raise ValueError("frames must not be empty")
+        self._frames = frames
+        self._interval = interval_ms / 1000.0
+        self._push_fn = push_fn
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the animation is currently playing."""
+        return self._running
+
+    async def start(self) -> None:
+        """Begin the animation loop.
+
+        If already running, this is a no-op.
+        """
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop(), name="deckui-spinner")
+
+    async def stop(self) -> None:
+        """Stop the animation loop.
+
+        Cancels the running task and waits for it to finish.
+        """
+        if not self._running:
+            return
+        self._running = False
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+    async def _loop(self) -> None:
+        """Cycle through frames at the configured interval."""
+        idx = 0
+        n = len(self._frames)
+        try:
+            while self._running:
+                frame = self._frames[idx % n]
+                try:
+                    await self._push_fn(frame)
+                except Exception:
+                    logger.exception("Error pushing spinner frame")
+                idx += 1
+                await asyncio.sleep(self._interval)
+        except asyncio.CancelledError:
+            pass

--- a/src/deckui/dui/card.py
+++ b/src/deckui/dui/card.py
@@ -6,7 +6,9 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ..ui.cards.base import Card
+from .animator import PushFn, SpinnerAnimator
 from .event_map import EventMap
+from .spinner import SpinnerFrames
 from .svg_renderer import SvgRenderer
 
 if TYPE_CHECKING:
@@ -56,11 +58,38 @@ class DuiCard(Card):
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events, spec.regions)
+        self._busy = False
+        self._animator: SpinnerAnimator | None = None
+        self._spinner_frames: SpinnerFrames | None = None
+        self._push_fn: PushFn | None = None
 
     @property
     def spec(self) -> PackageSpec:
         """The package specification backing this card."""
         return self._spec
+
+    @property
+    def is_busy(self) -> bool:
+        """Whether a busy-guarded handler is currently executing."""
+        return self._busy
+
+    @property
+    def is_animating(self) -> bool:
+        """Whether a spinner animation is currently running."""
+        return self._animator is not None and self._animator.is_running
+
+    def set_push_fn(self, push_fn: PushFn) -> None:
+        """Set the async function used to push animation frames to the device.
+
+        This must be called before busy events can trigger spinner
+        animations.  Typically set by :class:`~deckui.runtime.deck.Deck`.
+
+        Parameters
+        ----------
+        push_fn
+            Async callable ``(frame_bytes) -> None``.
+        """
+        self._push_fn = push_fn
 
     def set(self, name: str, value: Any) -> DuiCard:
         """Set a binding value.  Marks the card dirty if changed.
@@ -273,19 +302,29 @@ class DuiCard(Card):
 
     def handle_encoder_turn(self, direction: int) -> None:
         """Route encoder turn through the event map."""
-        handler = self._events.handle_encoder_turn(direction)
-        if handler is not None:
-            self.queue_pending_callback(handler, ())
+        result = self._events.handle_encoder_turn(direction)
+        if result is not None:
+            handler, is_busy = result
+            if is_busy:
+                self.queue_pending_callback(self._busy_wrap(handler), ())
+            else:
+                self.queue_pending_callback(handler, ())
 
     def handle_encoder_press(self) -> None:
         """Route encoder press through the event map."""
-        for handler in self._events.handle_encoder_press():
-            self.queue_pending_callback(handler, ())
+        for handler, is_busy in self._events.handle_encoder_press():
+            if is_busy:
+                self.queue_pending_callback(self._busy_wrap(handler), ())
+            else:
+                self.queue_pending_callback(handler, ())
 
     def handle_encoder_release(self) -> None:
         """Route encoder release through the event map."""
-        for handler in self._events.handle_encoder_release():
-            self.queue_pending_callback(handler, ())
+        for handler, is_busy in self._events.handle_encoder_release():
+            if is_busy:
+                self.queue_pending_callback(self._busy_wrap(handler), ())
+            else:
+                self.queue_pending_callback(handler, ())
 
     async def dispatch_touch(self, event: TouchEvent) -> None:
         """Dispatch touch events through regions and the event map.
@@ -293,8 +332,56 @@ class DuiCard(Card):
         Falls back to the base Card touch handlers (on_tap, etc.)
         if the event map doesn't handle the event.
         """
-        handler = self._events.handle_touch(event.event_type, event.x, event.y)
-        if handler is not None:
-            await handler()
+        result = self._events.handle_touch(event.event_type, event.x, event.y)
+        if result is not None:
+            handler, is_busy = result
+            if is_busy:
+                await self._busy_wrap(handler)()
+            else:
+                await handler()
         else:
             await super().dispatch_touch(event)
+
+    def _busy_wrap(self, handler: AsyncHandler) -> AsyncHandler:
+        """Wrap a handler with busy-guard and spinner animation."""
+
+        async def wrapped() -> None:
+            if self._busy:
+                return  # suppress duplicate events while busy
+            self._busy = True
+            try:
+                await self._start_spinner()
+                await handler()
+            finally:
+                await self._stop_spinner()
+                self._busy = False
+                self.mark_dirty()
+
+        return wrapped
+
+    async def _start_spinner(self) -> None:
+        """Start the spinner animation if configured."""
+        if self._spec.spinner is None or self._push_fn is None:
+            return
+
+        if self._spinner_frames is None:
+            from ..render.metrics import PANEL_HEIGHT, PANEL_WIDTH
+
+            self._spinner_frames = SpinnerFrames(
+                self._spec,
+                width=PANEL_WIDTH,
+                height=PANEL_HEIGHT,
+            )
+
+        self._animator = SpinnerAnimator(
+            frames=self._spinner_frames.frames,
+            interval_ms=self._spinner_frames.interval_ms,
+            push_fn=self._push_fn,
+        )
+        await self._animator.start()
+
+    async def _stop_spinner(self) -> None:
+        """Stop the spinner animation."""
+        if self._animator is not None:
+            await self._animator.stop()
+            self._animator = None

--- a/src/deckui/dui/event_map.py
+++ b/src/deckui/dui/event_map.py
@@ -47,6 +47,9 @@ class EventMap:
         self._mappings = events
         self._regions = regions
         self._handlers: dict[str, AsyncHandler] = {}
+        self._busy_events: frozenset[str] = frozenset(
+            m.name for m in events if m.busy
+        )
 
         self._press_time: float | None = None
         self._pressed = False
@@ -85,6 +88,15 @@ class EventMap:
         """All semantic event names defined in this map."""
         return [m.name for m in self._mappings]
 
+    def is_busy_event(self, event_name: str) -> bool:
+        """Return whether *event_name* is marked as ``busy``."""
+        return event_name in self._busy_events
+
+    @property
+    def has_busy_events(self) -> bool:
+        """Whether any events in this map are marked ``busy``."""
+        return bool(self._busy_events)
+
     def _start_hold_timer(self, source: str) -> None:
         """Start a hold timer for the first matching hold mapping.
 
@@ -118,7 +130,7 @@ class EventMap:
             self._hold_task.cancel()
             self._hold_task = None
 
-    def handle_encoder_turn(self, direction: int) -> AsyncHandler | None:
+    def handle_encoder_turn(self, direction: int) -> tuple[AsyncHandler, bool] | None:
         """Match an encoder turn to a semantic event.
 
         Parameters
@@ -128,23 +140,27 @@ class EventMap:
 
         Returns
         -------
-        AsyncHandler or None
-            The handler to call, or ``None`` if no mapping matched.
+        tuple[AsyncHandler, bool] or None
+            ``(handler, is_busy)`` or ``None`` if no mapping matched.
         """
         if self._pressed:
             self._cancel_hold_timer()
 
             for mapping in self._by_source.get("encoder_press_turn", []):
                 if self._direction_matches(mapping, direction):
-                    return self._handlers.get(mapping.name)
+                    h = self._handlers.get(mapping.name)
+                    if h is not None:
+                        return (h, mapping.name in self._busy_events)
 
         for mapping in self._by_source.get("encoder_turn", []):
             if self._direction_matches(mapping, direction):
-                return self._handlers.get(mapping.name)
+                h = self._handlers.get(mapping.name)
+                if h is not None:
+                    return (h, mapping.name in self._busy_events)
 
         return None
 
-    def handle_encoder_press(self) -> list[AsyncHandler]:
+    def handle_encoder_press(self) -> list[tuple[AsyncHandler, bool]]:
         """Match an encoder press to semantic events.
 
         Records the press timestamp for gesture detection and starts
@@ -152,8 +168,8 @@ class EventMap:
 
         Returns
         -------
-        list[AsyncHandler]
-            A list of handlers to call (may be empty).
+        list[tuple[AsyncHandler, bool]]
+            A list of ``(handler, is_busy)`` tuples (may be empty).
         """
         self._press_time = time.monotonic()
         self._pressed = True
@@ -161,14 +177,14 @@ class EventMap:
 
         self._start_hold_timer("encoder_hold")
 
-        handlers: list[AsyncHandler] = []
+        handlers: list[tuple[AsyncHandler, bool]] = []
         for mapping in self._by_source.get("encoder_press", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append(handler)
+                handlers.append((handler, mapping.name in self._busy_events))
         return handlers
 
-    def handle_encoder_release(self) -> list[AsyncHandler]:
+    def handle_encoder_release(self) -> list[tuple[AsyncHandler, bool]]:
         """Match an encoder release to semantic events.
 
         Cancels any running hold timer.  The simple ``encoder_release``
@@ -179,8 +195,8 @@ class EventMap:
 
         Returns
         -------
-        list[AsyncHandler]
-            A list of handlers to call (may be empty).
+        list[tuple[AsyncHandler, bool]]
+            A list of ``(handler, is_busy)`` tuples (may be empty).
         """
         self._pressed = False
         self._cancel_hold_timer()
@@ -188,7 +204,7 @@ class EventMap:
         hold_fired = self._hold_fired
         self._hold_fired = False
 
-        handlers: list[AsyncHandler] = []
+        handlers: list[tuple[AsyncHandler, bool]] = []
 
         if not hold_fired and self._press_time is not None:
             elapsed_ms = (time.monotonic() - self._press_time) * 1000
@@ -200,18 +216,20 @@ class EventMap:
                 if max_ms is None or elapsed_ms <= max_ms:
                     handler = self._handlers.get(mapping.name)
                     if handler is not None:
-                        handlers.append(handler)
+                        handlers.append(
+                            (handler, mapping.name in self._busy_events)
+                        )
 
         self._press_time = None
 
         for mapping in self._by_source.get("encoder_release", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append(handler)
+                handlers.append((handler, mapping.name in self._busy_events))
 
         return handlers
 
-    def handle_key_press(self) -> list[AsyncHandler]:
+    def handle_key_press(self) -> list[tuple[AsyncHandler, bool]]:
         """Match a key press to semantic events.
 
         Records the press timestamp and starts a hold timer if a
@@ -219,8 +237,8 @@ class EventMap:
 
         Returns
         -------
-        list[AsyncHandler]
-            A list of handlers to call (may be empty).
+        list[tuple[AsyncHandler, bool]]
+            A list of ``(handler, is_busy)`` tuples (may be empty).
         """
         self._press_time = time.monotonic()
         self._pressed = True
@@ -228,14 +246,14 @@ class EventMap:
 
         self._start_hold_timer("key_hold")
 
-        handlers: list[AsyncHandler] = []
+        handlers: list[tuple[AsyncHandler, bool]] = []
         for mapping in self._by_source.get("key_press", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append(handler)
+                handlers.append((handler, mapping.name in self._busy_events))
         return handlers
 
-    def handle_key_release(self) -> list[AsyncHandler]:
+    def handle_key_release(self) -> list[tuple[AsyncHandler, bool]]:
         """Match a key release to semantic events.
 
         Cancels any running hold timer.  The simple ``key_release``
@@ -246,8 +264,8 @@ class EventMap:
 
         Returns
         -------
-        list[AsyncHandler]
-            A list of handlers to call (may be empty).
+        list[tuple[AsyncHandler, bool]]
+            A list of ``(handler, is_busy)`` tuples (may be empty).
         """
         self._pressed = False
         self._cancel_hold_timer()
@@ -255,7 +273,7 @@ class EventMap:
         hold_fired = self._hold_fired
         self._hold_fired = False
 
-        handlers: list[AsyncHandler] = []
+        handlers: list[tuple[AsyncHandler, bool]] = []
 
         if not hold_fired and self._press_time is not None:
             elapsed_ms = (time.monotonic() - self._press_time) * 1000
@@ -265,20 +283,22 @@ class EventMap:
                 if max_ms is None or elapsed_ms <= max_ms:
                     handler = self._handlers.get(mapping.name)
                     if handler is not None:
-                        handlers.append(handler)
+                        handlers.append(
+                            (handler, mapping.name in self._busy_events)
+                        )
 
         self._press_time = None
 
         for mapping in self._by_source.get("key_release", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append(handler)
+                handlers.append((handler, mapping.name in self._busy_events))
 
         return handlers
 
     def handle_touch(
         self, event_type: EventType, x: int, y: int
-    ) -> AsyncHandler | None:
+    ) -> tuple[AsyncHandler, bool] | None:
         """Match a touch event to a semantic event via regions.
 
         Parameters
@@ -292,8 +312,8 @@ class EventMap:
 
         Returns
         -------
-        AsyncHandler or None
-            The handler to call, or ``None`` if no region/mapping matched.
+        tuple[AsyncHandler, bool] or None
+            ``(handler, is_busy)`` or ``None`` if no region/mapping matched.
         """
         from ..runtime.events import EventType as ET_Enum
 
@@ -312,10 +332,14 @@ class EventMap:
                 and region.y <= y < region.y + region.height
             ):
                 for mapping in self._by_source.get(touch_name, []):
-                    return self._handlers.get(mapping.name)
+                    h = self._handlers.get(mapping.name)
+                    if h is not None:
+                        return (h, mapping.name in self._busy_events)
 
         for mapping in self._by_source.get(touch_name, []):
-            return self._handlers.get(mapping.name)
+            h = self._handlers.get(mapping.name)
+            if h is not None:
+                return (h, mapping.name in self._busy_events)
 
         return None
 

--- a/src/deckui/dui/key.py
+++ b/src/deckui/dui/key.py
@@ -10,7 +10,9 @@ from PIL import Image
 from ..render.key_renderer import _encode_image
 from ..render.metrics import KEY_SIZE
 from ..ui.controls.key_slot import KeySlot
+from .animator import PushFn, SpinnerAnimator
 from .event_map import EventMap
+from .spinner import SpinnerFrames
 from .svg_renderer import SvgRenderer
 
 if TYPE_CHECKING:
@@ -59,11 +61,35 @@ class DuiKey(KeySlot):
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events)
         self._dirty = True
+        self._busy = False
+        self._animator: SpinnerAnimator | None = None
+        self._spinner_frames: SpinnerFrames | None = None
+        self._push_fn: PushFn | None = None
 
     @property
     def spec(self) -> PackageSpec:
         """The package specification backing this key."""
         return self._spec
+
+    @property
+    def is_busy(self) -> bool:
+        """Whether a busy-guarded handler is currently executing."""
+        return self._busy
+
+    @property
+    def is_animating(self) -> bool:
+        """Whether a spinner animation is currently running."""
+        return self._animator is not None and self._animator.is_running
+
+    def set_push_fn(self, push_fn: PushFn) -> None:
+        """Set the async function used to push animation frames to the device.
+
+        Parameters
+        ----------
+        push_fn
+            Async callable ``(frame_bytes) -> None``.
+        """
+        self._push_fn = push_fn
 
     def set(self, name: str, value: Any) -> DuiKey:
         """Set a binding value.  Marks the key dirty if changed.
@@ -311,7 +337,52 @@ class DuiKey(KeySlot):
         )
 
         if handlers:
-            for handler in handlers:
-                await handler()
+            for handler, is_busy in handlers:
+                if is_busy:
+                    await self._busy_wrap(handler)()
+                else:
+                    await handler()
         else:
             await super().dispatch(pressed)
+
+    def _busy_wrap(self, handler: AsyncHandler) -> AsyncHandler:
+        """Wrap a handler with busy-guard and spinner animation."""
+
+        async def wrapped() -> None:
+            if self._busy:
+                return  # suppress duplicate events while busy
+            self._busy = True
+            try:
+                await self._start_spinner()
+                await handler()
+            finally:
+                await self._stop_spinner()
+                self._busy = False
+                self._dirty = True
+
+        return wrapped
+
+    async def _start_spinner(self) -> None:
+        """Start the spinner animation if configured."""
+        if self._spec.spinner is None or self._push_fn is None:
+            return
+
+        if self._spinner_frames is None:
+            self._spinner_frames = SpinnerFrames(
+                self._spec,
+                width=KEY_SIZE[0],
+                height=KEY_SIZE[1],
+            )
+
+        self._animator = SpinnerAnimator(
+            frames=self._spinner_frames.frames,
+            interval_ms=self._spinner_frames.interval_ms,
+            push_fn=self._push_fn,
+        )
+        await self._animator.start()
+
+    async def _stop_spinner(self) -> None:
+        """Stop the spinner animation."""
+        if self._animator is not None:
+            await self._animator.stop()
+            self._animator = None

--- a/src/deckui/dui/loader.py
+++ b/src/deckui/dui/loader.py
@@ -12,6 +12,8 @@ import yaml
 from .schema import (
     DEFAULT_HOLD_MS,
     DEFAULT_MAX_DURATION_MS,
+    DEFAULT_SPINNER_FRAMES,
+    DEFAULT_SPINNER_INTERVAL_MS,
     HOLD_SOURCES,
     KNOWN_MANIFEST_KEYS,
     VALID_CATEGORIES,
@@ -32,6 +34,8 @@ from .schema import (
     RangeDirection,
     Region,
     SliderBinding,
+    SpinnerSpec,
+    SpinnerType,
     TextBinding,
     ToggleBinding,
     VisibilityBinding,
@@ -292,12 +296,55 @@ def _parse_event(raw: dict[str, Any], index: int) -> EventMapping:
     if source in _PRESS_RELEASE_SOURCES and max_duration_ms is None:
         max_duration_ms = DEFAULT_MAX_DURATION_MS
 
+    busy = raw.get("busy", False)
+    if not isinstance(busy, bool):
+        raise PackageError(f"Event '{name}': busy must be a boolean")
+
     return EventMapping(
         name=name,
         source=source,
         direction=direction,
         max_duration_ms=max_duration_ms,
         hold_ms=hold_ms,
+        busy=busy,
+    )
+
+
+def _parse_spinner(raw: dict[str, Any]) -> SpinnerSpec:
+    """Parse a spinner configuration from the manifest."""
+    raw_type = raw.get("type")
+    if raw_type is None:
+        raise PackageError("Spinner missing 'type'")
+    try:
+        spinner_type = SpinnerType(raw_type)
+    except ValueError:
+        valid = [t.value for t in SpinnerType]
+        raise PackageError(
+            f"Invalid spinner type '{raw_type}'. Valid types: {valid}"
+        ) from None
+
+    node = raw.get("node")
+    if spinner_type in (SpinnerType.ROTATION, SpinnerType.PULSE):
+        if not node or not isinstance(node, str):
+            raise PackageError(
+                f"Spinner type '{raw_type}' requires a 'node' (SVG element ID)"
+            )
+    elif node is not None and not isinstance(node, str):
+        raise PackageError("Spinner 'node' must be a string if provided")
+
+    frames = raw.get("frames", DEFAULT_SPINNER_FRAMES)
+    if not isinstance(frames, int) or isinstance(frames, bool) or frames < 2:
+        raise PackageError("Spinner 'frames' must be an integer >= 2")
+
+    interval_ms = raw.get("interval_ms", DEFAULT_SPINNER_INTERVAL_MS)
+    if not isinstance(interval_ms, int) or isinstance(interval_ms, bool) or interval_ms < 10:
+        raise PackageError("Spinner 'interval_ms' must be an integer >= 10")
+
+    return SpinnerSpec(
+        type=spinner_type,
+        node=node,
+        frames=frames,
+        interval_ms=interval_ms,
     )
 
 
@@ -527,12 +574,47 @@ def load_package(path: str | Path) -> PackageSpec:
         region = _parse_region(region_name, region_raw)
         regions.append(region)
 
+    # ── Spinner ───────────────────────────────────────────────────────
+    spinner: SpinnerSpec | None = None
+    raw_spinner = manifest.get("spinner")
+    if raw_spinner is not None:
+        if not isinstance(raw_spinner, dict):
+            raise PackageError("'spinner' must be a mapping")
+        spinner = _parse_spinner(raw_spinner)
+
+        # Validate spinner node exists in SVG (for rotation/pulse)
+        if spinner.node is not None and spinner.node not in svg_ids:
+            raise PackageError(
+                f"Spinner references node '{spinner.node}' "
+                f"which does not exist in the SVG. "
+                f"Available ids: {sorted(svg_ids)}"
+            )
+
+    # Validate busy events require a spinner
+    has_busy_event = any(e.busy for e in events)
+    if has_busy_event and spinner is None:
+        raise PackageError(
+            "Events with 'busy: true' require a 'spinner' section in the manifest"
+        )
+
     assets: dict[str, bytes] = {}
     assets_dir = pkg_dir / "assets"
     if assets_dir.is_dir():
-        for asset_file in assets_dir.iterdir():
+        for asset_file in sorted(assets_dir.rglob("*")):
             if asset_file.is_file():
-                assets[asset_file.name] = asset_file.read_bytes()
+                rel = str(asset_file.relative_to(assets_dir))
+                assets[rel] = asset_file.read_bytes()
+
+    # Validate custom spinner frames exist in assets
+    if spinner is not None and spinner.type == SpinnerType.CUSTOM:
+        has_gif = "spinner.gif" in assets
+        frame_keys = sorted(k for k in assets if k.startswith("spinner/frame_"))
+        if not has_gif and not frame_keys:
+            raise PackageError(
+                "Spinner type 'custom' requires either 'assets/spinner.gif' "
+                "or frame images in 'assets/spinner/' "
+                "(e.g. 'spinner/frame_00.png', 'spinner/frame_01.png', ...)"
+            )
 
     logger.info(
         "Loaded .dui package '%s' (%s, %d bindings, %d events)",
@@ -551,6 +633,7 @@ def load_package(path: str | Path) -> PackageSpec:
         events=tuple(events),
         regions=tuple(regions),
         assets=assets,
+        spinner=spinner,
         description=description,
         author=author,
         license=pkg_license,

--- a/src/deckui/dui/schema.py
+++ b/src/deckui/dui/schema.py
@@ -13,6 +13,14 @@ class PackageType(Enum):
     KEY = "Key"
 
 
+class SpinnerType(Enum):
+    """Animation strategy for the busy spinner."""
+
+    ROTATION = "rotation"
+    PULSE = "pulse"
+    CUSTOM = "custom"
+
+
 class BindingType(Enum):
     """Supported binding types for SVG node manipulation."""
 
@@ -199,6 +207,7 @@ class EventMapping:
     direction: str | None = None
     max_duration_ms: int | None = None
     hold_ms: int | None = None
+    busy: bool = False
 
 
 HOLD_SOURCES = frozenset({"key_hold", "encoder_hold"})
@@ -220,6 +229,41 @@ class Region:
     width: int
     height: int
     events: tuple[str, ...] = ()
+
+
+DEFAULT_SPINNER_FRAMES: int = 12
+"""Default number of frames in a spinner animation cycle."""
+
+DEFAULT_SPINNER_INTERVAL_MS: int = 80
+"""Default interval (ms) between spinner animation frames."""
+
+
+@dataclass(frozen=True, slots=True)
+class SpinnerSpec:
+    """Configuration for a busy-state spinner animation.
+
+    The spinner is shown when an event handler marked with ``busy: true``
+    is executing.  It provides immediate visual feedback by cycling
+    pre-rendered animation frames on the key or card panel.
+
+    Parameters
+    ----------
+    type
+        Animation strategy: ``rotation`` (rotate an SVG node),
+        ``pulse`` (fade opacity), or ``custom`` (user-provided frames).
+    node
+        SVG element ID to animate (required for ``rotation`` and
+        ``pulse``; ignored for ``custom``).
+    frames
+        Number of frames per animation cycle.
+    interval_ms
+        Milliseconds between frames.
+    """
+
+    type: SpinnerType
+    node: str | None = None
+    frames: int = DEFAULT_SPINNER_FRAMES
+    interval_ms: int = DEFAULT_SPINNER_INTERVAL_MS
 
 
 VALID_CATEGORIES = frozenset(
@@ -256,6 +300,7 @@ KNOWN_MANIFEST_KEYS = frozenset(
         "bindings",
         "events",
         "regions",
+        "spinner",
     }
 )
 """All recognised top-level keys in a manifest.yaml file."""
@@ -273,6 +318,7 @@ class PackageSpec:
     events: tuple[EventMapping, ...] = ()
     regions: tuple[Region, ...] = ()
     assets: dict[str, bytes] = field(default_factory=dict)
+    spinner: SpinnerSpec | None = None
     description: str | None = None
     author: str | None = None
     license: str | None = None

--- a/src/deckui/dui/spinner.py
+++ b/src/deckui/dui/spinner.py
@@ -1,0 +1,215 @@
+"""Spinner frame generation for busy-state animations."""
+
+from __future__ import annotations
+
+import copy
+import io
+import logging
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
+
+from PIL import Image
+
+from ..render.key_renderer import _encode_image
+from .svg_renderer import _find_element_by_id
+
+if TYPE_CHECKING:
+    from .schema import PackageSpec, SpinnerSpec
+
+logger = logging.getLogger(__name__)
+
+_SVG_NS = "http://www.w3.org/2000/svg"
+
+
+class SpinnerFrames:
+    """Pre-renders spinner animation frames from an SVG template.
+
+    Frames are generated lazily on first access and cached for the
+    lifetime of the instance.
+
+    Parameters
+    ----------
+    spec
+        The package specification containing the SVG source and spinner config.
+    width
+        Target image width in pixels.
+    height
+        Target image height in pixels.
+    image_format
+        Encoding format (``"JPEG"`` or ``"BMP"``).
+    """
+
+    def __init__(
+        self,
+        spec: PackageSpec,
+        width: int,
+        height: int,
+        image_format: str = "JPEG",
+    ) -> None:
+        if spec.spinner is None:
+            raise ValueError("PackageSpec has no spinner configuration")
+        self._spec = spec
+        self._spinner: SpinnerSpec = spec.spinner
+        self._width = width
+        self._height = height
+        self._image_format = image_format
+        self._cached_frames: list[bytes] | None = None
+
+    @property
+    def frame_count(self) -> int:
+        """Number of frames in the animation cycle."""
+        return self._spinner.frames
+
+    @property
+    def interval_ms(self) -> int:
+        """Milliseconds between frames."""
+        return self._spinner.interval_ms
+
+    @property
+    def frames(self) -> list[bytes]:
+        """Encoded animation frames, generated on first access."""
+        if self._cached_frames is None:
+            self._cached_frames = self._generate()
+        return self._cached_frames
+
+    def _generate(self) -> list[bytes]:
+        """Generate all animation frames."""
+        from .schema import SpinnerType
+
+        if self._spinner.type == SpinnerType.ROTATION:
+            return self._generate_rotation()
+        if self._spinner.type == SpinnerType.PULSE:
+            return self._generate_pulse()
+        return self._generate_custom()
+
+    def _generate_rotation(self) -> list[bytes]:
+        """Generate frames by rotating the spinner node."""
+        base_root = ET.fromstring(self._spec.svg_source)  # noqa: S314
+        node = self._spinner.node
+        assert node is not None
+
+        # Find the element to determine its centre of rotation
+        elem = _find_element_by_id(base_root, node)
+        if elem is None:
+            logger.warning("Spinner node '%s' not found; returning blank frames", node)
+            return self._blank_frames()
+
+        cx, cy = self._element_centre(elem)
+        step = 360.0 / self._spinner.frames
+
+        frames: list[bytes] = []
+        for i in range(self._spinner.frames):
+            root = copy.deepcopy(base_root)
+            el = _find_element_by_id(root, node)
+            if el is not None:
+                # Make the spinner node visible
+                el.attrib.pop("display", None)
+                angle = step * i
+                existing = el.get("transform", "")
+                rotation = f"rotate({angle:.1f},{cx:.1f},{cy:.1f})"
+                el.set("transform", f"{existing} {rotation}".strip())
+
+            frames.append(self._rasterise(root))
+        return frames
+
+    def _generate_pulse(self) -> list[bytes]:
+        """Generate frames by pulsing opacity on the spinner node."""
+        base_root = ET.fromstring(self._spec.svg_source)  # noqa: S314
+        node = self._spinner.node
+        assert node is not None
+
+        n = self._spinner.frames
+        frames: list[bytes] = []
+        for i in range(n):
+            root = copy.deepcopy(base_root)
+            el = _find_element_by_id(root, node)
+            if el is not None:
+                el.attrib.pop("display", None)
+                # Triangle wave: 0→1→0 over the cycle
+                t = i / n
+                opacity = 1.0 - 2.0 * abs(t - 0.5)
+                opacity = max(0.2, min(1.0, 0.2 + 0.8 * opacity))
+                el.set("opacity", f"{opacity:.2f}")
+
+            frames.append(self._rasterise(root))
+        return frames
+
+    def _generate_custom(self) -> list[bytes]:
+        """Load custom frames from package assets."""
+        assets = self._spec.assets
+
+        # Try animated GIF first
+        if "spinner.gif" in assets:
+            return self._load_gif_frames(assets["spinner.gif"])
+
+        # Try numbered PNGs in spinner/ subdirectory
+        frame_keys = sorted(k for k in assets if k.startswith("spinner/frame_"))
+        if not frame_keys:
+            logger.warning("No custom spinner frames found; returning blank frames")
+            return self._blank_frames()
+
+        frames: list[bytes] = []
+        for key in frame_keys:
+            img: Image.Image = Image.open(io.BytesIO(assets[key]))
+            if img.size != (self._width, self._height):
+                img = img.resize(
+                    (self._width, self._height), Image.Resampling.LANCZOS
+                )
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+            frames.append(_encode_image(img, self._image_format))
+        return frames
+
+    def _load_gif_frames(self, data: bytes) -> list[bytes]:
+        """Extract and encode frames from an animated GIF."""
+        gif = Image.open(io.BytesIO(data))
+        frames: list[bytes] = []
+        try:
+            while True:
+                frame = gif.copy()
+                if frame.size != (self._width, self._height):
+                    frame = frame.resize(
+                        (self._width, self._height), Image.Resampling.LANCZOS
+                    )
+                if frame.mode != "RGB":
+                    frame = frame.convert("RGB")
+                frames.append(_encode_image(frame, self._image_format))
+                gif.seek(gif.tell() + 1)
+        except EOFError:
+            pass
+
+        if not frames:
+            logger.warning("Animated GIF has no frames; returning blank frames")
+            return self._blank_frames()
+        return frames
+
+    def _blank_frames(self) -> list[bytes]:
+        """Return a list of blank encoded frames as fallback."""
+        blank = Image.new("RGB", (self._width, self._height), "black")
+        data = _encode_image(blank, self._image_format)
+        return [data] * self._spinner.frames
+
+    def _rasterise(self, root: ET.Element) -> bytes:
+        """Rasterise an SVG element tree to encoded image bytes."""
+        from ..render.svg_rasterize import _svg_to_png
+
+        svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
+        png_data = _svg_to_png(svg_bytes.encode("utf-8"), self._width, self._height)
+        img = Image.open(io.BytesIO(png_data)).convert("RGB")
+        return _encode_image(img, self._image_format)
+
+    @staticmethod
+    def _element_centre(elem: ET.Element) -> tuple[float, float]:
+        """Compute the centre of an SVG element from its geometry attributes."""
+        x = float(elem.get("x", "0"))
+        y = float(elem.get("y", "0"))
+        w = float(elem.get("width", "0"))
+        h = float(elem.get("height", "0"))
+
+        # For circle/ellipse elements
+        if w == 0 and h == 0:
+            cx = float(elem.get("cx", str(x)))
+            cy = float(elem.get("cy", str(y)))
+            return cx, cy
+
+        return x + w / 2, y + h / 2

--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -25,6 +25,7 @@ from .events import (
 from .transport import AsyncTransport
 
 if TYPE_CHECKING:
+    from ..dui.animator import PushFn
     from ..dui.key import DuiKey
     from ..ui.cards.base import Card
     from ..ui.controls.key_slot import KeySlot
@@ -325,13 +326,38 @@ class Deck:
         """Check whether a key slot is a DuiKey."""
         return getattr(key_slot, "has_dui_content", False)
 
+    @staticmethod
+    def _is_animating(obj: Any) -> bool:
+        """Check whether a card or key has an active spinner animation."""
+        return getattr(obj, "is_animating", False)
+
     async def _render_dui_key(self, key_slot: KeySlot) -> None:
         """Render a DuiKey and push to the device."""
         if not self._device:
             return
 
-
         dui_key = cast("DuiKey", key_slot)
+
+        # Skip rendering if a spinner animation is active
+        if self._is_animating(dui_key):
+            return
+
+        # Wire up push_fn for spinner animation support
+        if not dui_key._push_fn:  # noqa: SLF001
+            key_index = dui_key.index
+
+            async def _push_key_frame(frame_bytes: bytes) -> None:
+                loop = asyncio.get_running_loop()
+                async with self._device_lock:
+                    await loop.run_in_executor(
+                        self._executor,
+                        self._device.set_key_image,
+                        key_index,
+                        frame_bytes,
+                    )
+
+            dui_key.set_push_fn(_push_key_frame)
+
         image_bytes = dui_key.render_image(
             key_size=self._caps.key_size if self._caps else (120, 120),
             image_format=self._caps.key_image_format if self._caps else "JPEG",
@@ -356,8 +382,48 @@ class Deck:
         if screen.touch_strip is None:
             return
 
+        metrics = self._metrics
+
+        # Wire up push_fn for each DuiCard that needs spinner support
+        for card_idx, card in enumerate(screen.cards):
+            from ..dui.card import DuiCard
+
+            if isinstance(card, DuiCard) and card._push_fn is None:  # noqa: SLF001
+                x_pos = metrics.margin_left + card_idx * (
+                    metrics.panel_width + metrics.panel_gap
+                )
+                y_pos = metrics.margin_top
+
+                async def _make_push(x: int, y: int, w: int, h: int) -> PushFn:
+                    async def _push_card_frame(frame_bytes: bytes) -> None:
+                        loop = asyncio.get_running_loop()
+                        async with self._device_lock:
+                            await loop.run_in_executor(
+                                self._executor,
+                                self._device.set_touchscreen_image,
+                                frame_bytes,
+                                x,
+                                y,
+                                w,
+                                h,
+                            )
+
+                    return _push_card_frame
+
+                push_fn = await _make_push(
+                    x_pos,
+                    y_pos,
+                    metrics.panel_width,
+                    metrics.panel_height,
+                )
+                card.set_push_fn(push_fn)
+
         card_images = []
         for card in screen.cards:
+            # Skip re-rendering cards with active spinner animations
+            if self._is_animating(card):
+                card_images.append(card.rendered)
+                continue
             await card.prepare_assets()
             img = card.render()
             card.set_rendered(img)

--- a/tests/test_animator.py
+++ b/tests/test_animator.py
@@ -1,0 +1,73 @@
+"""Tests for deckui.dui.animator — SpinnerAnimator class."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deckui.dui.animator import SpinnerAnimator
+
+
+class TestSpinnerAnimatorLifecycle:
+    async def test_start_stop_lifecycle(self):
+        push_fn = AsyncMock()
+        animator = SpinnerAnimator(frames=[b"a", b"b"], interval_ms=50, push_fn=push_fn)
+
+        await animator.start()
+        assert animator.is_running is True
+
+        await asyncio.sleep(0.12)
+        await animator.stop()
+        assert animator.is_running is False
+        assert push_fn.await_count >= 1
+
+    async def test_is_running_property(self):
+        push_fn = AsyncMock()
+        animator = SpinnerAnimator(frames=[b"a"], interval_ms=50, push_fn=push_fn)
+        assert animator.is_running is False
+
+        await animator.start()
+        assert animator.is_running is True
+
+        await animator.stop()
+        assert animator.is_running is False
+
+    async def test_frames_are_pushed(self):
+        """Verify push_fn is called with frame bytes."""
+        push_fn = AsyncMock()
+        frames = [b"frame0", b"frame1"]
+        animator = SpinnerAnimator(frames=frames, interval_ms=20, push_fn=push_fn)
+
+        await animator.start()
+        await asyncio.sleep(0.08)
+        await animator.stop()
+
+        assert push_fn.await_count >= 2
+        # First call should be frame0
+        push_fn.assert_any_await(b"frame0")
+
+    async def test_stop_when_not_running_is_noop(self):
+        push_fn = AsyncMock()
+        animator = SpinnerAnimator(frames=[b"a"], interval_ms=50, push_fn=push_fn)
+        # Should not raise
+        await animator.stop()
+        assert animator.is_running is False
+
+    async def test_start_when_already_running_is_noop(self):
+        push_fn = AsyncMock()
+        animator = SpinnerAnimator(frames=[b"a"], interval_ms=50, push_fn=push_fn)
+
+        await animator.start()
+        task1 = animator._task
+        await animator.start()  # no-op
+        task2 = animator._task
+        assert task1 is task2
+
+        await animator.stop()
+
+    def test_empty_frames_raises(self):
+        push_fn = AsyncMock()
+        with pytest.raises(ValueError, match="must not be empty"):
+            SpinnerAnimator(frames=[], interval_ms=50, push_fn=push_fn)

--- a/tests/test_busy_guard.py
+++ b/tests/test_busy_guard.py
@@ -1,0 +1,319 @@
+"""Tests for the busy guard on DuiCard and DuiKey, plus spinner manifest validation."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image
+
+from deckui.dui.card import DuiCard
+from deckui.dui.key import DuiKey
+from deckui.dui.loader import PackageError, _parse_spinner, load_package
+from deckui.dui.schema import (
+    EventMapping,
+    PackageSpec,
+    PackageType,
+    SpinnerSpec,
+    SpinnerType,
+)
+
+_CARD_SVG = (
+    '<svg id="TestCard" xmlns="http://www.w3.org/2000/svg" width="197" height="98">'
+    '<rect id="bg" width="197" height="98" fill="#1c1c1c"/>'
+    '<text id="title" x="4" y="40" font-size="14" fill="#ffffff">Default</text>'
+    '<rect id="spinner" x="80" y="30" width="30" height="30" display="none" fill="#fff"/>'
+    "</svg>"
+)
+
+_KEY_SVG = (
+    '<svg id="TestKey" xmlns="http://www.w3.org/2000/svg" width="120" height="120">'
+    '<rect id="bg" width="120" height="120" fill="#1c1c1c"/>'
+    '<text id="label" x="60" y="100" font-size="14" fill="#fff" text-anchor="middle">Key</text>'
+    '<rect id="spinner" x="80" y="30" width="30" height="30" display="none" fill="#fff"/>'
+    "</svg>"
+)
+
+
+def _fake_png(width: int = 120, height: int = 120) -> bytes:
+    img = Image.new("RGB", (width, height), "black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_card_spec(
+    busy: bool = False,
+    spinner: SpinnerSpec | None = None,
+) -> PackageSpec:
+    events = (
+        EventMapping(name="action", source="encoder_press", busy=busy),
+    )
+    return PackageSpec(
+        name="TestCard",
+        type=PackageType.TOUCH_STRIP_CARD,
+        version=1,
+        svg_source=_CARD_SVG,
+        bindings={},
+        events=events,
+        spinner=spinner,
+    )
+
+
+def _make_key_spec(
+    busy: bool = False,
+    spinner: SpinnerSpec | None = None,
+) -> PackageSpec:
+    events = (
+        EventMapping(name="activate", source="key_press", busy=busy),
+    )
+    return PackageSpec(
+        name="TestKey",
+        type=PackageType.KEY,
+        version=1,
+        svg_source=_KEY_SVG,
+        bindings={},
+        events=events,
+        spinner=spinner,
+    )
+
+
+# ── Card busy guard ───────────────────────────────────────────────────
+
+
+class TestCardBusyGuard:
+    def test_card_not_busy_by_default(self):
+        spec = _make_card_spec(busy=False)
+        card = DuiCard(spec)
+        assert card.is_busy is False
+
+    async def test_card_busy_wrap_suppresses_duplicate(self):
+        spec = _make_card_spec(busy=True)
+        card = DuiCard(spec)
+
+        call_count = 0
+        event = asyncio.Event()
+
+        async def slow_handler():
+            nonlocal call_count
+            call_count += 1
+            await event.wait()
+
+        card.bind_event("action", slow_handler)
+
+        # First press queues the busy-wrapped handler
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        assert len(callbacks) == 1
+
+        # Start the handler (it blocks on the event)
+        task = asyncio.create_task(callbacks[0][0](*callbacks[0][1]))
+        await asyncio.sleep(0.01)
+        assert card.is_busy is True
+
+        # Second press while busy — handler gets wrapped but suppressed
+        card.handle_encoder_press()
+        callbacks2 = card.drain_pending_callbacks()
+        assert len(callbacks2) == 1
+        # Call the wrapped handler — should be suppressed
+        await callbacks2[0][0](*callbacks2[0][1])
+
+        # Unblock first handler
+        event.set()
+        await task
+
+        assert call_count == 1
+
+    async def test_card_busy_clears_after_handler(self):
+        spec = _make_card_spec(busy=True)
+        card = DuiCard(spec)
+        handler = AsyncMock()
+        card.bind_event("action", handler)
+
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        await callbacks[0][0](*callbacks[0][1])
+
+        assert card.is_busy is False
+
+    async def test_card_marks_dirty_after_busy_handler(self):
+        spec = _make_card_spec(busy=True)
+        card = DuiCard(spec)
+        handler = AsyncMock()
+        card.bind_event("action", handler)
+
+        card.mark_clean()
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        await callbacks[0][0](*callbacks[0][1])
+
+        assert card.is_dirty is True
+
+    @patch(
+        "deckui.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_card_spinner_starts_and_stops(self, mock_raster):
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
+        spec = _make_card_spec(busy=True, spinner=spinner)
+        card = DuiCard(spec)
+
+        push_fn = AsyncMock()
+        card.set_push_fn(push_fn)
+
+        handler = AsyncMock()
+        card.bind_event("action", handler)
+
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        await callbacks[0][0](*callbacks[0][1])
+
+        # After completion, animator should be stopped and cleared
+        assert card.is_animating is False
+        assert push_fn.await_count >= 0  # may or may not have pushed in fast test
+
+    @patch(
+        "deckui.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_card_is_animating_property(self, mock_raster):
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
+        spec = _make_card_spec(busy=True, spinner=spinner)
+        card = DuiCard(spec)
+
+        push_fn = AsyncMock()
+        card.set_push_fn(push_fn)
+
+        event = asyncio.Event()
+
+        async def blocking_handler():
+            await event.wait()
+
+        card.bind_event("action", blocking_handler)
+
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        task = asyncio.create_task(callbacks[0][0](*callbacks[0][1]))
+        await asyncio.sleep(0.05)
+
+        assert card.is_animating is True
+
+        event.set()
+        await task
+
+        assert card.is_animating is False
+
+
+# ── Key busy guard ────────────────────────────────────────────────────
+
+
+class TestKeyBusyGuard:
+    def test_key_not_busy_by_default(self):
+        spec = _make_key_spec(busy=False)
+        key = DuiKey(spec)
+        assert key.is_busy is False
+
+    async def test_key_busy_wrap_suppresses_duplicate(self):
+        spec = _make_key_spec(busy=True)
+        key = DuiKey(spec)
+
+        call_count = 0
+        event = asyncio.Event()
+
+        async def slow_handler():
+            nonlocal call_count
+            call_count += 1
+            await event.wait()
+
+        key.bind_event("activate", slow_handler)
+
+        # First press — DuiKey.dispatch calls handler directly (not queued)
+        task = asyncio.create_task(key.dispatch(True))
+        await asyncio.sleep(0.01)
+        assert key.is_busy is True
+
+        # Second press while busy — suppressed
+        await key.dispatch(True)
+
+        event.set()
+        await task
+
+        assert call_count == 1
+
+    async def test_key_busy_clears_after_handler(self):
+        spec = _make_key_spec(busy=True)
+        key = DuiKey(spec)
+        handler = AsyncMock()
+        key.bind_event("activate", handler)
+
+        await key.dispatch(True)
+        assert key.is_busy is False
+
+
+# ── Spinner manifest validation ───────────────────────────────────────
+
+
+class TestSpinnerManifestValidation:
+    def test_invalid_spinner_type(self):
+        with pytest.raises(PackageError, match="Invalid spinner type"):
+            _parse_spinner({"type": "wobble"})
+
+    def test_frames_less_than_2(self):
+        with pytest.raises(PackageError, match="frames.*must be an integer >= 2"):
+            _parse_spinner({"type": "rotation", "node": "spinner", "frames": 1})
+
+    def test_interval_ms_less_than_10(self):
+        with pytest.raises(PackageError, match="interval_ms.*must be an integer >= 10"):
+            _parse_spinner({"type": "rotation", "node": "spinner", "interval_ms": 5})
+
+    def test_rotation_without_node_raises(self):
+        with pytest.raises(PackageError, match="requires a 'node'"):
+            _parse_spinner({"type": "rotation"})
+
+    def test_pulse_without_node_raises(self):
+        with pytest.raises(PackageError, match="requires a 'node'"):
+            _parse_spinner({"type": "pulse"})
+
+    def test_busy_without_spinner_raises(self, tmp_path):
+        """An event with busy:true but no spinner section should fail."""
+        pkg_dir = tmp_path / "Test.dui"
+        pkg_dir.mkdir()
+        (pkg_dir / "layout.svg").write_text(_CARD_SVG, encoding="utf-8")
+        manifest = (
+            "name: Test\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: act\n    source: encoder_press\n    busy: true\n"
+        )
+        (pkg_dir / "manifest.yaml").write_text(manifest, encoding="utf-8")
+
+        with pytest.raises(PackageError, match="require a 'spinner' section"):
+            load_package(pkg_dir)
+
+    def test_custom_without_frames_raises(self, tmp_path):
+        """Custom spinner with no asset frames should fail."""
+        pkg_dir = tmp_path / "Test.dui"
+        pkg_dir.mkdir()
+        (pkg_dir / "layout.svg").write_text(_CARD_SVG, encoding="utf-8")
+        manifest = (
+            "name: Test\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "spinner:\n  type: custom\n"
+        )
+        (pkg_dir / "manifest.yaml").write_text(manifest, encoding="utf-8")
+
+        with pytest.raises(PackageError, match="custom.*requires"):
+            load_package(pkg_dir)
+
+    def test_spinner_node_not_in_svg_raises(self, tmp_path):
+        """Spinner referencing a node not present in SVG should fail."""
+        pkg_dir = tmp_path / "Test.dui"
+        pkg_dir.mkdir()
+        (pkg_dir / "layout.svg").write_text(_CARD_SVG, encoding="utf-8")
+        manifest = (
+            "name: Test\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "spinner:\n  type: rotation\n  node: nonexistent\n"
+        )
+        (pkg_dir / "manifest.yaml").write_text(manifest, encoding="utf-8")
+
+        with pytest.raises(PackageError, match="does not exist in the SVG"):
+            load_package(pkg_dir)

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -26,6 +26,18 @@ def _make_events(*specs: tuple) -> tuple[EventMapping, ...]:
     return tuple(result)
 
 
+def _handlers(results: list[tuple]) -> list:
+    """Extract just the handler from (handler, is_busy) tuples."""
+    return [h for h, _ in results]
+
+
+def _handler(result: tuple | None):
+    """Extract handler from a single (handler, is_busy) or None."""
+    if result is None:
+        return None
+    return result[0]
+
+
 class TestEncoderTurn:
     def test_turn_right(self):
         events = _make_events(
@@ -36,7 +48,7 @@ class TestEncoderTurn:
         handler = AsyncMock()
         em.on("next", handler)
         result = em.handle_encoder_turn(1)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_turn_left(self):
         events = _make_events(
@@ -47,15 +59,15 @@ class TestEncoderTurn:
         handler = AsyncMock()
         em.on("prev", handler)
         result = em.handle_encoder_turn(-1)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_turn_no_direction_filter(self):
         events = _make_events(("scroll", "encoder_turn"))
         em = EventMap(events)
         handler = AsyncMock()
         em.on("scroll", handler)
-        assert em.handle_encoder_turn(1) is handler
-        assert em.handle_encoder_turn(-1) is handler
+        assert _handler(em.handle_encoder_turn(1)) is handler
+        assert _handler(em.handle_encoder_turn(-1)) is handler
 
     def test_turn_no_match(self):
         events = _make_events(("next", "encoder_turn", {"direction": "right"}))
@@ -78,7 +90,7 @@ class TestEncoderPressRelease:
         em = EventMap(events)
         handler = AsyncMock()
         em.on("press", handler)
-        assert em.handle_encoder_press() == [handler]
+        assert em.handle_encoder_press() == [(handler, False)]
 
     def test_simple_release(self):
         events = _make_events(("release", "encoder_release"))
@@ -86,7 +98,7 @@ class TestEncoderPressRelease:
         handler = AsyncMock()
         em.on("release", handler)
         em.handle_encoder_press()
-        assert em.handle_encoder_release() == [handler]
+        assert _handlers(em.handle_encoder_release()) == [handler]
 
     def test_press_release_gesture_within_duration(self):
         events = _make_events(
@@ -98,7 +110,7 @@ class TestEncoderPressRelease:
 
         em.handle_encoder_press()
         result = em.handle_encoder_release()
-        assert handler in result
+        assert handler in _handlers(result)
 
     def test_press_release_gesture_exceeded_duration(self):
         events = _make_events(
@@ -111,7 +123,7 @@ class TestEncoderPressRelease:
         em.handle_encoder_press()
         time.sleep(0.01)
         result = em.handle_encoder_release()
-        assert handler not in result
+        assert handler not in _handlers(result)
 
     def test_press_release_no_max_duration(self):
         events = _make_events(("toggle", "encoder_press_release"))
@@ -122,7 +134,7 @@ class TestEncoderPressRelease:
         em.handle_encoder_press()
         time.sleep(0.01)
         result = em.handle_encoder_release()
-        assert handler in result
+        assert handler in _handlers(result)
 
     def test_release_without_press(self):
         events = _make_events(("release", "encoder_release"))
@@ -130,7 +142,7 @@ class TestEncoderPressRelease:
         handler = AsyncMock()
         em.on("release", handler)
         result = em.handle_encoder_release()
-        assert result == [handler]
+        assert _handlers(result) == [handler]
 
     def test_release_always_fires_alongside_press_release(self):
         """encoder_release fires even when encoder_press_release also fires."""
@@ -146,8 +158,8 @@ class TestEncoderPressRelease:
 
         em.handle_encoder_press()
         result = em.handle_encoder_release()
-        assert toggle_handler in result
-        assert release_handler in result
+        assert toggle_handler in _handlers(result)
+        assert release_handler in _handlers(result)
 
 
 class TestEncoderPressTurn:
@@ -159,7 +171,7 @@ class TestEncoderPressTurn:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(1)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_press_turn_not_pressed(self):
         events = _make_events(("seek", "encoder_press_turn"))
@@ -194,7 +206,7 @@ class TestEncoderPressTurn:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(1)
-        assert result is fwd_handler
+        assert _handler(result) is fwd_handler
 
     def test_press_turn_direction_left(self):
         events = _make_events(
@@ -209,7 +221,7 @@ class TestEncoderPressTurn:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(-1)
-        assert result is bwd_handler
+        assert _handler(result) is bwd_handler
 
     def test_press_turn_direction_no_match(self):
         events = _make_events(
@@ -237,7 +249,7 @@ class TestEncoderPressTurn:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(1)
-        assert result is seek_handler
+        assert _handler(result) is seek_handler
 
     def test_regular_turn_fires_when_press_turn_direction_mismatches(self):
         """Falls back to encoder_turn when press_turn direction doesn't match."""
@@ -253,7 +265,7 @@ class TestEncoderPressTurn:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(-1)
-        assert result is scroll_handler
+        assert _handler(result) is scroll_handler
 
 
 class TestKeyEvents:
@@ -262,7 +274,7 @@ class TestKeyEvents:
         em = EventMap(events)
         handler = AsyncMock()
         em.on("hold", handler)
-        assert em.handle_key_press() == [handler]
+        assert _handlers(em.handle_key_press()) == [handler]
 
     def test_key_release(self):
         events = _make_events(("up", "key_release"))
@@ -270,7 +282,7 @@ class TestKeyEvents:
         handler = AsyncMock()
         em.on("up", handler)
         em.handle_key_press()
-        assert em.handle_key_release() == [handler]
+        assert _handlers(em.handle_key_release()) == [handler]
 
     def test_key_press_release_within_duration(self):
         events = _make_events(
@@ -282,7 +294,7 @@ class TestKeyEvents:
 
         em.handle_key_press()
         result = em.handle_key_release()
-        assert handler in result
+        assert handler in _handlers(result)
 
     def test_key_press_release_exceeded(self):
         events = _make_events(
@@ -295,7 +307,7 @@ class TestKeyEvents:
         em.handle_key_press()
         time.sleep(0.01)
         result = em.handle_key_release()
-        assert handler not in result
+        assert handler not in _handlers(result)
 
     def test_key_release_without_press(self):
         events = _make_events(("up", "key_release"))
@@ -303,7 +315,7 @@ class TestKeyEvents:
         handler = AsyncMock()
         em.on("up", handler)
         result = em.handle_key_release()
-        assert result == [handler]
+        assert _handlers(result) == [handler]
 
     def test_key_press_release_no_max(self):
         events = _make_events(("tap", "key_press_release"))
@@ -312,7 +324,7 @@ class TestKeyEvents:
         em.on("tap", handler)
         em.handle_key_press()
         time.sleep(0.01)
-        assert handler in em.handle_key_release()
+        assert handler in _handlers(em.handle_key_release())
 
     def test_release_always_fires_alongside_press_release(self):
         """key_release fires even when key_press_release also fires."""
@@ -328,8 +340,8 @@ class TestKeyEvents:
 
         em.handle_key_press()
         result = em.handle_key_release()
-        assert tap_handler in result
-        assert release_handler in result
+        assert tap_handler in _handlers(result)
+        assert release_handler in _handlers(result)
 
     def test_press_always_fires_with_hold_configured(self):
         """key_press fires even when key_hold is also configured."""
@@ -344,7 +356,7 @@ class TestKeyEvents:
         em.on("long_hold", hold_handler)
 
         result = em.handle_key_press()
-        assert press_handler in result
+        assert press_handler in _handlers(result)
 
     def test_no_key_press_mapping_returns_empty(self):
         """handle_key_press returns empty list when no key_press mapping."""
@@ -409,7 +421,7 @@ class TestKeyHold:
         hold_handler.assert_awaited_once()
 
         result = em.handle_key_release()
-        assert tap_handler not in result
+        assert tap_handler not in _handlers(result)
         tap_handler.assert_not_awaited()
 
     async def test_hold_does_not_suppress_key_release(self):
@@ -429,7 +441,7 @@ class TestKeyHold:
         hold_handler.assert_awaited_once()
 
         result = em.handle_key_release()
-        assert release_handler in result
+        assert release_handler in _handlers(result)
 
     async def test_short_tap_still_works_with_hold(self):
         """Quick release fires press_release, not the hold."""
@@ -445,7 +457,7 @@ class TestKeyHold:
 
         em.handle_key_press()
         result = em.handle_key_release()
-        assert tap_handler in result
+        assert tap_handler in _handlers(result)
         hold_handler.assert_not_awaited()
 
     async def test_hold_no_handler_registered(self):
@@ -478,7 +490,7 @@ class TestKeyHold:
 
         em.handle_key_press()
         result = em.handle_key_release()
-        assert tap_handler in result
+        assert tap_handler in _handlers(result)
 
     async def test_hold_suppresses_press_release_but_not_release(self):
         """After key_hold fires, key_press_release is suppressed but key_release still fires."""
@@ -500,8 +512,8 @@ class TestKeyHold:
         hold_handler.assert_awaited_once()
 
         result = em.handle_key_release()
-        assert tap_handler not in result
-        assert release_handler in result
+        assert tap_handler not in _handlers(result)
+        assert release_handler in _handlers(result)
 
 
 class TestEncoderHold:
@@ -546,7 +558,7 @@ class TestEncoderHold:
         hold_handler.assert_awaited_once()
 
         result = em.handle_encoder_release()
-        assert toggle_handler not in result
+        assert toggle_handler not in _handlers(result)
         toggle_handler.assert_not_awaited()
 
     async def test_encoder_short_tap_still_works_with_hold(self):
@@ -562,7 +574,7 @@ class TestEncoderHold:
 
         em.handle_encoder_press()
         result = em.handle_encoder_release()
-        assert toggle_handler in result
+        assert toggle_handler in _handlers(result)
         hold_handler.assert_not_awaited()
 
     async def test_encoder_release_fires_alongside_press_release(self):
@@ -582,8 +594,8 @@ class TestEncoderHold:
 
         em.handle_encoder_press()
         result = em.handle_encoder_release()
-        assert toggle_handler in result
-        assert release_handler in result
+        assert toggle_handler in _handlers(result)
+        assert release_handler in _handlers(result)
 
     async def test_encoder_hold_cancelled_by_turn_before_hold_ms(self):
         """encoder_hold does NOT fire if a turn occurs before hold_ms expires."""
@@ -599,7 +611,7 @@ class TestEncoderHold:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(1)
-        assert result is seek_handler
+        assert _handler(result) is seek_handler
 
         await asyncio.sleep(0.1)
         hold_handler.assert_not_awaited()
@@ -639,7 +651,7 @@ class TestEncoderHold:
         hold_handler.assert_awaited_once()
 
         result = em.handle_encoder_release()
-        assert release_handler in result
+        assert release_handler in _handlers(result)
 
 
 class TestTouchEvents:
@@ -653,7 +665,7 @@ class TestTouchEvents:
         em.on("card_tap", handler)
 
         result = em.handle_touch(EventType.TOUCH_SHORT, 50, 50)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_tap_outside_region(self):
         events = _make_events(("card_tap", "tap"))
@@ -663,7 +675,7 @@ class TestTouchEvents:
         em.on("card_tap", handler)
 
         result = em.handle_touch(EventType.TOUCH_SHORT, 100, 50)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_long_press_in_region(self):
         events = _make_events(("menu", "long_press"))
@@ -675,7 +687,7 @@ class TestTouchEvents:
         em.on("menu", handler)
 
         result = em.handle_touch(EventType.TOUCH_LONG, 50, 50)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_drag_not_handled(self):
         events = _make_events(("card_tap", "tap"))
@@ -691,7 +703,7 @@ class TestTouchEvents:
         handler = AsyncMock()
         em.on("card_tap", handler)
         result = em.handle_touch(EventType.TOUCH_SHORT, 50, 50)
-        assert result is handler
+        assert _handler(result) is handler
 
     def test_region_event_mismatch(self):
         """Region only accepts 'tap' but we send long_press."""
@@ -703,7 +715,7 @@ class TestTouchEvents:
         handler = AsyncMock()
         em.on("menu", handler)
         result = em.handle_touch(EventType.TOUCH_LONG, 50, 50)
-        assert result is handler
+        assert _handler(result) is handler
 
 
 class TestEventMapRegistration:

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -1,0 +1,161 @@
+"""Tests for deckui.dui.spinner — SpinnerFrames class."""
+
+from __future__ import annotations
+
+import io
+import xml.etree.ElementTree as ET
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from deckui.dui.schema import (
+    PackageSpec,
+    PackageType,
+    SpinnerSpec,
+    SpinnerType,
+)
+from deckui.dui.spinner import SpinnerFrames
+
+_SPINNER_SVG = (
+    '<svg id="TestCard" xmlns="http://www.w3.org/2000/svg" '
+    'width="120" height="120">'
+    '<rect id="bg" width="120" height="120" fill="#1c1c1c"/>'
+    '<rect id="spinner" x="80" y="30" width="30" height="30" '
+    'display="none" fill="#fff"/>'
+    '<circle id="spinner_circle" cx="60" cy="60" r="20" '
+    'display="none" fill="#fff"/>'
+    "</svg>"
+)
+
+
+def _fake_png(width: int = 120, height: int = 120) -> bytes:
+    """Return a minimal valid PNG."""
+    img = Image.new("RGB", (width, height), "black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_spec(
+    spinner: SpinnerSpec | None = None,
+    assets: dict[str, bytes] | None = None,
+    svg: str = _SPINNER_SVG,
+) -> PackageSpec:
+    return PackageSpec(
+        name="TestSpinner",
+        type=PackageType.KEY,
+        version=1,
+        svg_source=svg,
+        spinner=spinner,
+        assets=assets or {},
+    )
+
+
+class TestRotation:
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_rotation_generates_correct_frame_count(self, mock_raster):
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=8)
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 8
+
+    def test_element_centre_calculation_rect(self):
+        """Rect at x=80,y=30,w=30,h=30 → centre (95, 45)."""
+        elem = ET.fromstring(
+            '<rect xmlns="http://www.w3.org/2000/svg" '
+            'x="80" y="30" width="30" height="30"/>'
+        )
+        cx, cy = SpinnerFrames._element_centre(elem)
+        assert cx == pytest.approx(95.0)
+        assert cy == pytest.approx(45.0)
+
+    def test_element_centre_calculation_circle(self):
+        """Circle with cx=60, cy=60 → centre (60, 60)."""
+        elem = ET.fromstring(
+            '<circle xmlns="http://www.w3.org/2000/svg" cx="60" cy="60" r="20"/>'
+        )
+        cx, cy = SpinnerFrames._element_centre(elem)
+        assert cx == pytest.approx(60.0)
+        assert cy == pytest.approx(60.0)
+
+
+class TestPulse:
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_pulse_generates_correct_frame_count(self, mock_raster):
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.PULSE, node="spinner", frames=6)
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 6
+
+
+class TestCustom:
+    def test_custom_from_png_files(self):
+        """Custom spinner loads numbered PNGs from assets."""
+        assets = {}
+        for i in range(4):
+            assets[f"spinner/frame_{i:02d}.png"] = _fake_png(120, 120)
+
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.CUSTOM, frames=4),
+            assets=assets,
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        frames = sf.frames
+        assert len(frames) == 4
+        for f in frames:
+            assert isinstance(f, bytes)
+            assert len(f) > 0
+
+    def test_custom_from_animated_gif(self):
+        """Custom spinner loads frames from an animated GIF."""
+        # Create a 3-frame animated GIF
+        imgs = [Image.new("RGB", (120, 120), color) for color in ["red", "green", "blue"]]
+        buf = io.BytesIO()
+        imgs[0].save(buf, format="GIF", save_all=True, append_images=imgs[1:], loop=0)
+        gif_bytes = buf.getvalue()
+
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.CUSTOM, frames=3),
+            assets={"spinner.gif": gif_bytes},
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        frames = sf.frames
+        assert len(frames) == 3
+
+
+class TestCaching:
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_frames_are_cached_after_first_access(self, mock_raster):
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        first = sf.frames
+        second = sf.frames
+        assert first is second
+        # _generate called only once
+        assert mock_raster.call_count == 4  # once per frame, not 8
+
+
+class TestErrors:
+    def test_no_spinner_spec_raises(self):
+        spec = _make_spec(spinner=None)
+        with pytest.raises(ValueError, match="no spinner configuration"):
+            SpinnerFrames(spec, width=120, height=120)
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_blank_frames_fallback_for_missing_node(self, mock_raster):
+        """When the spinner node ID doesn't exist in the SVG, return blank frames."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION, node="nonexistent", frames=4
+            )
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        frames = sf.frames
+        assert len(frames) == 4
+        # All frames should be identical (blank)
+        assert all(f == frames[0] for f in frames)


### PR DESCRIPTION
## Summary

- Add spinner/busy animation system for DUI cards and keys — provides immediate visual feedback during slow event handlers and suppresses duplicate event fires
- Support three spinner types: **rotation** (SVG node rotation), **pulse** (opacity cycle), and **custom** (PNG sequence or animated GIF)
- New modules: `spinner.py` (lazy frame generation with caching), `animator.py` (asyncio frame cycling)
- Busy guard integrated into `DuiCard` and `DuiKey` with `set_push_fn()` wiring from `Deck`
- Partial touchstrip updates for card spinners (only affected panel region, not full 800x100 strip)
- `EventMap` handle methods now return `(handler, is_busy)` tuples to thread busy flag through dispatch
- Manifest validation: `busy: true` requires `spinner` section; rotation/pulse require valid SVG node; custom requires frame assets
- 32 new tests covering frame generation, animator lifecycle, busy guard behavior, and manifest validation
- Documentation added to the DUI packages guide

**Coverage:** 96.42% (987 tests, all passing)