### PR TITLE
feat: add DialAccumulator to debounce rapid encoder ticks

### DIFF
--- a/src/deckui/ui/__init__.py
+++ b/src/deckui/ui/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .cards import BlankCard, Card
-from .controls import EncoderSlot, KeySlot
+from .controls import DialAccumulator, EncoderSlot, KeySlot
 from .info_screen import InfoScreen
 from .screen import Screen
 from .touch_strip import TouchStrip
@@ -11,6 +11,7 @@ from .touch_strip import TouchStrip
 __all__ = [
     "BlankCard",
     "Card",
+    "DialAccumulator",
     "EncoderSlot",
     "InfoScreen",
     "KeySlot",

--- a/src/deckui/ui/controls/__init__.py
+++ b/src/deckui/ui/controls/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from .dial_accumulator import DialAccumulator
 from .encoder_slot import EncoderSlot
 from .key_slot import KeySlot
 
 __all__ = [
+    "DialAccumulator",
     "EncoderSlot",
     "KeySlot",
 ]

--- a/src/deckui/ui/controls/dial_accumulator.py
+++ b/src/deckui/ui/controls/dial_accumulator.py
@@ -1,0 +1,84 @@
+"""DialAccumulator: debounce rapid dial/encoder ticks into a single callback."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class DialAccumulator:
+    """Debounce rapid dial/encoder ticks and flush them with a single callback.
+
+    *callback*   - ``async def callback(steps: int)`` called once per flush
+                   with the net accumulated tick count (signed).
+    *delay*      - seconds to wait after the last tick before flushing.
+    *max_steps*  - cap on how many ticks can accumulate (positive number).
+                   Use ``max_steps=1`` to collapse any number of ticks into
+                   a single +1 / -1 event (useful for next/previous).
+
+    Examples
+    --------
+    ::
+
+        acc = DialAccumulator(my_handler, delay=0.2, max_steps=5)
+
+        @encoder.on_turn
+        async def on_turn(direction: int):
+            acc.tick(direction)
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[int], Awaitable[None]],
+        *,
+        delay: float = 0.25,
+        max_steps: int = 10,
+    ) -> None:
+        if delay <= 0:
+            msg = "delay must be positive"
+            raise ValueError(msg)
+        if max_steps < 1:
+            msg = "max_steps must be >= 1"
+            raise ValueError(msg)
+        logger.debug("DialAccumulator.__init__: delay=%.2f max_steps=%d", delay, max_steps)
+        self._callback = callback
+        self._delay = delay
+        self._max_steps = max_steps
+        self._pending: int = 0
+        self._flush_task: asyncio.Task[None] | None = None
+
+    def tick(self, direction: int) -> None:
+        """Add *direction* (+1 or -1). Clamps to ±max_steps."""
+        logger.debug("DialAccumulator.tick: direction=%+d pending=%d", direction, self._pending)
+        self._pending = max(-self._max_steps, min(self._max_steps, self._pending + direction))
+        if self._flush_task is not None:
+            self._flush_task.cancel()
+        self._flush_task = asyncio.create_task(self._schedule_flush())
+
+    async def _schedule_flush(self) -> None:
+        try:
+            logger.debug("DialAccumulator._schedule_flush: waiting %.2fs", self._delay)
+            await asyncio.sleep(self._delay)
+            await self._flush()
+        except asyncio.CancelledError:
+            pass
+
+    async def _flush(self) -> None:
+        steps = self._pending
+        self._pending = 0
+        self._flush_task = None
+        logger.debug("DialAccumulator._flush: steps=%+d", steps)
+        if steps == 0:
+            return
+        await self._callback(steps)
+
+    def cancel(self) -> None:
+        """Cancel any pending flush and reset the accumulated count."""
+        if self._flush_task is not None:
+            self._flush_task.cancel()
+            self._flush_task = None
+        self._pending = 0
+        logger.debug("DialAccumulator.cancel: reset")

--- a/tests/test_dial_accumulator.py
+++ b/tests/test_dial_accumulator.py
@@ -1,0 +1,172 @@
+"""Tests for DialAccumulator."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from deckui.ui.controls.dial_accumulator import DialAccumulator
+
+
+class TestDialAccumulatorInit:
+    """Constructor validation."""
+
+    def test_invalid_delay_raises(self) -> None:
+        async def cb(steps: int) -> None:
+            pass
+
+        with pytest.raises(ValueError, match="delay must be positive"):
+            DialAccumulator(cb, delay=0)
+
+    def test_invalid_max_steps_raises(self) -> None:
+        async def cb(steps: int) -> None:
+            pass
+
+        with pytest.raises(ValueError, match="max_steps must be >= 1"):
+            DialAccumulator(cb, max_steps=0)
+
+
+class TestDialAccumulatorTick:
+    """Core tick / flush behaviour."""
+
+    async def test_single_tick_flushes_after_delay(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(1)
+        await asyncio.sleep(0.1)
+        assert results == [1]
+
+    async def test_multiple_ticks_accumulate(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(1)
+        acc.tick(1)
+        acc.tick(1)
+        await asyncio.sleep(0.1)
+        assert results == [3]
+
+    async def test_opposite_ticks_cancel_out(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(1)
+        acc.tick(-1)
+        await asyncio.sleep(0.1)
+        # Net is zero — callback should not fire
+        assert results == []
+
+    async def test_negative_ticks(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(-1)
+        acc.tick(-1)
+        await asyncio.sleep(0.1)
+        assert results == [-2]
+
+    async def test_clamps_to_max_steps(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05, max_steps=3)
+        for _ in range(10):
+            acc.tick(1)
+        await asyncio.sleep(0.1)
+        assert results == [3]
+
+    async def test_clamps_negative_to_max_steps(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05, max_steps=3)
+        for _ in range(10):
+            acc.tick(-1)
+        await asyncio.sleep(0.1)
+        assert results == [-3]
+
+    async def test_max_steps_one_collapses(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05, max_steps=1)
+        acc.tick(1)
+        acc.tick(1)
+        acc.tick(1)
+        await asyncio.sleep(0.1)
+        assert results == [1]
+
+    async def test_debounce_resets_timer(self) -> None:
+        """Ticks spaced within the delay window should still accumulate."""
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.1)
+        acc.tick(1)
+        await asyncio.sleep(0.05)
+        acc.tick(1)
+        await asyncio.sleep(0.05)
+        # Should not have flushed yet (timer restarted)
+        assert results == []
+        await asyncio.sleep(0.1)
+        assert results == [2]
+
+
+class TestDialAccumulatorCancel:
+    """cancel() behaviour."""
+
+    async def test_cancel_prevents_flush(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(1)
+        acc.cancel()
+        await asyncio.sleep(0.1)
+        assert results == []
+
+    async def test_cancel_resets_pending(self) -> None:
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(1)
+        acc.tick(1)
+        acc.cancel()
+        # New tick after cancel should only have its own value
+        acc.tick(-1)
+        await asyncio.sleep(0.1)
+        assert results == [-1]
+
+    async def test_cancel_when_idle_is_noop(self) -> None:
+        async def cb(steps: int) -> None:
+            pass
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.cancel()  # should not raise


### PR DESCRIPTION
## Summary
- Adds `DialAccumulator`, an asyncio-native utility that debounces rapid dial/encoder tick events and flushes them as a single net-steps callback after a configurable delay
- Supports `max_steps` clamping (e.g. `max_steps=1` collapses any burst into +1/-1) and clean shutdown via `cancel()`
- Exported from `deckui.ui.controls` and `deckui.ui`
- 13 new tests covering accumulation, clamping, debounce reset, cancel, and zero-net suppression — 100% coverage on the new module