### PR TITLE
fix: spinner renders over current UI and app controls busy lifecycle

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -414,11 +414,45 @@ When an event marked `busy: true` fires:
 
 1. The library sets the card/key to **busy** state — further events for that slot are suppressed
 2. The spinner animation starts, pushing pre-rendered frames directly to the device at `interval_ms` intervals
-3. For touchscreen cards, only the affected panel region is updated (not the entire strip)
-4. The normal refresh cycle skips animating slots to avoid overwriting frames
-5. When the handler returns, the animation stops, the slot is marked dirty, and a normal re-render occurs
+3. Spinner frames are rendered **on top of the current UI state** — all bindings (text, colors, images, etc.) are preserved. Only the spinner node is animated; the rest of the key/card looks exactly as it did before the event fired.
+4. For touchscreen cards, only the affected panel region is updated (not the entire strip)
+5. The normal refresh cycle skips animating slots to avoid overwriting frames
+6. **The application decides when the busy state ends** by calling `finish_busy()`. The spinner keeps running until then. If the handler raises an exception, the busy state is auto-cleared so the UI doesn't stay stuck.
 
-Frames are generated **lazily on first use** and cached for the lifetime of the card/key.
+Frames are re-generated each time the spinner starts so they always reflect the latest binding values.
+
+### Controlling the Busy Lifecycle
+
+The spinner does **not** stop automatically when the event handler returns.
+Your application must call ``finish_busy()`` to signal that work is
+complete. This lets you decouple the handler from the actual completion
+of the task — for example, when waiting for an external system to push a
+state update.
+
+```python
+@key.on_event("toggle")
+async def handle():
+    # Fire-and-forget an API call. The spinner keeps running
+    # after this handler returns.
+    await smart_home_api.toggle_light()
+
+# Later, when the external system confirms the new state:
+async def on_state_update(new_state):
+    key.set("status_color", "#00ff00" if new_state else "#333333")
+    await key.finish_busy()   # stops the spinner and re-renders
+```
+
+If you don't need external lifecycle control and just want the spinner
+to last for the duration of the handler, call ``finish_busy()`` at the
+end:
+
+```python
+@key.on_event("toggle")
+async def handle():
+    new_state = await smart_home_api.toggle_light()
+    key.set("status_color", "#00ff00" if new_state else "#333333")
+    await key.finish_busy()
+```
 
 ### Busy Events
 
@@ -479,10 +513,15 @@ key = DuiKey(spec)
 
 @key.on_event("toggle")
 async def handle():
-    # This takes 2 seconds — spinner plays during this time,
-    # and duplicate presses are ignored
-    new_state = await smart_home_api.toggle_light()
+    # Spinner starts automatically — the key still shows the current
+    # label and status_color while the spinner animates in the corner.
+    await smart_home_api.toggle_light()
+    # Don't call finish_busy() here — wait for the state update callback.
+
+async def on_light_state_changed(new_state):
+    """Called by your integration when the light confirms its new state."""
     key.set("status_color", "#00ff00" if new_state else "#333333")
+    await key.finish_busy()   # stops spinner, re-renders the key
 ```
 
 ---

--- a/src/deckui/dui/card.py
+++ b/src/deckui/dui/card.py
@@ -343,7 +343,12 @@ class DuiCard(Card):
             await super().dispatch_touch(event)
 
     def _busy_wrap(self, handler: AsyncHandler) -> AsyncHandler:
-        """Wrap a handler with busy-guard and spinner animation."""
+        """Wrap a handler with busy-guard and spinner animation.
+
+        The spinner keeps running after the handler returns.  Call
+        :meth:`finish_busy` to stop the spinner and restore the
+        normal render cycle.
+        """
 
         async def wrapped() -> None:
             if self._busy:
@@ -352,26 +357,44 @@ class DuiCard(Card):
             try:
                 await self._start_spinner()
                 await handler()
-            finally:
+            except BaseException:
+                # On error, auto-clear so the UI doesn't stay stuck
                 await self._stop_spinner()
                 self._busy = False
                 self.mark_dirty()
+                raise
 
         return wrapped
+
+    async def finish_busy(self) -> None:
+        """Stop the spinner and exit the busy state.
+
+        Call this from your application code when the asynchronous
+        work is truly complete (e.g. after receiving a state update
+        from an external system).
+
+        If the card is not currently busy this is a no-op.
+        """
+        if not self._busy:
+            return
+        await self._stop_spinner()
+        self._busy = False
+        self.mark_dirty()
 
     async def _start_spinner(self) -> None:
         """Start the spinner animation if configured."""
         if self._spec.spinner is None or self._push_fn is None:
             return
 
-        if self._spinner_frames is None:
-            from ..render.metrics import PANEL_HEIGHT, PANEL_WIDTH
+        from ..render.metrics import PANEL_HEIGHT, PANEL_WIDTH
 
-            self._spinner_frames = SpinnerFrames(
-                self._spec,
-                width=PANEL_WIDTH,
-                height=PANEL_HEIGHT,
-            )
+        rendered_svg = self._renderer.render_svg()
+        self._spinner_frames = SpinnerFrames(
+            self._spec,
+            width=PANEL_WIDTH,
+            height=PANEL_HEIGHT,
+            rendered_svg=rendered_svg,
+        )
 
         self._animator = SpinnerAnimator(
             frames=self._spinner_frames.frames,

--- a/src/deckui/dui/key.py
+++ b/src/deckui/dui/key.py
@@ -346,7 +346,12 @@ class DuiKey(KeySlot):
             await super().dispatch(pressed)
 
     def _busy_wrap(self, handler: AsyncHandler) -> AsyncHandler:
-        """Wrap a handler with busy-guard and spinner animation."""
+        """Wrap a handler with busy-guard and spinner animation.
+
+        The spinner keeps running after the handler returns.  Call
+        :meth:`finish_busy` to stop the spinner and restore the
+        normal render cycle.
+        """
 
         async def wrapped() -> None:
             if self._busy:
@@ -355,24 +360,42 @@ class DuiKey(KeySlot):
             try:
                 await self._start_spinner()
                 await handler()
-            finally:
+            except BaseException:
+                # On error, auto-clear so the UI doesn't stay stuck
                 await self._stop_spinner()
                 self._busy = False
                 self._dirty = True
+                raise
 
         return wrapped
+
+    async def finish_busy(self) -> None:
+        """Stop the spinner and exit the busy state.
+
+        Call this from your application code when the asynchronous
+        work is truly complete (e.g. after receiving a state update
+        from an external system).
+
+        If the key is not currently busy this is a no-op.
+        """
+        if not self._busy:
+            return
+        await self._stop_spinner()
+        self._busy = False
+        self._dirty = True
 
     async def _start_spinner(self) -> None:
         """Start the spinner animation if configured."""
         if self._spec.spinner is None or self._push_fn is None:
             return
 
-        if self._spinner_frames is None:
-            self._spinner_frames = SpinnerFrames(
-                self._spec,
-                width=KEY_SIZE[0],
-                height=KEY_SIZE[1],
-            )
+        rendered_svg = self._renderer.render_svg()
+        self._spinner_frames = SpinnerFrames(
+            self._spec,
+            width=KEY_SIZE[0],
+            height=KEY_SIZE[1],
+            rendered_svg=rendered_svg,
+        )
 
         self._animator = SpinnerAnimator(
             frames=self._spinner_frames.frames,

--- a/src/deckui/dui/spinner.py
+++ b/src/deckui/dui/spinner.py
@@ -45,6 +45,7 @@ class SpinnerFrames:
         width: int,
         height: int,
         image_format: str = "JPEG",
+        rendered_svg: str | None = None,
     ) -> None:
         if spec.spinner is None:
             raise ValueError("PackageSpec has no spinner configuration")
@@ -53,6 +54,7 @@ class SpinnerFrames:
         self._width = width
         self._height = height
         self._image_format = image_format
+        self._rendered_svg = rendered_svg
         self._cached_frames: list[bytes] | None = None
 
     @property
@@ -84,7 +86,8 @@ class SpinnerFrames:
 
     def _generate_rotation(self) -> list[bytes]:
         """Generate frames by rotating the spinner node."""
-        base_root = ET.fromstring(self._spec.svg_source)  # noqa: S314
+        svg_source = self._rendered_svg or self._spec.svg_source
+        base_root = ET.fromstring(svg_source)  # noqa: S314
         node = self._spinner.node
         assert node is not None
 
@@ -114,7 +117,8 @@ class SpinnerFrames:
 
     def _generate_pulse(self) -> list[bytes]:
         """Generate frames by pulsing opacity on the spinner node."""
-        base_root = ET.fromstring(self._spec.svg_source)  # noqa: S314
+        svg_source = self._rendered_svg or self._spec.svg_source
+        base_root = ET.fromstring(svg_source)  # noqa: S314
         node = self._spinner.node
         assert node is not None
 

--- a/src/deckui/dui/svg_renderer.py
+++ b/src/deckui/dui/svg_renderer.py
@@ -393,6 +393,27 @@ class SvgRenderer:
         svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
         return self._rasterise(svg_bytes.encode("utf-8"))
 
+    def render_svg(self) -> str:
+        """Return the SVG source with current bindings applied (not rasterised).
+
+        This is used by the spinner system to generate frames that
+        reflect the current binding state rather than the raw template.
+
+        Returns
+        -------
+        str
+            SVG markup as a Unicode string.
+        """
+        root = copy.deepcopy(self._base_root)
+
+        for name, binding in self._spec.bindings.items():
+            value = self._values.get(name)
+            self._apply_binding(root, name, binding, value)
+
+        self._inline_assets(root)
+
+        return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
     def _apply_binding(
         self,
         root: ET.Element,

--- a/tests/test_busy_guard.py
+++ b/tests/test_busy_guard.py
@@ -13,11 +13,13 @@ from deckui.dui.card import DuiCard
 from deckui.dui.key import DuiKey
 from deckui.dui.loader import PackageError, _parse_spinner, load_package
 from deckui.dui.schema import (
+    Binding,
     EventMapping,
     PackageSpec,
     PackageType,
     SpinnerSpec,
     SpinnerType,
+    TextBinding,
 )
 
 _CARD_SVG = (
@@ -47,6 +49,7 @@ def _fake_png(width: int = 120, height: int = 120) -> bytes:
 def _make_card_spec(
     busy: bool = False,
     spinner: SpinnerSpec | None = None,
+    bindings: dict[str, Binding] | None = None,
 ) -> PackageSpec:
     events = (
         EventMapping(name="action", source="encoder_press", busy=busy),
@@ -56,7 +59,7 @@ def _make_card_spec(
         type=PackageType.TOUCH_STRIP_CARD,
         version=1,
         svg_source=_CARD_SVG,
-        bindings={},
+        bindings=bindings or {},
         events=events,
         spinner=spinner,
     )
@@ -65,6 +68,7 @@ def _make_card_spec(
 def _make_key_spec(
     busy: bool = False,
     spinner: SpinnerSpec | None = None,
+    bindings: dict[str, Binding] | None = None,
 ) -> PackageSpec:
     events = (
         EventMapping(name="activate", source="key_press", busy=busy),
@@ -74,7 +78,7 @@ def _make_key_spec(
         type=PackageType.KEY,
         version=1,
         svg_source=_KEY_SVG,
-        bindings={},
+        bindings=bindings or {},
         events=events,
         spinner=spinner,
     )
@@ -124,9 +128,15 @@ class TestCardBusyGuard:
         event.set()
         await task
 
+        # Still busy until finish_busy() is called
+        assert card.is_busy is True
         assert call_count == 1
 
-    async def test_card_busy_clears_after_handler(self):
+        await card.finish_busy()
+        assert card.is_busy is False
+
+    async def test_card_busy_stays_after_handler(self):
+        """Busy state persists after handler returns — app must call finish_busy()."""
         spec = _make_card_spec(busy=True)
         card = DuiCard(spec)
         handler = AsyncMock()
@@ -136,9 +146,11 @@ class TestCardBusyGuard:
         callbacks = card.drain_pending_callbacks()
         await callbacks[0][0](*callbacks[0][1])
 
+        assert card.is_busy is True
+        await card.finish_busy()
         assert card.is_busy is False
 
-    async def test_card_marks_dirty_after_busy_handler(self):
+    async def test_card_finish_busy_marks_dirty(self):
         spec = _make_card_spec(busy=True)
         card = DuiCard(spec)
         handler = AsyncMock()
@@ -149,6 +161,33 @@ class TestCardBusyGuard:
         callbacks = card.drain_pending_callbacks()
         await callbacks[0][0](*callbacks[0][1])
 
+        card.mark_clean()
+        await card.finish_busy()
+        assert card.is_dirty is True
+
+    async def test_card_finish_busy_noop_when_not_busy(self):
+        spec = _make_card_spec(busy=True)
+        card = DuiCard(spec)
+        card.mark_clean()
+        await card.finish_busy()
+        assert card.is_dirty is False
+
+    async def test_card_busy_clears_on_handler_error(self):
+        """If the handler raises, busy state is auto-cleared."""
+        spec = _make_card_spec(busy=True)
+        card = DuiCard(spec)
+
+        async def failing_handler():
+            raise RuntimeError("boom")
+
+        card.bind_event("action", failing_handler)
+
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        with pytest.raises(RuntimeError, match="boom"):
+            await callbacks[0][0](*callbacks[0][1])
+
+        assert card.is_busy is False
         assert card.is_dirty is True
 
     @patch(
@@ -170,9 +209,12 @@ class TestCardBusyGuard:
         callbacks = card.drain_pending_callbacks()
         await callbacks[0][0](*callbacks[0][1])
 
-        # After completion, animator should be stopped and cleared
+        # Spinner still running after handler returns
+        assert card.is_animating is True
+
+        await card.finish_busy()
         assert card.is_animating is False
-        assert push_fn.await_count >= 0  # may or may not have pushed in fast test
+        assert push_fn.await_count >= 0
 
     @patch(
         "deckui.render.svg_rasterize._svg_to_png",
@@ -203,7 +245,41 @@ class TestCardBusyGuard:
         event.set()
         await task
 
+        # Still animating until finish_busy
+        assert card.is_animating is True
+
+        await card.finish_busy()
         assert card.is_animating is False
+
+    @patch(
+        "deckui.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_card_spinner_uses_rendered_svg(self, mock_raster):
+        """Spinner frames should include current binding values."""
+        bindings: dict[str, Binding] = {
+            "title": TextBinding(node="title", default="Default"),
+        }
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=2)
+        spec = _make_card_spec(busy=True, spinner=spinner, bindings=bindings)
+        card = DuiCard(spec)
+        card.set("title", "Updated")
+
+        push_fn = AsyncMock()
+        card.set_push_fn(push_fn)
+        handler = AsyncMock()
+        card.bind_event("action", handler)
+
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        await callbacks[0][0](*callbacks[0][1])
+
+        # Inspect what was rasterised — SVG bytes should contain "Updated"
+        assert mock_raster.call_count >= 2
+        first_svg_bytes: bytes = mock_raster.call_args_list[0][0][0]
+        assert b"Updated" in first_svg_bytes
+
+        await card.finish_busy()
 
 
 # ── Key busy guard ────────────────────────────────────────────────────
@@ -241,15 +317,71 @@ class TestKeyBusyGuard:
         await task
 
         assert call_count == 1
+        # Still busy until finish_busy
+        assert key.is_busy is True
+        await key.finish_busy()
+        assert key.is_busy is False
 
-    async def test_key_busy_clears_after_handler(self):
+    async def test_key_busy_stays_after_handler(self):
+        """Busy state persists after handler returns — app must call finish_busy()."""
         spec = _make_key_spec(busy=True)
         key = DuiKey(spec)
         handler = AsyncMock()
         key.bind_event("activate", handler)
 
         await key.dispatch(True)
+        assert key.is_busy is True
+        await key.finish_busy()
         assert key.is_busy is False
+
+    async def test_key_finish_busy_noop_when_not_busy(self):
+        spec = _make_key_spec(busy=True)
+        key = DuiKey(spec)
+        key._dirty = False
+        await key.finish_busy()
+        assert key._dirty is False
+
+    async def test_key_busy_clears_on_handler_error(self):
+        """If the handler raises, busy state is auto-cleared."""
+        spec = _make_key_spec(busy=True)
+        key = DuiKey(spec)
+
+        async def failing_handler():
+            raise RuntimeError("boom")
+
+        key.bind_event("activate", failing_handler)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await key.dispatch(True)
+
+        assert key.is_busy is False
+
+    @patch(
+        "deckui.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_key_spinner_uses_rendered_svg(self, mock_raster):
+        """Spinner frames should include current binding values."""
+        bindings: dict[str, Binding] = {
+            "label": TextBinding(node="label", default="Key"),
+        }
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=2)
+        spec = _make_key_spec(busy=True, spinner=spinner, bindings=bindings)
+        key = DuiKey(spec)
+        key.set("label", "Playing")
+
+        push_fn = AsyncMock()
+        key.set_push_fn(push_fn)
+        handler = AsyncMock()
+        key.bind_event("activate", handler)
+
+        await key.dispatch(True)
+
+        assert mock_raster.call_count >= 2
+        first_svg_bytes: bytes = mock_raster.call_args_list[0][0][0]
+        assert b"Playing" in first_svg_bytes
+
+        await key.finish_busy()
 
 
 # ── Spinner manifest validation ───────────────────────────────────────

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -140,6 +140,62 @@ class TestCaching:
         assert mock_raster.call_count == 4  # once per frame, not 8
 
 
+class TestRenderedSvg:
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_rotation_uses_rendered_svg_when_provided(self, mock_raster):
+        """When rendered_svg is passed, spinner frames use it instead of raw svg_source."""
+        rendered = (
+            '<svg id="TestCard" xmlns="http://www.w3.org/2000/svg" '
+            'width="120" height="120">'
+            '<rect id="bg" width="120" height="120" fill="#1c1c1c"/>'
+            '<text id="title">Updated Title</text>'
+            '<rect id="spinner" x="80" y="30" width="30" height="30" '
+            'display="none" fill="#fff"/>'
+            "</svg>"
+        )
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=2)
+        )
+        sf = SpinnerFrames(spec, width=120, height=120, rendered_svg=rendered)
+        assert len(sf.frames) == 2
+
+        # Verify the rendered SVG was used — it should contain "Updated Title"
+        first_call_svg: bytes = mock_raster.call_args_list[0][0][0]
+        assert b"Updated Title" in first_call_svg
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_pulse_uses_rendered_svg_when_provided(self, mock_raster):
+        rendered = (
+            '<svg id="TestCard" xmlns="http://www.w3.org/2000/svg" '
+            'width="120" height="120">'
+            '<rect id="bg" width="120" height="120" fill="#1c1c1c"/>'
+            '<text id="title">Rendered Content</text>'
+            '<rect id="spinner" x="80" y="30" width="30" height="30" '
+            'display="none" fill="#fff"/>'
+            "</svg>"
+        )
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.PULSE, node="spinner", frames=2)
+        )
+        sf = SpinnerFrames(spec, width=120, height=120, rendered_svg=rendered)
+        assert len(sf.frames) == 2
+
+        first_call_svg: bytes = mock_raster.call_args_list[0][0][0]
+        assert b"Rendered Content" in first_call_svg
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_falls_back_to_svg_source_without_rendered(self, mock_raster):
+        """Without rendered_svg, spinner uses the raw svg_source."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=2)
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 2
+        # Raw SVG should NOT contain "Updated Title"
+        first_call_svg: bytes = mock_raster.call_args_list[0][0][0]
+        assert b"Updated Title" not in first_call_svg
+
+
 class TestErrors:
     def test_no_spinner_spec_raises(self):
         spec = _make_spec(spinner=None)


### PR DESCRIPTION
## Summary

Two fixes to the spinner system:

### 1. Spinner preserves current UI state

Previously, spinner frames were generated from the raw layout.svg template, discarding all binding values. Now spinner frames are rendered from the **current SVG state** with all bindings applied. The spinner animates in its designated area while the rest of the key/card remains unchanged.

### 2. Application controls busy lifecycle via finish_busy()

Previously, the spinner auto-stopped when the event handler returned. Now the spinner **keeps running** after the handler returns, and the application calls `finish_busy()` to stop it. This supports use cases where the handler fires an API call but completion comes later from an external system (e.g. Home Assistant state callback). Handler exceptions still auto-clear to prevent stuck UI.

### Testing
- All 996 tests pass, coverage at 96.65% (threshold: 95%)
- New tests for finish_busy(), error auto-cleanup, rendered SVG verification
- Lint (ruff) and typecheck (mypy) clean