### PR TITLE
feat: declarative dial accumulation in DUI manifest events

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -260,6 +260,9 @@ events:
 | `direction` | `str` | no | `"left"` or `"right"` (turn events only) |
 | `max_duration_ms` | `int` | no | Max press duration for `*_press_release` (default 500) |
 | `hold_ms` | `int` | no | Hold threshold for `*_hold` (default 500) |
+| `accumulate` | `bool` | no | Debounce rapid ticks via `DialAccumulator` (turn events only, default `false`) |
+| `accumulate_delay` | `float` | no | Seconds to wait after last tick before flushing (default 0.25, requires `accumulate: true`) |
+| `accumulate_max_steps` | `int` | no | Cap on accumulated ticks (default 10, requires `accumulate: true`) |
 | `busy` | `bool` | no | Enable spinner animation and event suppression (default `false`) |
 
 ### Sources
@@ -290,6 +293,48 @@ events:
 |--------|------------|
 | `tap` | Touch tap on a region |
 | `long_press` | Long press on a region |
+
+### Accumulated Turns
+
+By default, each encoder tick fires the handler once. For continuous controls like volume or brightness, rapid ticks produce many individual calls. The `accumulate` option debounces rapid ticks and flushes them as a single callback with the net step count.
+
+```yaml
+events:
+  - name: brightness_up
+    source: encoder_turn
+    direction: right
+    accumulate: true
+    accumulate_delay: 0.2       # optional – seconds before flush (default 0.25)
+    accumulate_max_steps: 5     # optional – cap on net ticks (default 10)
+
+  - name: brightness_down
+    source: encoder_turn
+    direction: left
+    accumulate: true
+
+  - name: kelvin_up
+    source: encoder_press_turn
+    direction: right
+    accumulate: true
+    accumulate_delay: 0.1
+    accumulate_max_steps: 5
+```
+
+The handler receives a single `int` argument — the net accumulated steps (positive for right, negative for left):
+
+```python
+@card.on("brightness_up")
+async def handle(steps: int):
+    # steps is e.g. 3 if the user turned right 3 ticks quickly
+    new_val = card.adjust_range("brightness", steps * 5, min_val=0, max_val=100)
+```
+
+**Validation rules:**
+
+- `accumulate` is only valid on `encoder_turn` and `encoder_press_turn` sources
+- `accumulate_delay` and `accumulate_max_steps` require `accumulate: true`
+- `accumulate_delay` must be a positive number
+- `accumulate_max_steps` must be a positive integer
 
 ---
 
@@ -559,9 +604,13 @@ events:
   - name: seek_forward
     source: encoder_press_turn
     direction: right
+    accumulate: true
+    accumulate_delay: 0.15
   - name: seek_backward
     source: encoder_press_turn
     direction: left
+    accumulate: true
+    accumulate_delay: 0.15
 
 regions:
   card:

--- a/src/deckui/dui/card.py
+++ b/src/deckui/dui/card.py
@@ -384,3 +384,7 @@ class DuiCard(Card):
         if self._animator is not None:
             await self._animator.stop()
             self._animator = None
+
+    def cleanup(self) -> None:
+        """Cancel pending accumulators and release resources."""
+        self._events.cancel_accumulators()

--- a/src/deckui/dui/event_map.py
+++ b/src/deckui/dui/event_map.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from ..ui.controls.dial_accumulator import DialAccumulator
 
 if TYPE_CHECKING:
     from ..runtime.events import AsyncHandler, EventType
@@ -58,6 +60,8 @@ class EventMap:
         for mapping in events:
             self._by_source.setdefault(mapping.source, []).append(mapping)
 
+        self._accumulators: dict[str, DialAccumulator] = {}
+
     def on(self, event_name: str, handler: AsyncHandler) -> None:
         """Register a handler for a named semantic event.
 
@@ -67,6 +71,8 @@ class EventMap:
             The semantic event name (as defined in the manifest).
         handler
             An async callable to invoke when the event fires.
+            For accumulated events the handler signature must accept
+            a single ``int`` argument (the net accumulated steps).
 
         Raises
         ------
@@ -78,6 +84,16 @@ class EventMap:
             raise KeyError(
                 f"Unknown event '{event_name}'. Defined events: {sorted(known)}"
             )
+
+        mapping = next(m for m in self._mappings if m.name == event_name)
+        if mapping.accumulate:
+            kwargs: dict[str, Any] = {}
+            if mapping.accumulate_delay is not None:
+                kwargs["delay"] = mapping.accumulate_delay
+            if mapping.accumulate_max_steps is not None:
+                kwargs["max_steps"] = mapping.accumulate_max_steps
+            self._accumulators[event_name] = DialAccumulator(handler, **kwargs)
+
         self._handlers[event_name] = handler
 
     @property
@@ -118,6 +134,11 @@ class EventMap:
             self._hold_task.cancel()
             self._hold_task = None
 
+    def cancel_accumulators(self) -> None:
+        """Cancel all active dial accumulators and discard pending ticks."""
+        for acc in self._accumulators.values():
+            acc.cancel()
+
     def handle_encoder_turn(self, direction: int) -> AsyncHandler | None:
         """Match an encoder turn to a semantic event.
 
@@ -130,18 +151,29 @@ class EventMap:
         -------
         AsyncHandler or None
             The matched handler, or ``None`` if no mapping matched.
+            For accumulated events this returns ``None`` because the
+            tick is forwarded to the :class:`DialAccumulator` which
+            schedules its own async flush.
         """
         if self._pressed:
             self._cancel_hold_timer()
 
             for mapping in self._by_source.get("encoder_press_turn", []):
                 if self._direction_matches(mapping, direction):
+                    acc = self._accumulators.get(mapping.name)
+                    if acc is not None:
+                        acc.tick(direction)
+                        return None
                     h = self._handlers.get(mapping.name)
                     if h is not None:
                         return h
 
         for mapping in self._by_source.get("encoder_turn", []):
             if self._direction_matches(mapping, direction):
+                acc = self._accumulators.get(mapping.name)
+                if acc is not None:
+                    acc.tick(direction)
+                    return None
                 h = self._handlers.get(mapping.name)
                 if h is not None:
                     return h

--- a/src/deckui/dui/loader.py
+++ b/src/deckui/dui/loader.py
@@ -16,6 +16,7 @@ from .schema import (
     DEFAULT_SPINNER_INTERVAL_MS,
     HOLD_SOURCES,
     KNOWN_MANIFEST_KEYS,
+    TURN_SOURCES,
     VALID_CATEGORIES,
     VALID_DIRECTIONS,
     VALID_REGION_EVENTS,
@@ -296,12 +297,53 @@ def _parse_event(raw: dict[str, Any], index: int) -> EventMapping:
     if source in _PRESS_RELEASE_SOURCES and max_duration_ms is None:
         max_duration_ms = DEFAULT_MAX_DURATION_MS
 
+    accumulate = bool(raw.get("accumulate", False))
+    accumulate_delay: float | None = None
+    accumulate_max_steps: int | None = None
+
+    if accumulate and source not in TURN_SOURCES:
+        raise PackageError(
+            f"Event '{name}': accumulate is only valid for "
+            f"encoder_turn/encoder_press_turn sources"
+        )
+
+    raw_delay = raw.get("accumulate_delay")
+    if raw_delay is not None:
+        if not accumulate:
+            raise PackageError(
+                f"Event '{name}': accumulate_delay requires accumulate: true"
+            )
+        if not isinstance(raw_delay, (int, float)) or raw_delay <= 0:
+            raise PackageError(
+                f"Event '{name}': accumulate_delay must be a positive number"
+            )
+        accumulate_delay = float(raw_delay)
+
+    raw_max_steps = raw.get("accumulate_max_steps")
+    if raw_max_steps is not None:
+        if not accumulate:
+            raise PackageError(
+                f"Event '{name}': accumulate_max_steps requires accumulate: true"
+            )
+        if (
+            not isinstance(raw_max_steps, int)
+            or isinstance(raw_max_steps, bool)
+            or raw_max_steps < 1
+        ):
+            raise PackageError(
+                f"Event '{name}': accumulate_max_steps must be a positive integer"
+            )
+        accumulate_max_steps = raw_max_steps
+
     return EventMapping(
         name=name,
         source=source,
         direction=direction,
         max_duration_ms=max_duration_ms,
         hold_ms=hold_ms,
+        accumulate=accumulate,
+        accumulate_delay=accumulate_delay,
+        accumulate_max_steps=accumulate_max_steps,
     )
 
 

--- a/src/deckui/dui/schema.py
+++ b/src/deckui/dui/schema.py
@@ -198,6 +198,10 @@ VALID_DIRECTIONS = frozenset({"left", "right"})
 VALID_REGION_EVENTS = frozenset({"tap", "long_press"})
 
 
+TURN_SOURCES = frozenset({"encoder_turn", "encoder_press_turn"})
+"""Sources that support the ``accumulate`` option."""
+
+
 @dataclass(frozen=True, slots=True)
 class EventMapping:
     """Map a physical input to a named semantic event."""
@@ -207,6 +211,9 @@ class EventMapping:
     direction: str | None = None
     max_duration_ms: int | None = None
     hold_ms: int | None = None
+    accumulate: bool = False
+    accumulate_delay: float | None = None
+    accumulate_max_steps: int | None = None
 
 
 HOLD_SOURCES = frozenset({"key_hold", "encoder_hold"})

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -732,3 +732,139 @@ class TestEventMapRegistration:
         events = _make_events(("play", "encoder_press"))
         em = EventMap(events)
         assert em.handle_encoder_press() == []
+
+
+class TestAccumulatedTurns:
+    async def test_accumulated_turn_debounces(self):
+        """Multiple ticks flush as a single call with net steps."""
+        events = _make_events(
+            ("vol_up", "encoder_turn", {
+                "direction": "right", "accumulate": True, "accumulate_delay": 0.05,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("vol_up", handler)
+
+        assert em.handle_encoder_turn(1) is None
+        assert em.handle_encoder_turn(1) is None
+        assert em.handle_encoder_turn(1) is None
+
+        await asyncio.sleep(0.1)
+        handler.assert_awaited_once_with(3)
+
+    async def test_accumulated_turn_respects_max_steps(self):
+        events = _make_events(
+            ("vol_up", "encoder_turn", {
+                "direction": "right", "accumulate": True,
+                "accumulate_delay": 0.05, "accumulate_max_steps": 2,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("vol_up", handler)
+
+        for _ in range(5):
+            em.handle_encoder_turn(1)
+
+        await asyncio.sleep(0.1)
+        handler.assert_awaited_once_with(2)
+
+    async def test_accumulated_turn_custom_delay(self):
+        events = _make_events(
+            ("vol", "encoder_turn", {
+                "accumulate": True, "accumulate_delay": 0.05,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("vol", handler)
+
+        em.handle_encoder_turn(1)
+        await asyncio.sleep(0.02)
+        handler.assert_not_awaited()
+
+        await asyncio.sleep(0.05)
+        handler.assert_awaited_once_with(1)
+
+    async def test_accumulated_press_turn(self):
+        events = _make_events(
+            ("kelvin", "encoder_press_turn", {
+                "direction": "right", "accumulate": True, "accumulate_delay": 0.05,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("kelvin", handler)
+
+        em.handle_encoder_press()
+        assert em.handle_encoder_turn(1) is None
+        assert em.handle_encoder_turn(1) is None
+
+        await asyncio.sleep(0.1)
+        handler.assert_awaited_once_with(2)
+
+    async def test_accumulated_press_turn_not_pressed(self):
+        """Accumulated press_turn doesn't fire when not pressed."""
+        events = _make_events(
+            ("kelvin", "encoder_press_turn", {
+                "accumulate": True, "accumulate_delay": 0.05,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("kelvin", handler)
+
+        assert em.handle_encoder_turn(1) is None
+
+        await asyncio.sleep(0.1)
+        handler.assert_not_awaited()
+
+    async def test_cancel_accumulators(self):
+        events = _make_events(
+            ("vol_up", "encoder_turn", {
+                "direction": "right", "accumulate": True, "accumulate_delay": 0.05,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("vol_up", handler)
+
+        em.handle_encoder_turn(1)
+        em.cancel_accumulators()
+
+        await asyncio.sleep(0.1)
+        handler.assert_not_awaited()
+
+    async def test_non_accumulated_turn_unchanged(self):
+        """Non-accumulated turns still return handler directly."""
+        events = _make_events(
+            ("vol_up", "encoder_turn", {"direction": "right"}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("vol_up", handler)
+
+        result = em.handle_encoder_turn(1)
+        assert result is handler
+
+    async def test_accumulated_direction_filtering(self):
+        """Accumulated left turn only captures left ticks."""
+        events = _make_events(
+            ("vol_down", "encoder_turn", {
+                "direction": "left", "accumulate": True, "accumulate_delay": 0.05,
+            }),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("vol_down", handler)
+
+        # Right tick should not match
+        assert em.handle_encoder_turn(1) is None
+        await asyncio.sleep(0.1)
+        handler.assert_not_awaited()
+
+        # Left tick should match
+        em.handle_encoder_turn(-1)
+        await asyncio.sleep(0.1)
+        handler.assert_awaited_once_with(-1)

--- a/tests/test_dui_loader.py
+++ b/tests/test_dui_loader.py
@@ -697,6 +697,139 @@ class TestLoadPackageInvalid:
         with pytest.raises(PackageError, match="Duplicate event name"):
             load_package(pkg)
 
+    def test_event_accumulate_encoder_turn(self, tmp_path):
+        pkg = tmp_path / "Good.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Good\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: vol_up\n    source: encoder_turn\n"
+            "    direction: right\n    accumulate: true",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        ev = next(e for e in spec.events if e.name == "vol_up")
+        assert ev.accumulate is True
+        assert ev.accumulate_delay is None
+        assert ev.accumulate_max_steps is None
+
+    def test_event_accumulate_encoder_press_turn(self, tmp_path):
+        pkg = tmp_path / "Good.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Good\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: seek\n    source: encoder_press_turn\n"
+            "    accumulate: true",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        ev = next(e for e in spec.events if e.name == "seek")
+        assert ev.accumulate is True
+
+    def test_event_accumulate_with_delay_and_max_steps(self, tmp_path):
+        pkg = tmp_path / "Good.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Good\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: vol\n    source: encoder_turn\n"
+            "    accumulate: true\n    accumulate_delay: 0.1\n"
+            "    accumulate_max_steps: 5",
+            encoding="utf-8",
+        )
+        spec = load_package(pkg)
+        ev = next(e for e in spec.events if e.name == "vol")
+        assert ev.accumulate is True
+        assert ev.accumulate_delay == 0.1
+        assert ev.accumulate_max_steps == 5
+
+    def test_event_accumulate_invalid_source(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: Key\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: key_press\n    accumulate: true",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="accumulate is only valid for"):
+            load_package(pkg)
+
+    def test_event_accumulate_delay_without_accumulate(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: encoder_turn\n"
+            "    accumulate_delay: 0.1",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="accumulate_delay requires accumulate"):
+            load_package(pkg)
+
+    def test_event_accumulate_max_steps_without_accumulate(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: encoder_turn\n"
+            "    accumulate_max_steps: 5",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="accumulate_max_steps requires accumulate"):
+            load_package(pkg)
+
+    def test_event_accumulate_delay_not_positive(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: encoder_turn\n"
+            "    accumulate: true\n    accumulate_delay: -1",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="accumulate_delay must be a positive number"):
+            load_package(pkg)
+
+    def test_event_accumulate_max_steps_not_positive(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: encoder_turn\n"
+            "    accumulate: true\n    accumulate_max_steps: 0",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="accumulate_max_steps must be a positive integer"):
+            load_package(pkg)
+
+    def test_event_accumulate_max_steps_boolean_rejected(self, tmp_path):
+        pkg = tmp_path / "Bad.dui"
+        pkg.mkdir()
+        svg = '<svg xmlns="http://www.w3.org/2000/svg"/>'
+        (pkg / "layout.svg").write_text(svg, encoding="utf-8")
+        (pkg / "manifest.yaml").write_text(
+            "name: Bad\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "events:\n  - name: x\n    source: encoder_turn\n"
+            "    accumulate: true\n    accumulate_max_steps: true",
+            encoding="utf-8",
+        )
+        with pytest.raises(PackageError, match="accumulate_max_steps must be a positive integer"):
+            load_package(pkg)
+
     def test_region_missing_field(self, tmp_path):
         pkg = tmp_path / "Bad.dui"
         pkg.mkdir()


### PR DESCRIPTION
## Summary

- Adds `accumulate`, `accumulate_delay`, and `accumulate_max_steps` fields to DUI manifest event mappings for `encoder_turn` and `encoder_press_turn` sources
- Integrates the existing `DialAccumulator` into the DUI `EventMap` so rapid encoder ticks are debounced into a single handler call with the net step count
- Adds `DuiCard.cleanup()` method to cancel pending accumulators on teardown

## Manifest YAML

```yaml
events:
  - name: brightness_up
    source: encoder_turn
    direction: right
    accumulate: true
    accumulate_delay: 0.2       # optional, default 0.25s
    accumulate_max_steps: 5     # optional, default 10
```

The handler receives `steps: int` instead of being called once per tick:

```python
@card.on("brightness_up")
async def handle(steps: int):
    card.adjust_range("brightness", steps * 5, min_val=0, max_val=100)
```

## Changes

| File | Change |
|---|---|
| `src/deckui/dui/schema.py` | Add `TURN_SOURCES`, 3 fields to `EventMapping` |
| `src/deckui/dui/loader.py` | Parse + validate new fields |
| `src/deckui/dui/event_map.py` | Create/manage `DialAccumulator`, modify turn dispatch |
| `src/deckui/dui/card.py` | Add `cleanup()` for accumulator teardown |
| `docs/guides/creating-dui-packages.md` | Document accumulated turns + update examples |
| `tests/test_dui_loader.py` | 11 new validation tests |
| `tests/test_dui_event_map.py` | 8 new accumulation behavior tests |

## Testing

All 1051 tests pass, 96.91% coverage (>95% gate), lint clean, mypy clean.