### PR TITLE
Add auto-generated architecture diagrams to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - run: sudo apt-get update && sudo apt-get install -y graphviz
       - run: pip install -e ".[docs]"
+      - run: python tools/generate_diagrams.py
       - run: mkdocs build --strict
       - if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ dmypy.json
 *.pem
 *.key
 site/
+docs/architecture/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,12 @@
+# Architecture
+
+Auto-generated diagrams showing the structure of the DeckUI codebase.
+These are regenerated from source on every docs build.
+
+## Class Diagram
+
+![Class Diagram](architecture/classes.svg)
+
+## Package Diagram
+
+![Package Diagram](architecture/packages.svg)

--- a/docs/gen_diagrams.py
+++ b/docs/gen_diagrams.py
@@ -1,0 +1,25 @@
+"""Run architecture diagram generation during MkDocs builds.
+
+This script is executed by the ``mkdocs-gen-files`` plugin during
+``mkdocs build`` so local docs builds regenerate architecture diagrams
+without relying on a separate manual pre-build step.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Generate docs architecture diagrams from the repository root."""
+    repo_root = Path(__file__).resolve().parent.parent
+    subprocess.run(  # noqa: S603
+        [sys.executable, "tools/generate_diagrams.py"],
+        check=True,
+        cwd=repo_root,
+    )
+
+
+main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Architecture: architecture.md
   - Guides:
       - Creating DUI Packages: guides/creating-dui-packages.md
   - API Reference: reference/
@@ -26,6 +27,7 @@ plugins:
   - search
   - gen-files:
       scripts:
+        - docs/gen_diagrams.py
         - docs/gen_ref_pages.py
   - literate-nav:
       nav_file: SUMMARY.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ docs = [
     "mkdocstrings[python]>=0.25",
     "mkdocs-gen-files>=0.5",
     "mkdocs-literate-nav>=0.6",
+    "pylint>=3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tools/generate_diagrams.py
+++ b/tools/generate_diagrams.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate architecture diagrams from DeckUI source code.
+
+Uses pyreverse to extract class and package relationships, then renders
+them to SVG via Graphviz. The resulting files are placed in
+``docs/architecture/`` for inclusion in the MkDocs site.
+
+Requirements
+------------
+- ``pylint`` (provides ``pyreverse``)
+- ``graphviz`` (provides the ``dot`` CLI)
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_NAME = "deckui"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src"
+PACKAGE_PATH = SRC_ROOT / PROJECT_NAME
+OUTPUT_DIR = REPO_ROOT / "docs" / "architecture"
+
+DOT_FILES = {
+    f"classes_{PROJECT_NAME}.dot": "classes.svg",
+    f"packages_{PROJECT_NAME}.dot": "packages.svg",
+}
+
+
+def _check_prerequisites() -> None:
+    """Verify that required external tools are available.
+
+    Raises
+    ------
+    SystemExit
+        Raised when Graphviz ``dot`` is not available on ``PATH``.
+    """
+    if shutil.which("dot") is None:
+        print("ERROR: 'dot' (graphviz) not found on PATH", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _run(cmd: list[str], **kwargs: object) -> None:
+    """Run a subprocess and fail loudly if it exits non-zero.
+
+    Parameters
+    ----------
+    cmd : list[str]
+        Command and arguments to execute.
+    **kwargs : object
+        Additional keyword arguments passed to ``subprocess.run``.
+    """
+    print(f"  > {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, **kwargs)  # noqa: S603
+
+
+def main() -> None:
+    """Generate class and package diagrams as SVG files.
+
+    Raises
+    ------
+    SystemExit
+        Raised when Graphviz is unavailable or when expected pyreverse
+        output files are not produced.
+    """
+    _check_prerequisites()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        print("Running pyreverse ...")
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "pylint.pyreverse.main",
+                "--output",
+                "dot",
+                "--project",
+                PROJECT_NAME,
+                "--source-roots",
+                str(SRC_ROOT),
+                str(PACKAGE_PATH),
+            ],
+            cwd=tmp,
+        )
+
+        for dot_name, svg_name in DOT_FILES.items():
+            dot_file = tmp_path / dot_name
+            if not dot_file.exists():
+                print(f"ERROR: expected {dot_name} not found", file=sys.stderr)
+                raise SystemExit(1)
+
+            svg_dest = OUTPUT_DIR / svg_name
+            print(f"Rendering {dot_name} -> {svg_dest}")
+            _run(["dot", "-Tsvg", str(dot_file), "-o", str(svg_dest)])
+
+    print("Done. Diagrams written to", OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,19 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
 
 [[package]]
 name = "babel"
@@ -376,6 +389,7 @@ docs = [
     { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pylint" },
 ]
 test = [
     { name = "pytest" },
@@ -392,6 +406,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25" },
     { name = "pillow", specifier = ">=12.0.0" },
+    { name = "pylint", marker = "extra == 'docs'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0" },
@@ -408,6 +423,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -447,6 +471,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -542,6 +575,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -872,6 +914,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
 name = "pymdown-extensions"
 version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1103,6 +1163,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add automatic architecture diagram generation for DeckUI docs
- publish a new Architecture page in MkDocs and GitHub Pages
- wire docs dependencies and workflow steps for pyreverse + Graphviz

## Testing
- .venv/bin/python tools/generate_diagrams.py
- PATH=/usr/bin:/bin .venv/bin/python tools/generate_diagrams.py
- .venv/bin/mkdocs build --strict
- .venv/bin/python -m pytest tests/ --cov=deckui --cov-report=term-missing --cov-fail-under=95