### PR TITLE
Auto-generate API reference pages from source code

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,0 +1,41 @@
+"""Auto-generate API reference pages for mkdocstrings.
+
+This script is executed by the mkdocs-gen-files plugin during ``mkdocs build``.
+It walks the ``src/deckui`` package tree and creates a virtual
+``reference/<module>.md`` page for every public sub-package, each containing
+the appropriate ``::: deckui.<module>`` directive so that *mkdocstrings*
+renders the API docs from docstrings automatically.
+
+A ``reference/SUMMARY.md`` file is also generated so that *mkdocs-literate-nav*
+can build the sidebar navigation without manual ``nav:`` entries.
+"""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+SRC = Path("src")
+PACKAGE = "deckui"
+
+nav_lines: list[str] = []
+
+# Generate one page per top-level sub-package (runtime, ui, dui, render, tools)
+for child in sorted((SRC / PACKAGE).iterdir()):
+    if not child.is_dir() or child.name.startswith("_"):
+        continue
+    if not (child / "__init__.py").exists():
+        continue
+
+    module_path = f"{PACKAGE}.{child.name}"
+    doc_path = f"reference/{child.name}.md"
+
+    with mkdocs_gen_files.open(doc_path, "w") as f:
+        f.write(f"# {child.name.replace('_', ' ').title()}\n\n")
+        f.write(f"::: {module_path}\n")
+
+    mkdocs_gen_files.set_edit_path(doc_path, f"../src/{PACKAGE}/{child.name}/__init__.py")
+    nav_lines.append(f"- [{child.name.replace('_', ' ').title()}]({child.name}.md)")
+
+# Write the SUMMARY consumed by literate-nav
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as f:
+    f.write("\n".join(nav_lines) + "\n")

--- a/docs/reference/dui.md
+++ b/docs/reference/dui.md
@@ -1,5 +1,0 @@
-# DUI
-
-`.dui` package format — SVG layouts, YAML manifests, data bindings, and event maps.
-
-::: deckui.dui

--- a/docs/reference/render.md
+++ b/docs/reference/render.md
@@ -1,5 +1,0 @@
-# Render
-
-Image rendering pipeline and metrics.
-
-::: deckui.render

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -1,5 +1,0 @@
-# Runtime
-
-Device discovery, management, capabilities, and event handling.
-
-::: deckui.runtime

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,5 +1,0 @@
-# Tools
-
-CLI utilities for DeckUI.
-
-::: deckui.tools

--- a/docs/reference/ui.md
+++ b/docs/reference/ui.md
@@ -1,5 +1,0 @@
-# UI
-
-Screen layouts, key slots, encoder controls, and touch strip.
-
-::: deckui.ui

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,15 +20,15 @@ nav:
   - Home: index.md
   - Guides:
       - Creating DUI Packages: guides/creating-dui-packages.md
-  - API Reference:
-      - Runtime: reference/runtime.md
-      - UI: reference/ui.md
-      - DUI: reference/dui.md
-      - Render: reference/render.md
-      - Tools: reference/tools.md
+  - API Reference: reference/
 
 plugins:
   - search
+  - gen-files:
+      scripts:
+        - docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
   - mkdocstrings:
       handlers:
         python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ test = [
 docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.25",
+    "mkdocs-gen-files>=0.5",
+    "mkdocs-literate-nav>=0.6",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -372,6 +372,8 @@ dependencies = [
 
 [package.optional-dependencies]
 docs = [
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
@@ -385,6 +387,8 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "cairosvg", specifier = ">=2.7.0" },
+    { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5" },
+    { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = ">=0.6" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25" },
     { name = "pillow", specifier = ">=12.0.0" },
@@ -588,6 +592,19 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-gen-files"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "properdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/43/428f312149c161cae557eecd35f3c4a82b867998b1d47fb29fdfe927be26/mkdocs_gen_files-0.6.1.tar.gz", hash = "sha256:57d7ff2229e23d077e46d14a33db6d37c8823f6ce1a503c874c1764a71679763", size = 8746, upload-time = "2026-03-16T23:26:09.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/1b/3075eb67fe66e19db059f0a25744c4e56978a309603a20e1d3353d545b5e/mkdocs_gen_files-0.6.1-py3-none-any.whl", hash = "sha256:b3182bfc6219e35b8d26658cb988368659d5d023aac30c2a819247558fc12189", size = 8282, upload-time = "2026-03-16T23:26:08.292Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -599,6 +616,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-literate-nav"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "properdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/af/dd3776a7a713f798f79bec7eb9c661d5cfb83ddc17d9a3667595e53e1559/mkdocs_literate_nav-0.6.3.tar.gz", hash = "sha256:edbaca22343f861fe4e34aac47d55a0c9955c640dbf02eea99fe631e914cf9ee", size = 17526, upload-time = "2026-03-16T23:26:50.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/2c/bcf1ae903975ad6f169abb05c1eb0f94395478364deb89270cf034081b29/mkdocs_literate_nav-0.6.3-py3-none-any.whl", hash = "sha256:2c421561280fa9184f88cbf399bebbd4cc17ee507e978a31ce11fd6f3aabf233", size = 13355, upload-time = "2026-03-16T23:26:49.562Z" },
 ]
 
 [[package]]
@@ -798,6 +828,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "properdocs"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/29/f27a4e1eddf72ed3db6e47818fbafe6debbf09fd7051f9c1a007239b46ef/properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e", size = 276141, upload-time = "2026-03-20T20:07:48.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd", size = 225406, upload-time = "2026-03-20T20:07:46.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace manually maintained `docs/reference/*.md` files with auto-generation using **mkdocs-gen-files** and **mkdocs-literate-nav** plugins
- A build-time script (`docs/gen_ref_pages.py`) walks `src/deckui/` and creates reference pages + sidebar nav for every sub-package automatically
- New modules added to the codebase will get API docs without any manual steps

## Changes

- **`pyproject.toml`**: Added `mkdocs-gen-files>=0.5` and `mkdocs-literate-nav>=0.6` to `[docs]` extras
- **`mkdocs.yml`**: Added `gen-files` and `literate-nav` plugins; changed `API Reference` nav entry to use the generated `reference/` directory
- **`docs/gen_ref_pages.py`**: New script that generates virtual reference markdown files and a `SUMMARY.md` for literate-nav
- **Removed**: `docs/reference/{dui,render,runtime,tools,ui}.md` — no longer needed

## Verification

- `mkdocs build --strict` passes
- All 987 tests pass with 96.42% coverage