### PR TITLE
feat: add on_press_turn and on_press_turn_accumulated to EncoderSlot

### DIFF
--- a/src/deckui/ui/controls/encoder_slot.py
+++ b/src/deckui/ui/controls/encoder_slot.py
@@ -31,17 +31,25 @@ class EncoderSlot:
         self._turn_handler: AsyncHandler | None = None
         self._press_handler: AsyncHandler | None = None
         self._release_handler: AsyncHandler | None = None
+        self._press_turn_handler: AsyncHandler | None = None
         self._accumulator: DialAccumulator | None = None
+        self._press_turn_accumulator: DialAccumulator | None = None
+        self._pressed: bool = False
 
     @property
     def index(self) -> int:
         return self._index
+
+    # -- Turn handlers -------------------------------------------------------
 
     def on_turn(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder turn events.
 
         The handler receives a single ``direction`` argument:
         positive = clockwise, negative = counter-clockwise.
+
+        When a ``press_turn`` handler is also registered, ``on_turn`` only
+        fires for turns while the encoder is **not** pressed.
 
         Examples
         --------
@@ -82,17 +90,73 @@ class EncoderSlot:
         def _wrap(cb: Callable[[int], Awaitable[None]]) -> DialAccumulator:
             acc = DialAccumulator(cb, delay=delay, max_steps=max_steps)
             self._accumulator = acc
+
             async def _tick(direction: int) -> None:
                 acc.tick(direction)
 
             self._turn_handler = _tick
             return acc
 
-        # Called as @on_turn_accumulated (no parens) — callback is the function
         if callback is not None:
             return _wrap(callback)
-        # Called as @on_turn_accumulated(...) — return the wrapper
         return _wrap
+
+    # -- Press-turn handlers -------------------------------------------------
+
+    def on_press_turn(self, handler: AsyncHandler) -> AsyncHandler:
+        """Decorator to register a handler for turning while pressed.
+
+        The handler receives a single ``direction`` argument, just like
+        :meth:`on_turn`.  When registered, ``on_turn`` will **not** fire
+        for turns that happen while the encoder is held down.
+
+        Examples
+        --------
+        ::
+
+            @encoder.on_press_turn
+            async def handle(direction: int):
+                ...
+        """
+        self._press_turn_handler = handler
+        return handler
+
+    def on_press_turn_accumulated(
+        self,
+        callback: Callable[[int], Awaitable[None]] | None = None,
+        *,
+        delay: float = 0.25,
+        max_steps: int = 10,
+    ) -> DialAccumulator | Callable[[Callable[[int], Awaitable[None]]], DialAccumulator]:
+        """Register an accumulated press-turn handler backed by a :class:`DialAccumulator`.
+
+        Same API as :meth:`on_turn_accumulated` but only fires while the
+        encoder is held down.
+
+        Examples
+        --------
+        ::
+
+            @encoder.on_press_turn_accumulated(delay=0.1, max_steps=5)
+            async def handle(steps: int):
+                ...
+        """
+
+        def _wrap(cb: Callable[[int], Awaitable[None]]) -> DialAccumulator:
+            acc = DialAccumulator(cb, delay=delay, max_steps=max_steps)
+            self._press_turn_accumulator = acc
+
+            async def _tick(direction: int) -> None:
+                acc.tick(direction)
+
+            self._press_turn_handler = _tick
+            return acc
+
+        if callback is not None:
+            return _wrap(callback)
+        return _wrap
+
+    # -- Press / release handlers --------------------------------------------
 
     def on_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for encoder press events.
@@ -122,13 +186,24 @@ class EncoderSlot:
         self._release_handler = handler
         return handler
 
+    # -- Dispatch ------------------------------------------------------------
+
     async def dispatch_turn(self, direction: int) -> None:
-        """Dispatch an encoder turn event through the registered handler."""
+        """Dispatch an encoder turn event through the registered handler.
+
+        When a ``press_turn`` handler is registered, turns while pressed
+        are routed to it instead of the regular ``turn`` handler (matching
+        the priority logic of :class:`~deckui.dui.event_map.EventMap`).
+        """
+        if self._pressed and self._press_turn_handler is not None:
+            await self._press_turn_handler(direction)
+            return
         if self._turn_handler is not None:
             await self._turn_handler(direction)
 
     async def dispatch_press(self, pressed: bool) -> None:
         """Dispatch an encoder press or release event."""
+        self._pressed = pressed
         handler = self._press_handler if pressed else self._release_handler
         if handler is not None:
             await handler()

--- a/tests/test_encoder_slot.py
+++ b/tests/test_encoder_slot.py
@@ -16,6 +16,7 @@ class TestEncoderSlotInit:
         assert encoder._turn_handler is None
         assert encoder._press_handler is None
         assert encoder._release_handler is None
+        assert encoder._press_turn_handler is None
 
     def test_custom_index(self):
         e = EncoderSlot(3)
@@ -23,6 +24,10 @@ class TestEncoderSlotInit:
 
     def test_no_accumulator_by_default(self, encoder: EncoderSlot):
         assert encoder._accumulator is None
+        assert encoder._press_turn_accumulator is None
+
+    def test_not_pressed_by_default(self, encoder: EncoderSlot):
+        assert encoder._pressed is False
 
 
 class TestEncoderSlotOnTurn:
@@ -98,6 +103,189 @@ class TestEncoderSlotOnTurnAccumulated:
         handle.cancel()
         await asyncio.sleep(0.1)
         assert results == []
+
+
+class TestEncoderSlotOnPressTurn:
+    def test_registers_handler(self, encoder: EncoderSlot):
+        async def handler(direction: int):
+            pass
+
+        result = encoder.on_press_turn(handler)
+        assert encoder._press_turn_handler is handler
+        assert result is handler
+
+    def test_as_decorator(self, encoder: EncoderSlot):
+        @encoder.on_press_turn
+        async def handler(direction: int):
+            pass
+
+        assert encoder._press_turn_handler is handler
+
+    async def test_fires_when_pressed(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_press_turn
+        async def handle(direction: int):
+            results.append(direction)
+
+        await encoder.dispatch_press(True)
+        await encoder.dispatch_turn(1)
+        assert results == [1]
+
+    async def test_does_not_fire_when_not_pressed(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_press_turn
+        async def handle(direction: int):
+            results.append(direction)
+
+        await encoder.dispatch_turn(1)
+        assert results == []
+
+    async def test_does_not_fire_after_release(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_press_turn
+        async def handle(direction: int):
+            results.append(direction)
+
+        await encoder.dispatch_press(True)
+        await encoder.dispatch_press(False)
+        await encoder.dispatch_turn(1)
+        assert results == []
+
+    async def test_takes_priority_over_on_turn(self, encoder: EncoderSlot):
+        """When pressed and press_turn handler exists, on_turn does not fire."""
+        turn_results: list[int] = []
+        press_turn_results: list[int] = []
+
+        @encoder.on_turn
+        async def on_turn(direction: int):
+            turn_results.append(direction)
+
+        @encoder.on_press_turn
+        async def on_press_turn(direction: int):
+            press_turn_results.append(direction)
+
+        await encoder.dispatch_press(True)
+        await encoder.dispatch_turn(1)
+        assert press_turn_results == [1]
+        assert turn_results == []
+
+    async def test_on_turn_fires_when_not_pressed(self, encoder: EncoderSlot):
+        """When not pressed, on_turn fires even if press_turn is registered."""
+        turn_results: list[int] = []
+
+        @encoder.on_turn
+        async def on_turn(direction: int):
+            turn_results.append(direction)
+
+        @encoder.on_press_turn
+        async def on_press_turn(direction: int):
+            pass
+
+        await encoder.dispatch_turn(1)
+        assert turn_results == [1]
+
+    async def test_fallback_to_on_turn_when_no_press_turn_handler(self, encoder: EncoderSlot):
+        """When pressed but no press_turn handler, on_turn fires as fallback."""
+        turn_results: list[int] = []
+
+        @encoder.on_turn
+        async def on_turn(direction: int):
+            turn_results.append(direction)
+
+        await encoder.dispatch_press(True)
+        await encoder.dispatch_turn(1)
+        assert turn_results == [1]
+
+
+class TestEncoderSlotOnPressTurnAccumulated:
+    def test_plain_decorator(self, encoder: EncoderSlot):
+        @encoder.on_press_turn_accumulated
+        async def handle(steps: int):
+            pass
+
+        assert isinstance(handle, DialAccumulator)
+        assert encoder._press_turn_accumulator is handle
+        assert encoder._press_turn_handler is not None
+
+    def test_decorator_with_options(self, encoder: EncoderSlot):
+        @encoder.on_press_turn_accumulated(delay=0.1, max_steps=3)
+        async def handle(steps: int):
+            pass
+
+        assert isinstance(handle, DialAccumulator)
+        assert handle._delay == 0.1
+        assert handle._max_steps == 3
+
+    async def test_accumulates_while_pressed(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_press_turn_accumulated(delay=0.05)
+        async def handle(steps: int):
+            results.append(steps)
+
+        await encoder.dispatch_press(True)
+        await encoder.dispatch_turn(1)
+        await encoder.dispatch_turn(1)
+        await encoder.dispatch_turn(1)
+        await asyncio.sleep(0.1)
+        assert results == [3]
+
+    async def test_does_not_fire_when_not_pressed(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_press_turn_accumulated(delay=0.05)
+        async def handle(steps: int):
+            results.append(steps)
+
+        await encoder.dispatch_turn(1)
+        await asyncio.sleep(0.1)
+        assert results == []
+
+    async def test_cancel_via_instance(self, encoder: EncoderSlot):
+        results: list[int] = []
+
+        @encoder.on_press_turn_accumulated(delay=0.05)
+        async def handle(steps: int):
+            results.append(steps)
+
+        await encoder.dispatch_press(True)
+        await encoder.dispatch_turn(1)
+        assert isinstance(handle, DialAccumulator)
+        handle.cancel()
+        await asyncio.sleep(0.1)
+        assert results == []
+
+
+class TestEncoderSlotDispatchPress:
+    async def test_tracks_pressed_state(self, encoder: EncoderSlot):
+        assert encoder._pressed is False
+        await encoder.dispatch_press(True)
+        assert encoder._pressed is True
+        await encoder.dispatch_press(False)
+        assert encoder._pressed is False
+
+    async def test_calls_press_handler(self, encoder: EncoderSlot):
+        called: list[bool] = []
+
+        @encoder.on_press
+        async def handle():
+            called.append(True)
+
+        await encoder.dispatch_press(True)
+        assert called == [True]
+
+    async def test_calls_release_handler(self, encoder: EncoderSlot):
+        called: list[bool] = []
+
+        @encoder.on_release
+        async def handle():
+            called.append(True)
+
+        await encoder.dispatch_press(False)
+        assert called == [True]
 
 
 class TestEncoderSlotOnPress:


### PR DESCRIPTION
## Summary
- Adds `on_press_turn` and `on_press_turn_accumulated` decorators to `EncoderSlot`
- `EncoderSlot` now tracks `_pressed` state internally via `dispatch_press()`
- When a `press_turn` handler is registered, it takes priority over `on_turn` while pressed (matches EventMap behavior)
- Falls back to `on_turn` when no `press_turn` handler is registered, even while pressed
- 17 new tests covering registration, press/release state tracking, priority logic, accumulation, and cancel — 100% coverage on encoder_slot.py

**Note:** This PR is stacked on #103 (`feature/encoder-accumulated-turn`). Merge #103 first.