### PR TITLE
feat: add on_turn_accumulated convenience decorator to EncoderSlot

### DIFF
--- a/src/deckui/ui/controls/encoder_slot.py
+++ b/src/deckui/ui/controls/encoder_slot.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
+
+from .dial_accumulator import DialAccumulator
 
 if TYPE_CHECKING:
     from ...runtime.events import AsyncHandler
@@ -28,6 +31,7 @@ class EncoderSlot:
         self._turn_handler: AsyncHandler | None = None
         self._press_handler: AsyncHandler | None = None
         self._release_handler: AsyncHandler | None = None
+        self._accumulator: DialAccumulator | None = None
 
     @property
     def index(self) -> int:
@@ -49,6 +53,46 @@ class EncoderSlot:
         """
         self._turn_handler = handler
         return handler
+
+    def on_turn_accumulated(
+        self,
+        callback: Callable[[int], Awaitable[None]] | None = None,
+        *,
+        delay: float = 0.25,
+        max_steps: int = 10,
+    ) -> DialAccumulator | Callable[[Callable[[int], Awaitable[None]]], DialAccumulator]:
+        """Register an accumulated turn handler backed by a :class:`DialAccumulator`.
+
+        Can be used as a plain decorator or called with keyword arguments::
+
+            # Plain decorator — default delay/max_steps
+            @encoder.on_turn_accumulated
+            async def handle(steps: int):
+                ...
+
+            # With options
+            @encoder.on_turn_accumulated(delay=0.1, max_steps=5)
+            async def handle(steps: int):
+                ...
+
+        Returns the :class:`DialAccumulator` instance (which replaces the
+        decorated function reference).
+        """
+
+        def _wrap(cb: Callable[[int], Awaitable[None]]) -> DialAccumulator:
+            acc = DialAccumulator(cb, delay=delay, max_steps=max_steps)
+            self._accumulator = acc
+            async def _tick(direction: int) -> None:
+                acc.tick(direction)
+
+            self._turn_handler = _tick
+            return acc
+
+        # Called as @on_turn_accumulated (no parens) — callback is the function
+        if callback is not None:
+            return _wrap(callback)
+        # Called as @on_turn_accumulated(...) — return the wrapper
+        return _wrap
 
     def on_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder press events.

--- a/tests/test_encoder_slot.py
+++ b/tests/test_encoder_slot.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+
+from deckui.ui.controls.dial_accumulator import DialAccumulator
 from deckui.ui.controls.encoder_slot import EncoderSlot
 
 
@@ -17,6 +20,9 @@ class TestEncoderSlotInit:
     def test_custom_index(self):
         e = EncoderSlot(3)
         assert e.index == 3
+
+    def test_no_accumulator_by_default(self, encoder: EncoderSlot):
+        assert encoder._accumulator is None
 
 
 class TestEncoderSlotOnTurn:
@@ -34,6 +40,64 @@ class TestEncoderSlotOnTurn:
             pass
 
         assert encoder._turn_handler is handler
+
+
+class TestEncoderSlotOnTurnAccumulated:
+    def test_plain_decorator(self, encoder: EncoderSlot):
+        @encoder.on_turn_accumulated
+        async def handle(steps: int):
+            pass
+
+        assert isinstance(handle, DialAccumulator)
+        assert encoder._accumulator is handle
+        assert encoder._turn_handler is not None
+
+    def test_decorator_with_options(self, encoder: EncoderSlot):
+        @encoder.on_turn_accumulated(delay=0.1, max_steps=5)
+        async def handle(steps: int):
+            pass
+
+        assert isinstance(handle, DialAccumulator)
+        assert handle._delay == 0.1
+        assert handle._max_steps == 5
+
+    async def test_dispatch_turn_triggers_accumulator(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_turn_accumulated(delay=0.05)
+        async def handle(steps: int):
+            results.append(steps)
+
+        await encoder.dispatch_turn(1)
+        await encoder.dispatch_turn(1)
+        await encoder.dispatch_turn(1)
+        await asyncio.sleep(0.1)
+        assert results == [3]
+
+    async def test_accumulator_clamps(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_turn_accumulated(delay=0.05, max_steps=2)
+        async def handle(steps: int):
+            results.append(steps)
+
+        for _ in range(10):
+            await encoder.dispatch_turn(1)
+        await asyncio.sleep(0.1)
+        assert results == [2]
+
+    async def test_accumulator_cancel_via_instance(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_turn_accumulated(delay=0.05)
+        async def handle(steps: int):
+            results.append(steps)
+
+        await encoder.dispatch_turn(1)
+        assert isinstance(handle, DialAccumulator)
+        handle.cancel()
+        await asyncio.sleep(0.1)
+        assert results == []
 
 
 class TestEncoderSlotOnPress:


### PR DESCRIPTION
## Summary
- Adds `on_turn_accumulated()` method to `EncoderSlot` that wires a `DialAccumulator` behind the scenes
- Works as both a bare decorator (`@encoder.on_turn_accumulated`) and with options (`@encoder.on_turn_accumulated(delay=0.1, max_steps=5)`)
- Returns the `DialAccumulator` instance so users can call `cancel()` for clean shutdown
- 6 new tests covering registration, dispatch integration, clamping, and cancel — 100% coverage on encoder_slot.py