### PR TITLE
refactor: app-controlled busy state via start_busy/finish_busy

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -320,15 +320,11 @@ All coordinates are non-negative integers. The `events` list is optional and res
 
 ## Spinner & Busy State
 
-When an event handler takes time to complete (e.g. making an API call), users get no immediate visual feedback and may press the button again. The **spinner** system solves this by:
-
-1. Showing an animation immediately when the event fires
-2. Suppressing duplicate events while the handler is running
-3. Restoring the normal UI when the handler completes
+When an event handler takes time to complete (e.g. making an API call), users get no immediate visual feedback and may press the button again. The **spinner** system solves this by letting your application explicitly enter and exit a busy state with a visual animation.
 
 ### Defining a Spinner
 
-Add a `spinner` section to your manifest and mark events with `busy: true`:
+Add a `spinner` section to your manifest:
 
 ```yaml
 spinner:
@@ -336,11 +332,6 @@ spinner:
   node: spinner_icon    # SVG element ID to animate (required for rotation/pulse)
   frames: 12            # frames per cycle (default 12, minimum 2)
   interval_ms: 80       # ms between frames (default 80, minimum 10)
-
-events:
-  - name: toggle_play
-    source: encoder_press_release
-    busy: true           # enable spinner + event guard for this event
 ```
 
 Your SVG must include an element with the spinner node ID. It's typically hidden by default and made visible during animation:
@@ -410,29 +401,33 @@ spinner:
 
 ### How It Works
 
-When an event marked `busy: true` fires:
+The busy state is **entirely controlled by your application** via two methods:
 
-1. The library sets the card/key to **busy** state — further events for that slot are suppressed
-2. The spinner animation starts, pushing pre-rendered frames directly to the device at `interval_ms` intervals
-3. Spinner frames are rendered **on top of the current UI state** — all bindings (text, colors, images, etc.) are preserved. Only the spinner node is animated; the rest of the key/card looks exactly as it did before the event fired.
-4. For touchscreen cards, only the affected panel region is updated (not the entire strip)
-5. The normal refresh cycle skips animating slots to avoid overwriting frames
-6. **The application decides when the busy state ends** by calling `finish_busy()`. The spinner keeps running until then. If the handler raises an exception, the busy state is auto-cleared so the UI doesn't stay stuck.
+- `await card.start_busy()` / `await key.start_busy()` — enters the busy state and starts the spinner animation
+- `await card.finish_busy()` / `await key.finish_busy()` — stops the spinner and exits the busy state
 
-Frames are re-generated each time the spinner starts so they always reflect the latest binding values.
+When busy:
+
+1. Spinner frames are rendered **on top of the current UI state** — all bindings (text, colors, images, etc.) are preserved. Only the spinner node is animated; the rest of the key/card looks exactly as it did before.
+2. For touchscreen cards, only the affected panel region is updated (not the entire strip)
+3. The normal refresh cycle skips animating slots to avoid overwriting frames
+4. Frames are re-generated each time the spinner starts so they always reflect the latest binding values
+
+Duplicate `start_busy()` calls while already busy are no-ops.
+`finish_busy()` when not busy is also a no-op.
 
 ### Controlling the Busy Lifecycle
 
-The spinner does **not** stop automatically when the event handler returns.
-Your application must call ``finish_busy()`` to signal that work is
-complete. This lets you decouple the handler from the actual completion
-of the task — for example, when waiting for an external system to push a
-state update.
+Your application decides when to start and stop the spinner. This
+decouples the spinner from the event handler — the handler can return
+immediately while the spinner keeps running until an external signal
+arrives.
 
 ```python
 @key.on_event("toggle")
 async def handle():
-    # Fire-and-forget an API call. The spinner keeps running
+    await key.start_busy()
+    # Fire the API call. The spinner keeps running
     # after this handler returns.
     await smart_home_api.toggle_light()
 
@@ -442,34 +437,22 @@ async def on_state_update(new_state):
     await key.finish_busy()   # stops the spinner and re-renders
 ```
 
-If you don't need external lifecycle control and just want the spinner
-to last for the duration of the handler, call ``finish_busy()`` at the
-end:
+If the work completes within the handler, call both in the same handler:
 
 ```python
 @key.on_event("toggle")
 async def handle():
+    await key.start_busy()
     new_state = await smart_home_api.toggle_light()
     key.set("status_color", "#00ff00" if new_state else "#333333")
     await key.finish_busy()
 ```
 
-### Busy Events
-
-The `busy` field is opt-in per event. Only events you mark with `busy: true` get the spinner and event suppression. Non-busy events on the same card/key still fire normally.
-
-```yaml
-events:
-  - name: toggle_play
-    source: encoder_press_release
-    busy: true           # gets spinner + suppression
-  - name: next_track
-    source: encoder_turn
-    direction: right     # no busy — fires immediately, no spinner
-```
+Sometimes you don't need a spinner at all — the task resolves instantly.
+Since the application controls the busy state, you simply don't call
+`start_busy()` for fast operations.
 
 **Validation rules:**
-- If any event has `busy: true`, the manifest must define a `spinner` section
 - For `rotation` and `pulse` types, the `node` must exist in the SVG
 - For `custom` type, either `assets/spinner.gif` or `assets/spinner/frame_*.png` files must exist
 
@@ -502,7 +485,6 @@ events:
   - name: toggle
     source: key_press_release
     max_duration_ms: 300
-    busy: true
 ```
 
 ```python
@@ -513,7 +495,8 @@ key = DuiKey(spec)
 
 @key.on_event("toggle")
 async def handle():
-    # Spinner starts automatically — the key still shows the current
+    await key.start_busy()
+    # Spinner starts — the key still shows the current
     # label and status_color while the spinner animates in the corner.
     await smart_home_api.toggle_light()
     # Don't call finish_busy() here — wait for the state update callback.

--- a/src/deckui/dui/card.py
+++ b/src/deckui/dui/card.py
@@ -81,8 +81,8 @@ class DuiCard(Card):
     def set_push_fn(self, push_fn: PushFn) -> None:
         """Set the async function used to push animation frames to the device.
 
-        This must be called before busy events can trigger spinner
-        animations.  Typically set by :class:`~deckui.runtime.deck.Deck`.
+        This must be called before spinner animations can play.
+        Typically set by :class:`~deckui.runtime.deck.Deck`.
 
         Parameters
         ----------
@@ -302,29 +302,19 @@ class DuiCard(Card):
 
     def handle_encoder_turn(self, direction: int) -> None:
         """Route encoder turn through the event map."""
-        result = self._events.handle_encoder_turn(direction)
-        if result is not None:
-            handler, is_busy = result
-            if is_busy:
-                self.queue_pending_callback(self._busy_wrap(handler), ())
-            else:
-                self.queue_pending_callback(handler, ())
+        handler = self._events.handle_encoder_turn(direction)
+        if handler is not None:
+            self.queue_pending_callback(handler, ())
 
     def handle_encoder_press(self) -> None:
         """Route encoder press through the event map."""
-        for handler, is_busy in self._events.handle_encoder_press():
-            if is_busy:
-                self.queue_pending_callback(self._busy_wrap(handler), ())
-            else:
-                self.queue_pending_callback(handler, ())
+        for handler in self._events.handle_encoder_press():
+            self.queue_pending_callback(handler, ())
 
     def handle_encoder_release(self) -> None:
         """Route encoder release through the event map."""
-        for handler, is_busy in self._events.handle_encoder_release():
-            if is_busy:
-                self.queue_pending_callback(self._busy_wrap(handler), ())
-            else:
-                self.queue_pending_callback(handler, ())
+        for handler in self._events.handle_encoder_release():
+            self.queue_pending_callback(handler, ())
 
     async def dispatch_touch(self, event: TouchEvent) -> None:
         """Dispatch touch events through regions and the event map.
@@ -332,39 +322,25 @@ class DuiCard(Card):
         Falls back to the base Card touch handlers (on_tap, etc.)
         if the event map doesn't handle the event.
         """
-        result = self._events.handle_touch(event.event_type, event.x, event.y)
-        if result is not None:
-            handler, is_busy = result
-            if is_busy:
-                await self._busy_wrap(handler)()
-            else:
-                await handler()
+        handler = self._events.handle_touch(event.event_type, event.x, event.y)
+        if handler is not None:
+            await handler()
         else:
             await super().dispatch_touch(event)
 
-    def _busy_wrap(self, handler: AsyncHandler) -> AsyncHandler:
-        """Wrap a handler with busy-guard and spinner animation.
+    async def start_busy(self) -> None:
+        """Enter the busy state and start the spinner animation.
 
-        The spinner keeps running after the handler returns.  Call
-        :meth:`finish_busy` to stop the spinner and restore the
-        normal render cycle.
+        While busy, the card suppresses further ``start_busy()`` calls.
+        The spinner keeps running until :meth:`finish_busy` is called.
+
+        If no spinner is configured in the manifest the busy flag is
+        still set (suppressing duplicate calls) but no animation plays.
         """
-
-        async def wrapped() -> None:
-            if self._busy:
-                return  # suppress duplicate events while busy
-            self._busy = True
-            try:
-                await self._start_spinner()
-                await handler()
-            except BaseException:
-                # On error, auto-clear so the UI doesn't stay stuck
-                await self._stop_spinner()
-                self._busy = False
-                self.mark_dirty()
-                raise
-
-        return wrapped
+        if self._busy:
+            return
+        self._busy = True
+        await self._start_spinner()
 
     async def finish_busy(self) -> None:
         """Stop the spinner and exit the busy state.

--- a/src/deckui/dui/event_map.py
+++ b/src/deckui/dui/event_map.py
@@ -47,9 +47,6 @@ class EventMap:
         self._mappings = events
         self._regions = regions
         self._handlers: dict[str, AsyncHandler] = {}
-        self._busy_events: frozenset[str] = frozenset(
-            m.name for m in events if m.busy
-        )
 
         self._press_time: float | None = None
         self._pressed = False
@@ -88,15 +85,6 @@ class EventMap:
         """All semantic event names defined in this map."""
         return [m.name for m in self._mappings]
 
-    def is_busy_event(self, event_name: str) -> bool:
-        """Return whether *event_name* is marked as ``busy``."""
-        return event_name in self._busy_events
-
-    @property
-    def has_busy_events(self) -> bool:
-        """Whether any events in this map are marked ``busy``."""
-        return bool(self._busy_events)
-
     def _start_hold_timer(self, source: str) -> None:
         """Start a hold timer for the first matching hold mapping.
 
@@ -130,7 +118,7 @@ class EventMap:
             self._hold_task.cancel()
             self._hold_task = None
 
-    def handle_encoder_turn(self, direction: int) -> tuple[AsyncHandler, bool] | None:
+    def handle_encoder_turn(self, direction: int) -> AsyncHandler | None:
         """Match an encoder turn to a semantic event.
 
         Parameters
@@ -140,8 +128,8 @@ class EventMap:
 
         Returns
         -------
-        tuple[AsyncHandler, bool] or None
-            ``(handler, is_busy)`` or ``None`` if no mapping matched.
+        AsyncHandler or None
+            The matched handler, or ``None`` if no mapping matched.
         """
         if self._pressed:
             self._cancel_hold_timer()
@@ -150,17 +138,17 @@ class EventMap:
                 if self._direction_matches(mapping, direction):
                     h = self._handlers.get(mapping.name)
                     if h is not None:
-                        return (h, mapping.name in self._busy_events)
+                        return h
 
         for mapping in self._by_source.get("encoder_turn", []):
             if self._direction_matches(mapping, direction):
                 h = self._handlers.get(mapping.name)
                 if h is not None:
-                    return (h, mapping.name in self._busy_events)
+                    return h
 
         return None
 
-    def handle_encoder_press(self) -> list[tuple[AsyncHandler, bool]]:
+    def handle_encoder_press(self) -> list[AsyncHandler]:
         """Match an encoder press to semantic events.
 
         Records the press timestamp for gesture detection and starts
@@ -168,8 +156,8 @@ class EventMap:
 
         Returns
         -------
-        list[tuple[AsyncHandler, bool]]
-            A list of ``(handler, is_busy)`` tuples (may be empty).
+        list[AsyncHandler]
+            A list of matched handlers (may be empty).
         """
         self._press_time = time.monotonic()
         self._pressed = True
@@ -177,14 +165,14 @@ class EventMap:
 
         self._start_hold_timer("encoder_hold")
 
-        handlers: list[tuple[AsyncHandler, bool]] = []
+        handlers: list[AsyncHandler] = []
         for mapping in self._by_source.get("encoder_press", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append((handler, mapping.name in self._busy_events))
+                handlers.append(handler)
         return handlers
 
-    def handle_encoder_release(self) -> list[tuple[AsyncHandler, bool]]:
+    def handle_encoder_release(self) -> list[AsyncHandler]:
         """Match an encoder release to semantic events.
 
         Cancels any running hold timer.  The simple ``encoder_release``
@@ -195,8 +183,8 @@ class EventMap:
 
         Returns
         -------
-        list[tuple[AsyncHandler, bool]]
-            A list of ``(handler, is_busy)`` tuples (may be empty).
+        list[AsyncHandler]
+            A list of matched handlers (may be empty).
         """
         self._pressed = False
         self._cancel_hold_timer()
@@ -204,32 +192,28 @@ class EventMap:
         hold_fired = self._hold_fired
         self._hold_fired = False
 
-        handlers: list[tuple[AsyncHandler, bool]] = []
+        handlers: list[AsyncHandler] = []
 
         if not hold_fired and self._press_time is not None:
             elapsed_ms = (time.monotonic() - self._press_time) * 1000
 
             for mapping in self._by_source.get("encoder_press_release", []):
-
-
                 max_ms = mapping.max_duration_ms
                 if max_ms is None or elapsed_ms <= max_ms:
                     handler = self._handlers.get(mapping.name)
                     if handler is not None:
-                        handlers.append(
-                            (handler, mapping.name in self._busy_events)
-                        )
+                        handlers.append(handler)
 
         self._press_time = None
 
         for mapping in self._by_source.get("encoder_release", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append((handler, mapping.name in self._busy_events))
+                handlers.append(handler)
 
         return handlers
 
-    def handle_key_press(self) -> list[tuple[AsyncHandler, bool]]:
+    def handle_key_press(self) -> list[AsyncHandler]:
         """Match a key press to semantic events.
 
         Records the press timestamp and starts a hold timer if a
@@ -237,8 +221,8 @@ class EventMap:
 
         Returns
         -------
-        list[tuple[AsyncHandler, bool]]
-            A list of ``(handler, is_busy)`` tuples (may be empty).
+        list[AsyncHandler]
+            A list of matched handlers (may be empty).
         """
         self._press_time = time.monotonic()
         self._pressed = True
@@ -246,14 +230,14 @@ class EventMap:
 
         self._start_hold_timer("key_hold")
 
-        handlers: list[tuple[AsyncHandler, bool]] = []
+        handlers: list[AsyncHandler] = []
         for mapping in self._by_source.get("key_press", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append((handler, mapping.name in self._busy_events))
+                handlers.append(handler)
         return handlers
 
-    def handle_key_release(self) -> list[tuple[AsyncHandler, bool]]:
+    def handle_key_release(self) -> list[AsyncHandler]:
         """Match a key release to semantic events.
 
         Cancels any running hold timer.  The simple ``key_release``
@@ -264,8 +248,8 @@ class EventMap:
 
         Returns
         -------
-        list[tuple[AsyncHandler, bool]]
-            A list of ``(handler, is_busy)`` tuples (may be empty).
+        list[AsyncHandler]
+            A list of matched handlers (may be empty).
         """
         self._pressed = False
         self._cancel_hold_timer()
@@ -273,7 +257,7 @@ class EventMap:
         hold_fired = self._hold_fired
         self._hold_fired = False
 
-        handlers: list[tuple[AsyncHandler, bool]] = []
+        handlers: list[AsyncHandler] = []
 
         if not hold_fired and self._press_time is not None:
             elapsed_ms = (time.monotonic() - self._press_time) * 1000
@@ -283,22 +267,20 @@ class EventMap:
                 if max_ms is None or elapsed_ms <= max_ms:
                     handler = self._handlers.get(mapping.name)
                     if handler is not None:
-                        handlers.append(
-                            (handler, mapping.name in self._busy_events)
-                        )
+                        handlers.append(handler)
 
         self._press_time = None
 
         for mapping in self._by_source.get("key_release", []):
             handler = self._handlers.get(mapping.name)
             if handler is not None:
-                handlers.append((handler, mapping.name in self._busy_events))
+                handlers.append(handler)
 
         return handlers
 
     def handle_touch(
         self, event_type: EventType, x: int, y: int
-    ) -> tuple[AsyncHandler, bool] | None:
+    ) -> AsyncHandler | None:
         """Match a touch event to a semantic event via regions.
 
         Parameters
@@ -312,8 +294,8 @@ class EventMap:
 
         Returns
         -------
-        tuple[AsyncHandler, bool] or None
-            ``(handler, is_busy)`` or ``None`` if no region/mapping matched.
+        AsyncHandler or None
+            The matched handler, or ``None`` if no region/mapping matched.
         """
         from ..runtime.events import EventType as ET_Enum
 
@@ -334,12 +316,12 @@ class EventMap:
                 for mapping in self._by_source.get(touch_name, []):
                     h = self._handlers.get(mapping.name)
                     if h is not None:
-                        return (h, mapping.name in self._busy_events)
+                        return h
 
         for mapping in self._by_source.get(touch_name, []):
             h = self._handlers.get(mapping.name)
             if h is not None:
-                return (h, mapping.name in self._busy_events)
+                return h
 
         return None
 

--- a/src/deckui/dui/key.py
+++ b/src/deckui/dui/key.py
@@ -337,37 +337,24 @@ class DuiKey(KeySlot):
         )
 
         if handlers:
-            for handler, is_busy in handlers:
-                if is_busy:
-                    await self._busy_wrap(handler)()
-                else:
-                    await handler()
+            for handler in handlers:
+                await handler()
         else:
             await super().dispatch(pressed)
 
-    def _busy_wrap(self, handler: AsyncHandler) -> AsyncHandler:
-        """Wrap a handler with busy-guard and spinner animation.
+    async def start_busy(self) -> None:
+        """Enter the busy state and start the spinner animation.
 
-        The spinner keeps running after the handler returns.  Call
-        :meth:`finish_busy` to stop the spinner and restore the
-        normal render cycle.
+        While busy, the key suppresses further ``start_busy()`` calls.
+        The spinner keeps running until :meth:`finish_busy` is called.
+
+        If no spinner is configured in the manifest the busy flag is
+        still set (suppressing duplicate calls) but no animation plays.
         """
-
-        async def wrapped() -> None:
-            if self._busy:
-                return  # suppress duplicate events while busy
-            self._busy = True
-            try:
-                await self._start_spinner()
-                await handler()
-            except BaseException:
-                # On error, auto-clear so the UI doesn't stay stuck
-                await self._stop_spinner()
-                self._busy = False
-                self._dirty = True
-                raise
-
-        return wrapped
+        if self._busy:
+            return
+        self._busy = True
+        await self._start_spinner()
 
     async def finish_busy(self) -> None:
         """Stop the spinner and exit the busy state.

--- a/src/deckui/dui/loader.py
+++ b/src/deckui/dui/loader.py
@@ -296,17 +296,12 @@ def _parse_event(raw: dict[str, Any], index: int) -> EventMapping:
     if source in _PRESS_RELEASE_SOURCES and max_duration_ms is None:
         max_duration_ms = DEFAULT_MAX_DURATION_MS
 
-    busy = raw.get("busy", False)
-    if not isinstance(busy, bool):
-        raise PackageError(f"Event '{name}': busy must be a boolean")
-
     return EventMapping(
         name=name,
         source=source,
         direction=direction,
         max_duration_ms=max_duration_ms,
         hold_ms=hold_ms,
-        busy=busy,
     )
 
 
@@ -589,13 +584,6 @@ def load_package(path: str | Path) -> PackageSpec:
                 f"which does not exist in the SVG. "
                 f"Available ids: {sorted(svg_ids)}"
             )
-
-    # Validate busy events require a spinner
-    has_busy_event = any(e.busy for e in events)
-    if has_busy_event and spinner is None:
-        raise PackageError(
-            "Events with 'busy: true' require a 'spinner' section in the manifest"
-        )
 
     assets: dict[str, bytes] = {}
     assets_dir = pkg_dir / "assets"

--- a/src/deckui/dui/schema.py
+++ b/src/deckui/dui/schema.py
@@ -207,7 +207,6 @@ class EventMapping:
     direction: str | None = None
     max_duration_ms: int | None = None
     hold_ms: int | None = None
-    busy: bool = False
 
 
 HOLD_SOURCES = frozenset({"key_hold", "encoder_hold"})
@@ -240,11 +239,14 @@ DEFAULT_SPINNER_INTERVAL_MS: int = 80
 
 @dataclass(frozen=True, slots=True)
 class SpinnerSpec:
-    """Configuration for a busy-state spinner animation.
+    """Configuration for a spinner animation.
 
-    The spinner is shown when an event handler marked with ``busy: true``
-    is executing.  It provides immediate visual feedback by cycling
-    pre-rendered animation frames on the key or card panel.
+    The spinner is started and stopped explicitly by the application
+    via :meth:`~deckui.dui.card.DuiCard.start_busy` /
+    :meth:`~deckui.dui.card.DuiCard.finish_busy` (and the equivalent
+    methods on :class:`~deckui.dui.key.DuiKey`).  It provides visual
+    feedback by cycling pre-rendered animation frames on the key or
+    card panel.
 
     Parameters
     ----------

--- a/tests/test_busy_guard.py
+++ b/tests/test_busy_guard.py
@@ -1,8 +1,7 @@
-"""Tests for the busy guard on DuiCard and DuiKey, plus spinner manifest validation."""
+"""Tests for app-controlled busy state on DuiCard and DuiKey, plus spinner manifest validation."""
 
 from __future__ import annotations
 
-import asyncio
 import io
 from unittest.mock import AsyncMock, patch
 
@@ -47,12 +46,11 @@ def _fake_png(width: int = 120, height: int = 120) -> bytes:
 
 
 def _make_card_spec(
-    busy: bool = False,
     spinner: SpinnerSpec | None = None,
     bindings: dict[str, Binding] | None = None,
 ) -> PackageSpec:
     events = (
-        EventMapping(name="action", source="encoder_press", busy=busy),
+        EventMapping(name="action", source="encoder_press"),
     )
     return PackageSpec(
         name="TestCard",
@@ -66,12 +64,11 @@ def _make_card_spec(
 
 
 def _make_key_spec(
-    busy: bool = False,
     spinner: SpinnerSpec | None = None,
     bindings: dict[str, Binding] | None = None,
 ) -> PackageSpec:
     events = (
-        EventMapping(name="activate", source="key_press", busy=busy),
+        EventMapping(name="activate", source="key_press"),
     )
     return PackageSpec(
         name="TestKey",
@@ -84,111 +81,55 @@ def _make_key_spec(
     )
 
 
-# ── Card busy guard ───────────────────────────────────────────────────
+# ── Card busy state ──────────────────────────────────────────────────
 
 
-class TestCardBusyGuard:
+class TestCardBusyState:
     def test_card_not_busy_by_default(self):
-        spec = _make_card_spec(busy=False)
+        spec = _make_card_spec()
         card = DuiCard(spec)
         assert card.is_busy is False
 
-    async def test_card_busy_wrap_suppresses_duplicate(self):
-        spec = _make_card_spec(busy=True)
+    async def test_card_start_busy_sets_flag(self):
+        spec = _make_card_spec()
         card = DuiCard(spec)
 
-        call_count = 0
-        event = asyncio.Event()
-
-        async def slow_handler():
-            nonlocal call_count
-            call_count += 1
-            await event.wait()
-
-        card.bind_event("action", slow_handler)
-
-        # First press queues the busy-wrapped handler
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        assert len(callbacks) == 1
-
-        # Start the handler (it blocks on the event)
-        task = asyncio.create_task(callbacks[0][0](*callbacks[0][1]))
-        await asyncio.sleep(0.01)
+        await card.start_busy()
         assert card.is_busy is True
 
-        # Second press while busy — handler gets wrapped but suppressed
-        card.handle_encoder_press()
-        callbacks2 = card.drain_pending_callbacks()
-        assert len(callbacks2) == 1
-        # Call the wrapped handler — should be suppressed
-        await callbacks2[0][0](*callbacks2[0][1])
-
-        # Unblock first handler
-        event.set()
-        await task
-
-        # Still busy until finish_busy() is called
-        assert card.is_busy is True
-        assert call_count == 1
-
-        await card.finish_busy()
-        assert card.is_busy is False
-
-    async def test_card_busy_stays_after_handler(self):
-        """Busy state persists after handler returns — app must call finish_busy()."""
-        spec = _make_card_spec(busy=True)
+    async def test_card_start_busy_suppresses_duplicate(self):
+        """Second start_busy() while already busy is a no-op."""
+        spec = _make_card_spec()
         card = DuiCard(spec)
-        handler = AsyncMock()
-        card.bind_event("action", handler)
 
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        await callbacks[0][0](*callbacks[0][1])
-
+        await card.start_busy()
+        await card.start_busy()  # no-op
         assert card.is_busy is True
+
+    async def test_card_finish_busy_clears_flag(self):
+        spec = _make_card_spec()
+        card = DuiCard(spec)
+
+        await card.start_busy()
         await card.finish_busy()
         assert card.is_busy is False
 
     async def test_card_finish_busy_marks_dirty(self):
-        spec = _make_card_spec(busy=True)
+        spec = _make_card_spec()
         card = DuiCard(spec)
-        handler = AsyncMock()
-        card.bind_event("action", handler)
 
-        card.mark_clean()
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        await callbacks[0][0](*callbacks[0][1])
-
+        await card.start_busy()
         card.mark_clean()
         await card.finish_busy()
         assert card.is_dirty is True
 
     async def test_card_finish_busy_noop_when_not_busy(self):
-        spec = _make_card_spec(busy=True)
+        spec = _make_card_spec()
         card = DuiCard(spec)
         card.mark_clean()
         await card.finish_busy()
-        assert card.is_dirty is False
-
-    async def test_card_busy_clears_on_handler_error(self):
-        """If the handler raises, busy state is auto-cleared."""
-        spec = _make_card_spec(busy=True)
-        card = DuiCard(spec)
-
-        async def failing_handler():
-            raise RuntimeError("boom")
-
-        card.bind_event("action", failing_handler)
-
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        with pytest.raises(RuntimeError, match="boom"):
-            await callbacks[0][0](*callbacks[0][1])
-
         assert card.is_busy is False
-        assert card.is_dirty is True
+        assert card.is_dirty is False
 
     @patch(
         "deckui.render.svg_rasterize._svg_to_png",
@@ -196,56 +137,13 @@ class TestCardBusyGuard:
     )
     async def test_card_spinner_starts_and_stops(self, mock_raster):
         spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
-        spec = _make_card_spec(busy=True, spinner=spinner)
+        spec = _make_card_spec(spinner=spinner)
         card = DuiCard(spec)
 
         push_fn = AsyncMock()
         card.set_push_fn(push_fn)
 
-        handler = AsyncMock()
-        card.bind_event("action", handler)
-
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        await callbacks[0][0](*callbacks[0][1])
-
-        # Spinner still running after handler returns
-        assert card.is_animating is True
-
-        await card.finish_busy()
-        assert card.is_animating is False
-        assert push_fn.await_count >= 0
-
-    @patch(
-        "deckui.render.svg_rasterize._svg_to_png",
-        side_effect=lambda b, w, h: _fake_png(w, h),
-    )
-    async def test_card_is_animating_property(self, mock_raster):
-        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
-        spec = _make_card_spec(busy=True, spinner=spinner)
-        card = DuiCard(spec)
-
-        push_fn = AsyncMock()
-        card.set_push_fn(push_fn)
-
-        event = asyncio.Event()
-
-        async def blocking_handler():
-            await event.wait()
-
-        card.bind_event("action", blocking_handler)
-
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        task = asyncio.create_task(callbacks[0][0](*callbacks[0][1]))
-        await asyncio.sleep(0.05)
-
-        assert card.is_animating is True
-
-        event.set()
-        await task
-
-        # Still animating until finish_busy
+        await card.start_busy()
         assert card.is_animating is True
 
         await card.finish_busy()
@@ -261,18 +159,14 @@ class TestCardBusyGuard:
             "title": TextBinding(node="title", default="Default"),
         }
         spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=2)
-        spec = _make_card_spec(busy=True, spinner=spinner, bindings=bindings)
+        spec = _make_card_spec(spinner=spinner, bindings=bindings)
         card = DuiCard(spec)
         card.set("title", "Updated")
 
         push_fn = AsyncMock()
         card.set_push_fn(push_fn)
-        handler = AsyncMock()
-        card.bind_event("action", handler)
 
-        card.handle_encoder_press()
-        callbacks = card.drain_pending_callbacks()
-        await callbacks[0][0](*callbacks[0][1])
+        await card.start_busy()
 
         # Inspect what was rasterised — SVG bytes should contain "Updated"
         assert mock_raster.call_count >= 2
@@ -281,80 +175,86 @@ class TestCardBusyGuard:
 
         await card.finish_busy()
 
-
-# ── Key busy guard ────────────────────────────────────────────────────
-
-
-class TestKeyBusyGuard:
-    def test_key_not_busy_by_default(self):
-        spec = _make_key_spec(busy=False)
-        key = DuiKey(spec)
-        assert key.is_busy is False
-
-    async def test_key_busy_wrap_suppresses_duplicate(self):
-        spec = _make_key_spec(busy=True)
-        key = DuiKey(spec)
-
-        call_count = 0
-        event = asyncio.Event()
-
-        async def slow_handler():
-            nonlocal call_count
-            call_count += 1
-            await event.wait()
-
-        key.bind_event("activate", slow_handler)
-
-        # First press — DuiKey.dispatch calls handler directly (not queued)
-        task = asyncio.create_task(key.dispatch(True))
-        await asyncio.sleep(0.01)
-        assert key.is_busy is True
-
-        # Second press while busy — suppressed
-        await key.dispatch(True)
-
-        event.set()
-        await task
-
-        assert call_count == 1
-        # Still busy until finish_busy
-        assert key.is_busy is True
-        await key.finish_busy()
-        assert key.is_busy is False
-
-    async def test_key_busy_stays_after_handler(self):
-        """Busy state persists after handler returns — app must call finish_busy()."""
-        spec = _make_key_spec(busy=True)
-        key = DuiKey(spec)
+    async def test_card_events_dispatch_without_busy(self):
+        """Events dispatch normally — no automatic busy wrapping."""
+        spec = _make_card_spec()
+        card = DuiCard(spec)
         handler = AsyncMock()
-        key.bind_event("activate", handler)
+        card.bind_event("action", handler)
 
-        await key.dispatch(True)
+        card.handle_encoder_press()
+        callbacks = card.drain_pending_callbacks()
+        assert len(callbacks) == 1
+        await callbacks[0][0](*callbacks[0][1])
+        handler.assert_awaited_once()
+        assert card.is_busy is False
+
+
+# ── Key busy state ───────────────────────────────────────────────────
+
+
+class TestKeyBusyState:
+    def test_key_not_busy_by_default(self):
+        spec = _make_key_spec()
+        key = DuiKey(spec)
+        assert key.is_busy is False
+
+    async def test_key_start_busy_sets_flag(self):
+        spec = _make_key_spec()
+        key = DuiKey(spec)
+
+        await key.start_busy()
         assert key.is_busy is True
+
+    async def test_key_start_busy_suppresses_duplicate(self):
+        spec = _make_key_spec()
+        key = DuiKey(spec)
+
+        await key.start_busy()
+        await key.start_busy()  # no-op
+        assert key.is_busy is True
+
+    async def test_key_finish_busy_clears_flag(self):
+        spec = _make_key_spec()
+        key = DuiKey(spec)
+
+        await key.start_busy()
         await key.finish_busy()
         assert key.is_busy is False
+
+    async def test_key_finish_busy_marks_dirty(self):
+        spec = _make_key_spec()
+        key = DuiKey(spec)
+
+        await key.start_busy()
+        key._dirty = False
+        await key.finish_busy()
+        assert key._dirty is True
 
     async def test_key_finish_busy_noop_when_not_busy(self):
-        spec = _make_key_spec(busy=True)
+        spec = _make_key_spec()
         key = DuiKey(spec)
         key._dirty = False
         await key.finish_busy()
         assert key._dirty is False
 
-    async def test_key_busy_clears_on_handler_error(self):
-        """If the handler raises, busy state is auto-cleared."""
-        spec = _make_key_spec(busy=True)
+    @patch(
+        "deckui.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_key_spinner_starts_and_stops(self, mock_raster):
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
+        spec = _make_key_spec(spinner=spinner)
         key = DuiKey(spec)
 
-        async def failing_handler():
-            raise RuntimeError("boom")
+        push_fn = AsyncMock()
+        key.set_push_fn(push_fn)
 
-        key.bind_event("activate", failing_handler)
+        await key.start_busy()
+        assert key.is_animating is True
 
-        with pytest.raises(RuntimeError, match="boom"):
-            await key.dispatch(True)
-
-        assert key.is_busy is False
+        await key.finish_busy()
+        assert key.is_animating is False
 
     @patch(
         "deckui.render.svg_rasterize._svg_to_png",
@@ -366,22 +266,31 @@ class TestKeyBusyGuard:
             "label": TextBinding(node="label", default="Key"),
         }
         spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=2)
-        spec = _make_key_spec(busy=True, spinner=spinner, bindings=bindings)
+        spec = _make_key_spec(spinner=spinner, bindings=bindings)
         key = DuiKey(spec)
         key.set("label", "Playing")
 
         push_fn = AsyncMock()
         key.set_push_fn(push_fn)
-        handler = AsyncMock()
-        key.bind_event("activate", handler)
 
-        await key.dispatch(True)
+        await key.start_busy()
 
         assert mock_raster.call_count >= 2
         first_svg_bytes: bytes = mock_raster.call_args_list[0][0][0]
         assert b"Playing" in first_svg_bytes
 
         await key.finish_busy()
+
+    async def test_key_events_dispatch_without_busy(self):
+        """Events dispatch normally — no automatic busy wrapping."""
+        spec = _make_key_spec()
+        key = DuiKey(spec)
+        handler = AsyncMock()
+        key.bind_event("activate", handler)
+
+        await key.dispatch(True)
+        handler.assert_awaited_once()
+        assert key.is_busy is False
 
 
 # ── Spinner manifest validation ───────────────────────────────────────
@@ -407,20 +316,6 @@ class TestSpinnerManifestValidation:
     def test_pulse_without_node_raises(self):
         with pytest.raises(PackageError, match="requires a 'node'"):
             _parse_spinner({"type": "pulse"})
-
-    def test_busy_without_spinner_raises(self, tmp_path):
-        """An event with busy:true but no spinner section should fail."""
-        pkg_dir = tmp_path / "Test.dui"
-        pkg_dir.mkdir()
-        (pkg_dir / "layout.svg").write_text(_CARD_SVG, encoding="utf-8")
-        manifest = (
-            "name: Test\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
-            "events:\n  - name: act\n    source: encoder_press\n    busy: true\n"
-        )
-        (pkg_dir / "manifest.yaml").write_text(manifest, encoding="utf-8")
-
-        with pytest.raises(PackageError, match="require a 'spinner' section"):
-            load_package(pkg_dir)
 
     def test_custom_without_frames_raises(self, tmp_path):
         """Custom spinner with no asset frames should fail."""

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -26,16 +26,14 @@ def _make_events(*specs: tuple) -> tuple[EventMapping, ...]:
     return tuple(result)
 
 
-def _handlers(results: list[tuple]) -> list:
-    """Extract just the handler from (handler, is_busy) tuples."""
-    return [h for h, _ in results]
+def _handlers(results: list) -> list:
+    """Return the list of handlers as-is (identity helper for readability)."""
+    return results
 
 
-def _handler(result: tuple | None):
-    """Extract handler from a single (handler, is_busy) or None."""
-    if result is None:
-        return None
-    return result[0]
+def _handler(result):
+    """Return the handler as-is (identity helper for readability)."""
+    return result
 
 
 class TestEncoderTurn:
@@ -90,7 +88,7 @@ class TestEncoderPressRelease:
         em = EventMap(events)
         handler = AsyncMock()
         em.on("press", handler)
-        assert em.handle_encoder_press() == [(handler, False)]
+        assert em.handle_encoder_press() == [handler]
 
     def test_simple_release(self):
         events = _make_events(("release", "encoder_release"))


### PR DESCRIPTION
## Summary

**Breaking change** — the busy state is now fully controlled by the application.

### What changed

- **Removed** `busy: true` field from event mappings in the manifest
- **Removed** `_busy_wrap()` from DuiCard and DuiKey — events dispatch directly without any automatic busy wrapping
- **Added** `start_busy()` on DuiCard and DuiKey — app calls this to enter busy state and start the spinner
- **Simplified** EventMap return types from `tuple[AsyncHandler, bool]` to plain `AsyncHandler`
- **Removed** busy→spinner cross-validation from the loader (spinner section is still validated independently)

### Why

The application needs to decide if and when a key/card is busy. Sometimes events resolve instantly, sometimes they take seconds. The manifest shouldn't hardcode this — the app knows at runtime whether a spinner is needed.

### New usage pattern

```python
@key.on_event("toggle")
async def handle():
    await key.start_busy()          # app decides to show spinner
    await smart_home_api.toggle()

async def on_state_update(state):
    key.set("color", "#0f0" if state else "#333")
    await key.finish_busy()         # app decides when done
```

### Testing
- 998 tests pass, coverage 96.81% (threshold: 95%)
- Lint (ruff) and typecheck (mypy) clean