### PR TITLE
Fix streamdeck example: real countdown, refresh from any handler, settings screen

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -1,0 +1,176 @@
+# Example: A Complete Stream Deck App
+
+This page walks through [`examples/streamdeck.py`](https://github.com/graphras-com/DeckUI/blob/main/examples/streamdeck.py),
+a single-file demo that exercises every major DeckUI feature. It is the
+recommended starting point for new users — clone the repo, plug in any
+Stream Deck, and run:
+
+```bash
+python examples/streamdeck.py
+```
+
+No external services are required. All state lives in memory and every
+action is logged to the console.
+
+## What it demonstrates
+
+- **Auto-discovery and lifecycle** via `DeckManager`.
+- **Loading `.dui` packages** with `load_package` and using `DuiCard` /
+  `DuiKey`.
+- **Declarative UI bindings** — `set`, `set_many`, `set_range`, and
+  `adjust_range` keep domain values normalised for SVG renderers.
+- **Refreshing from any handler** — `request_refresh()` works from key
+  handlers, encoder handlers, and background tasks alike.
+- **A live countdown timer** driven by an `asyncio` task that ticks
+  every second.
+- **A live dashboard clock** that updates only when the displayed value
+  changes.
+- **Multi-screen navigation** — a `main` screen and a `settings` screen
+  swap atomically via `Deck.set_screen`.
+- **All three key event sources** — `press`, `release`, and the
+  higher-level `click`. Scene keys flash their colours while held to
+  prove that all three fire.
+
+## Layout
+
+The example is structured as a set of single-purpose **controllers**
+that each own one widget plus its state. A top-level
+`StreamDeckApp` wires them together and hooks into the manager.
+
+```
+StreamDeckApp
+├── AudioController        ── AudioCard.dui      (touch-strip card 0)
+├── LightsController       ── LightCard.dui      (touch-strip card 1)
+├── TimerController        ── TimerCard.dui      (touch-strip card 2)
+├── DashboardController    ── DashboardCard.dui  (touch-strip card 3)
+├── FavoritesController    ── PictureKey.dui     (keys 0..N favourites)
+├── SceneController        ── IconKey.dui        (keys after favourites)
+└── NavigationController   ── IconKey.dui        (last key, screen switch)
+```
+
+Controllers never talk to the deck directly. They mutate their card's
+bindings via `set`/`set_many` and call `card.request_refresh()` when the
+display needs to update. The deck transparently re-renders dirty regions
+on the next refresh tick.
+
+## The lifecycle
+
+The example follows the canonical DeckUI flow:
+
+```python
+async def run() -> None:
+    app = StreamDeckApp(MEDIA_CATALOG, SCENE_DEFS)
+    manager = DeckManager(brightness=60, auto_reconnect=True)
+
+    @manager.on_connect()
+    async def _on_connect(deck):
+        await app.on_connect(deck)
+
+    @manager.on_disconnect
+    async def _on_disconnect(info):
+        await app.on_disconnect(info)
+
+    async with manager:
+        await manager.wait_closed()
+```
+
+`DeckManager` discovers connected devices, calls `on_connect` once a
+deck is ready, and re-fires it on reconnects when `auto_reconnect=True`.
+On disconnect, the example shuts down its background tasks cleanly.
+
+## Highlights
+
+### Real countdown timer
+
+`TimerController` runs an `asyncio` task that decrements a counter once
+per second. When the user toggles, resets, or adjusts the duration,
+state is mutated and a refresh requested — the task itself does no UI
+work directly.
+
+```python
+async def _tick_loop(self) -> None:
+    while True:
+        await asyncio.sleep(self.TICK_INTERVAL_S)
+        if not self.is_running:
+            continue
+        if self.remaining > 0:
+            self.remaining -= 1
+            self._sync_card()
+            await self._card.request_refresh()
+        if self.remaining <= 0 and self.is_running:
+            self.is_running = False
+            self._sync_card()
+            await self._card.request_refresh()
+```
+
+The `request_refresh()` call is wired automatically when the screen is
+activated — no need to pass the deck handle into the controller.
+
+### Press, release, and click on the same key
+
+Scene keys register all three handlers. The press/release pair invert
+the foreground and background colours so the key visually flashes while
+held; click logs the scene name:
+
+```python
+@key.on_event("press")
+async def _press():
+    key.set_many(background=FG, foreground=BG)
+    await key.request_refresh()
+
+@key.on_event("release")
+async def _release():
+    key.set_many(background=BG, foreground=FG)
+    await key.request_refresh()
+
+@key.on_event("click")
+async def _click():
+    log.info("Scene activated: %s", label)
+```
+
+### Two screens, one set of controllers
+
+`NavigationController` swaps between a busy `main` screen (favourites,
+scenes, all four cards) and a focused `settings` screen (just the
+dashboard and lights). The same controllers appear on both — DeckUI
+re-renders whatever is installed on the active screen.
+
+```python
+async def _toggle(self) -> None:
+    target = self._primary if self._on_secondary else self._secondary
+    self._on_secondary = not self._on_secondary
+    self._render_label()
+    await self._deck.set_screen(target)
+```
+
+## Try it
+
+Once running, here are some interactions to try:
+
+| Action | Effect |
+| ------ | ------ |
+| Press a favourite key (cover art) | Starts that track; AudioCard updates instantly |
+| Press and hold a scene key | Key inverts colours; releases to log the scene |
+| Hold the audio encoder | Toggles play/pause |
+| Turn the audio encoder | Volume up/down |
+| Click the audio encoder | Mute toggle |
+| Press + turn the audio encoder | Previous/next track |
+| Click the timer encoder | Start or pause the countdown |
+| Hold the timer encoder | Reset the timer |
+| Turn the timer encoder | Add/remove 30 seconds |
+| Press the Settings key | Switch to the settings screen |
+
+## Full source
+
+The complete example, embedded straight from the repository so it stays
+in sync with what you'll run locally:
+
+```python title="examples/streamdeck.py"
+--8<-- "examples/streamdeck.py"
+```
+
+## Related
+
+- [Creating DUI Packages](guides/creating-dui-packages.md) — how to
+  build your own `.dui` cards and keys.
+- [API Reference](reference/runtime.md) — full library API documentation.

--- a/examples/LightCard.dui/manifest.yaml
+++ b/examples/LightCard.dui/manifest.yaml
@@ -48,11 +48,13 @@ events:
     source: encoder_turn
     direction: right
     accumulate: true
+    accumulate_delay: 0.1
 
   - name: brightness_down
     source: encoder_turn
     direction: left
     accumulate: true
+    accumulate_delay: 0.1
 
   - name: kelvin_up
     source: encoder_press_turn

--- a/examples/LightCard.dui/manifest.yaml
+++ b/examples/LightCard.dui/manifest.yaml
@@ -58,13 +58,15 @@ events:
     source: encoder_press_turn
     direction: right
     accumulate: true
-    accumulate_max_steps: 1
+    accumulate_delay: 0.1
+    accumulate_max_steps: 10
 
   - name: kelvin_down
     source: encoder_press_turn
     direction: left
     accumulate: true
-    accumulate_max_steps: 1
+    accumulate_delay: 0.1
+    accumulate_max_steps: 10
 
 regions:
   card:

--- a/examples/TimerCard.dui/manifest.yaml
+++ b/examples/TimerCard.dui/manifest.yaml
@@ -20,11 +20,13 @@ events:
     source: encoder_turn
     direction: left
     accumulate: true
+    accumulate_delay: 0.01
 
   - name: increase_duration
     source: encoder_turn
     direction: right
     accumulate: true
+    accumulate_delay: 0.01
 
   - name: toggle
     source: encoder_press_release

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -778,8 +778,17 @@ class SceneController:
     """Scene-activation keys -- one :class:`DuiKey` per scene definition.
 
     Loads ``IconKey.dui`` once and instantiates a key per scene.  Each
-    key's click handler logs the scene name; replace the body with your
-    own automation.
+    key has three handlers, demonstrating that ``press`` and ``release``
+    are emitted alongside the higher-level ``click`` event:
+
+    * ``press``   -- inverts the foreground / background colours so the
+      key visually flashes while held.
+    * ``release`` -- restores the original colours.
+    * ``click``   -- logs the scene name (replace with your automation).
+
+    The colour swap also showcases how to update bindings from a key
+    handler and call :meth:`DuiKey.request_refresh` to push the change
+    to the device immediately.
 
     Parameters
     ----------
@@ -789,6 +798,10 @@ class SceneController:
     packages_dir : Path | None
         Directory containing ``IconKey.dui``.
     """
+
+    # Defaults match the IconKey.dui manifest.
+    DEFAULT_BACKGROUND = "#1c1c1c"
+    DEFAULT_FOREGROUND = "#dedede"
 
     def __init__(
         self,
@@ -802,13 +815,52 @@ class SceneController:
 
         for scene in self._scenes:
             key = DuiKey(self._spec)
-            key.set_many(label=scene["label"], icon=scene["icon"])
+            key.set_many(
+                label=scene["label"],
+                icon=scene["icon"],
+                background=self.DEFAULT_BACKGROUND,
+                foreground=self.DEFAULT_FOREGROUND,
+            )
 
-            @key.on_event("click")
-            async def _click(name: str = scene["label"]) -> None:
-                log.info("Scene activated: %s", name)
-
+            # Bind handlers via a helper so each key captures its own
+            # *key* reference instead of the loop variable.
+            self._bind_handlers(key, scene["label"])
             self._keys.append(key)
+
+    def _bind_handlers(self, key: DuiKey, label: str) -> None:
+        """Attach press/release/click handlers to *key*.
+
+        Splitting this into a helper guarantees correct closure capture
+        for *key* and *label* per iteration.
+
+        Parameters
+        ----------
+        key : DuiKey
+            The key to wire.
+        label : str
+            Scene label, logged on click.
+        """
+
+        @key.on_event("press")
+        async def _press() -> None:
+            # Invert colours by swapping background <-> foreground.
+            key.set_many(
+                background=self.DEFAULT_FOREGROUND,
+                foreground=self.DEFAULT_BACKGROUND,
+            )
+            await key.request_refresh()
+
+        @key.on_event("release")
+        async def _release() -> None:
+            key.set_many(
+                background=self.DEFAULT_BACKGROUND,
+                foreground=self.DEFAULT_FOREGROUND,
+            )
+            await key.request_refresh()
+
+        @key.on_event("click")
+        async def _click() -> None:
+            log.info("Scene activated: %s", label)
 
     @property
     def keys(self) -> list[DuiKey]:

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -1,27 +1,38 @@
 #!/usr/bin/env python3
-"""Stream Deck example -- showcases DeckUI across all supported devices.
+"""Stream Deck demo -- a complete walkthrough of the DeckUI library.
 
-This example works with any Stream Deck model.  Physical keys (favourites
-and scenes) are laid out dynamically based on the connected device's key
-count.  Touchscreen cards (audio, lights, timer, dashboard) are only
-installed when the device has a touch strip and encoders.
+This single-file example showcases every major DeckUI concept against
+any connected Stream Deck.  It is designed to read top-to-bottom as a
+tutorial -- each section introduces one feature.
 
-Each controller owns its DUI card or keys, loads the ``.dui`` package,
-manages internal state, and wires up all event handlers.
-
-No real hardware or external services are required -- every controller
-uses in-memory state and logs actions to the console.
+What it demonstrates
+--------------------
+* :class:`~deckui.DeckManager` for auto-discovery and hot-plug.
+* Loading ``.dui`` packages via :func:`~deckui.load_package` and using
+  :class:`~deckui.DuiCard` / :class:`~deckui.DuiKey`.
+* Using :meth:`~deckui.DuiCard.set` / :meth:`~deckui.DuiCard.set_many`
+  / :meth:`~deckui.DuiCard.set_range` / :meth:`~deckui.DuiCard.adjust_range`
+  helpers instead of manual normalisation.
+* Triggering re-renders from key handlers and background tasks via
+  :meth:`~deckui.DuiCard.request_refresh`.
+* A live, asyncio-driven countdown ``TimerCard`` and a dashboard clock
+  that ticks every second.
+* Multi-screen navigation -- a ``main`` screen and a ``settings`` screen.
 
 Running
 -------
 ::
 
     python examples/streamdeck.py
+
+No real services are required -- every controller uses in-memory state
+and logs actions to the console.  Press Ctrl+C to exit.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import logging
 from pathlib import Path
@@ -31,14 +42,16 @@ from PIL import Image
 
 from deckui import DeckManager, DeviceInfo, DuiCard, DuiKey, load_package
 
-logging.basicConfig(level=logging.DEBUG, format="%(levelname)s: %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 
-# Resolve examples directory for .dui package loading
+# Resolve the directory holding the .dui packages and image assets used
+# below.  Adjust if you move them elsewhere.
 EXAMPLES_DIR = Path(__file__).resolve().parent
 
+
 # ---------------------------------------------------------------------------
-# Media catalog -- four classic albums used as favourites
+# Demo data -- four classic albums (favourites) and four "scenes"
 # ---------------------------------------------------------------------------
 
 MEDIA_CATALOG: list[dict[str, str]] = [
@@ -68,7 +81,6 @@ MEDIA_CATALOG: list[dict[str, str]] = [
     },
 ]
 
-# Scene definitions (installed on keys after favourites)
 SCENE_DEFS: list[dict[str, str]] = [
     {"label": "Normal", "icon": "fa-regular:smile-beam"},
     {"label": "Tired", "icon": "fa-regular:tired"},
@@ -77,30 +89,39 @@ SCENE_DEFS: list[dict[str, str]] = [
 ]
 
 
-# ===================================================================
-# Controllers -- each owns its card, state, and event handlers
-# ===================================================================
+# ===========================================================================
+# Controllers
+# ===========================================================================
+#
+# Each controller owns one ``.dui`` widget (card or key), maps domain
+# state -> bindings, and wires event handlers.  Controllers never touch
+# the deck directly: they call :meth:`DuiCard.request_refresh` /
+# :meth:`DuiKey.request_refresh` when state changes, and the deck
+# re-renders dirty regions automatically.
+# ===========================================================================
 
 
 class AudioController:
-    """Audio player card controller.
+    """Audio player card -- play/pause, mute, volume, track navigation.
 
-    Loads the ``AudioCard.dui`` package, manages playback state (volume,
-    mute, play/pause, track navigation) and exposes the wired
-    :class:`~deckui.DuiCard` via the :pyattr:`card` property.
+    Loads ``AudioCard.dui`` and binds encoder events:
 
-    Favourite keys call :meth:`play` to start a specific track.
+    * encoder hold     -> toggle play/pause
+    * encoder turn     -> volume up/down
+    * encoder click    -> mute toggle
+    * encoder press+turn -> previous/next track
+
+    Favourite keys (see :class:`FavoritesController`) call :meth:`play`
+    to start a specific track.
 
     Parameters
     ----------
     catalog : list[dict[str, str]]
-        Media entries, each with ``artist``, ``album``, ``title``,
-        and ``cover`` keys.
+        Media entries with ``artist``, ``album``, ``title``, ``cover``.
     initial_volume : float, default=0.3
-        Starting volume level (0.0 -- 1.0).
+        Starting volume (0.0 -- 1.0).
     packages_dir : Path | None
-        Directory containing ``.dui`` packages.  Defaults to the
-        ``examples/`` directory next to this script.
+        Directory containing ``AudioCard.dui``.  Defaults to ``examples/``.
     """
 
     def __init__(
@@ -116,17 +137,16 @@ class AudioController:
         self.is_playing: bool = False
 
         self._pkg_dir = packages_dir or EXAMPLES_DIR
-        spec = load_package(self._pkg_dir / "AudioCard.dui")
-        self._card = DuiCard(spec)
+        self._card = DuiCard(load_package(self._pkg_dir / "AudioCard.dui"))
 
         self._sync_card()
         self._bind_events()
 
-    # -- public API --------------------------------------------------------
+    # -- public API -----------------------------------------------------
 
     @property
     def card(self) -> DuiCard:
-        """The wired DuiCard ready to install on a screen."""
+        """The :class:`DuiCard` ready to install on a screen."""
         return self._card
 
     @property
@@ -135,12 +155,12 @@ class AudioController:
         return self._catalog[self._index]
 
     async def play(self, track: dict[str, str] | None = None) -> None:
-        """Start playback, optionally jumping to a specific track.
+        """Start playback (optionally jumping to *track*) and refresh.
 
         Parameters
         ----------
         track : dict[str, str] | None
-            If provided, switch to this track before playing.
+            If given and present in the catalog, jump to it first.
         """
         if track is not None and track in self._catalog:
             self._index = self._catalog.index(track)
@@ -151,21 +171,21 @@ class AudioController:
         await self._card.request_refresh()
 
     async def pause(self) -> None:
-        """Pause playback."""
+        """Pause playback and refresh."""
         self.is_playing = False
         log.info("Paused")
         self._sync_card()
         await self._card.request_refresh()
 
     async def play_pause(self) -> None:
-        """Toggle between play and pause."""
+        """Toggle play/pause."""
         if self.is_playing:
             await self.pause()
         else:
             await self.play()
 
     async def next_track(self) -> dict[str, str]:
-        """Advance to the next track (wraps around).
+        """Advance to the next track (wraps).
 
         Returns
         -------
@@ -179,7 +199,7 @@ class AudioController:
         return t
 
     async def previous_track(self) -> dict[str, str]:
-        """Go back to the previous track (wraps around).
+        """Go back to the previous track (wraps).
 
         Returns
         -------
@@ -193,24 +213,24 @@ class AudioController:
         return t
 
     async def set_volume(self, level: float) -> None:
-        """Set volume level.
+        """Set volume in [0.0, 1.0] and refresh.
 
         Parameters
         ----------
         level : float
-            Volume between 0.0 and 1.0.
+            Volume between 0.0 and 1.0.  Out-of-range values are clamped.
         """
         self.volume_level = max(0.0, min(1.0, level))
         log.info("Volume: %.0f%%", self.volume_level * 100)
         self._sync_volume_text()
 
     async def toggle_mute(self) -> None:
-        """Toggle mute state."""
+        """Toggle mute and refresh the volume text."""
         self.is_muted = not self.is_muted
         log.info("Muted: %s", self.is_muted)
         self._sync_volume_text()
 
-    # -- internal ----------------------------------------------------------
+    # -- internal -------------------------------------------------------
 
     def _sync_card(self) -> None:
         """Push the full player state into card bindings."""
@@ -224,8 +244,9 @@ class AudioController:
         cover_path = self._pkg_dir / t["cover"]
         if cover_path.exists():
             self._card.set("cover", Image.open(cover_path))
-        vol_pct = self.volume_level * 100
-        self._card.set_range("volume", vol_pct, min_val=0, max_val=100)
+        # set_range normalises 0-100 -> 0.0-1.0 so the SVG range binding
+        # gets the value it expects.
+        self._card.set_range("volume", self.volume_level * 100, min_val=0, max_val=100)
         self._sync_volume_text()
 
     def _sync_volume_text(self) -> None:
@@ -236,7 +257,7 @@ class AudioController:
             self._card.set("value_text", f"{int(self.volume_level * 100)}%")
 
     def _bind_events(self) -> None:
-        """Register card event handlers."""
+        """Register card event handlers (declared in the manifest)."""
         card = self._card
 
         @card.on("toggle_play_pause")
@@ -245,6 +266,8 @@ class AudioController:
 
         @card.on("volume_up")
         async def _vol_up(steps: int) -> None:
+            # adjust_range clamps and returns the new domain value, so we
+            # don't have to re-compute the percentage ourselves.
             new = card.adjust_range("volume", steps, min_val=0, max_val=100)
             await self.set_volume(new / 100.0)
 
@@ -258,19 +281,22 @@ class AudioController:
             await self.toggle_mute()
 
         @card.on("next")
-        async def _next(steps: int) -> None:
+        async def _next(_steps: int) -> None:
             await self.next_track()
 
         @card.on("previous")
-        async def _prev(steps: int) -> None:
+        async def _prev(_steps: int) -> None:
             await self.previous_track()
 
 
 class LightsController:
-    """Lights card controller with on/off, brightness, and colour temperature.
+    """Lights card -- on/off toggle, brightness, colour temperature.
 
-    Loads the ``LightCard.dui`` package and manages the light state
-    internally.
+    Loads ``LightCard.dui`` and binds:
+
+    * encoder click       -> on/off toggle
+    * encoder turn        -> brightness up/down (5 % per step)
+    * encoder press+turn  -> kelvin up/down (100 K per step)
 
     Parameters
     ----------
@@ -279,8 +305,13 @@ class LightsController:
     kelvin : int, default=4000
         Initial colour temperature in Kelvin (2000 -- 6500).
     packages_dir : Path | None
-        Directory containing ``.dui`` packages.
+        Directory containing ``LightCard.dui``.
     """
+
+    BRIGHTNESS_MIN = 0
+    BRIGHTNESS_MAX = 100
+    KELVIN_MIN = 2000
+    KELVIN_MAX = 6500
 
     def __init__(
         self,
@@ -293,15 +324,14 @@ class LightsController:
         self.kelvin: int = kelvin
 
         pkg_dir = packages_dir or EXAMPLES_DIR
-        spec = load_package(pkg_dir / "LightCard.dui")
-        self._card = DuiCard(spec)
+        self._card = DuiCard(load_package(pkg_dir / "LightCard.dui"))
 
         self._sync_card()
         self._bind_events()
 
     @property
     def card(self) -> DuiCard:
-        """The wired DuiCard ready to install on a screen."""
+        """The :class:`DuiCard` ready to install on a screen."""
         return self._card
 
     async def toggle(self) -> None:
@@ -311,38 +341,46 @@ class LightsController:
         self._card.set("lights", self.is_on)
 
     async def set_brightness(self, value: int) -> None:
-        """Set brightness percentage.
-
-        Parameters
-        ----------
-        value : int
-            Brightness between 0 and 100.
-        """
-        self.brightness = max(0, min(100, value))
+        """Set brightness percentage (clamped to 0 -- 100)."""
+        self.brightness = max(self.BRIGHTNESS_MIN, min(self.BRIGHTNESS_MAX, value))
         log.info("Brightness: %d%%", self.brightness)
         self._card.set("brightness_value_text", f"{self.brightness}%")
-        self._card.set_range("brightness", self.brightness, min_val=0, max_val=100)
+        self._card.set_range(
+            "brightness",
+            self.brightness,
+            min_val=self.BRIGHTNESS_MIN,
+            max_val=self.BRIGHTNESS_MAX,
+        )
 
     async def set_kelvin(self, value: int) -> None:
-        """Set colour temperature.
-
-        Parameters
-        ----------
-        value : int
-            Colour temperature in Kelvin (clamped to 2000 -- 6500).
-        """
-        self.kelvin = max(2000, min(6500, value))
+        """Set colour temperature (clamped to 2000 -- 6500 K)."""
+        self.kelvin = max(self.KELVIN_MIN, min(self.KELVIN_MAX, value))
         log.info("Kelvin: %dK", self.kelvin)
         self._card.set("kelvin_value_text", f"{self.kelvin}K")
-        self._card.set_range("kelvin", self.kelvin, min_val=2000, max_val=6500)
+        self._card.set_range(
+            "kelvin",
+            self.kelvin,
+            min_val=self.KELVIN_MIN,
+            max_val=self.KELVIN_MAX,
+        )
 
     def _sync_card(self) -> None:
         """Push the full light state into card bindings."""
         self._card.set("lights", self.is_on)
         self._card.set("brightness_value_text", f"{self.brightness}%")
-        self._card.set_range("brightness", self.brightness, min_val=0, max_val=100)
+        self._card.set_range(
+            "brightness",
+            self.brightness,
+            min_val=self.BRIGHTNESS_MIN,
+            max_val=self.BRIGHTNESS_MAX,
+        )
         self._card.set("kelvin_value_text", f"{self.kelvin}K")
-        self._card.set_range("kelvin", self.kelvin, min_val=2000, max_val=6500)
+        self._card.set_range(
+            "kelvin",
+            self.kelvin,
+            min_val=self.KELVIN_MIN,
+            max_val=self.KELVIN_MAX,
+        )
 
     def _bind_events(self) -> None:
         """Register card event handlers."""
@@ -369,18 +407,31 @@ class LightsController:
 
 
 class TimerController:
-    """Countdown timer card controller.
+    """Live countdown timer -- a real ticking timer driven by an asyncio task.
 
-    Loads the ``TimerCard.dui`` package and manages a simple countdown
-    timer with start/pause, reset, and duration adjustment.
+    Loads ``TimerCard.dui`` and binds:
+
+    * encoder click  -> start/pause
+    * encoder hold   -> reset to *initial_seconds*
+    * encoder turn   -> add/remove 30 s
+
+    While running, an internal asyncio task decrements ``remaining`` every
+    second and calls :meth:`DuiCard.request_refresh` so the display
+    updates live without any polling on the caller's side.
+
+    Use :meth:`start_runtime` once the deck is connected and
+    :meth:`stop_runtime` to clean up on disconnect.
 
     Parameters
     ----------
     initial_seconds : int, default=300
         Initial duration in seconds.
     packages_dir : Path | None
-        Directory containing ``.dui`` packages.
+        Directory containing ``TimerCard.dui``.
     """
+
+    TICK_INTERVAL_S = 1.0
+    ADJUST_STEP_S = 30
 
     def __init__(
         self,
@@ -392,31 +443,56 @@ class TimerController:
         self.is_running: bool = False
 
         pkg_dir = packages_dir or EXAMPLES_DIR
-        spec = load_package(pkg_dir / "TimerCard.dui")
-        self._card = DuiCard(spec)
+        self._card = DuiCard(load_package(pkg_dir / "TimerCard.dui"))
+        self._tick_task: asyncio.Task[None] | None = None
 
         self._sync_card()
         self._bind_events()
 
     @property
     def card(self) -> DuiCard:
-        """The wired DuiCard ready to install on a screen."""
+        """The :class:`DuiCard` ready to install on a screen."""
         return self._card
 
     def format_time(self) -> str:
-        """Format remaining time as ``HH:MM:SS``.
+        """Format ``remaining`` as ``HH:MM:SS``.
 
         Returns
         -------
         str
-            Formatted time string.
+            Zero-padded ``HH:MM:SS`` string.
         """
-        h, rem = divmod(self.remaining, 3600)
+        h, rem = divmod(max(0, self.remaining), 3600)
         m, s = divmod(rem, 60)
         return f"{h:02d}:{m:02d}:{s:02d}"
 
+    async def start_runtime(self) -> None:
+        """Start the background tick task.
+
+        Idempotent -- safe to call multiple times.  Should be called
+        after the screen is active so the first tick can refresh the
+        display.
+        """
+        if self._tick_task is None or self._tick_task.done():
+            self._tick_task = asyncio.create_task(
+                self._tick_loop(), name="timer-tick"
+            )
+
+    async def stop_runtime(self) -> None:
+        """Cancel the background tick task and wait for it to exit."""
+        task = self._tick_task
+        self._tick_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
     async def toggle(self) -> None:
-        """Start or pause the timer."""
+        """Start or pause the countdown."""
+        # When the timer was paused at 0 (or has rolled to 0 since pause)
+        # restart from the configured duration so the user gets a fresh run.
+        if not self.is_running and self.remaining <= 0:
+            self.remaining = self.duration
         self.is_running = not self.is_running
         log.info(
             "Timer %s -- %s",
@@ -424,16 +500,21 @@ class TimerController:
             self.format_time(),
         )
         self._sync_card()
+        await self._card.request_refresh()
 
     async def reset(self) -> None:
-        """Reset the timer to its initial duration."""
+        """Stop the countdown and reload the configured duration."""
         self.is_running = False
         self.remaining = self.duration
         log.info("Timer reset -- %s", self.format_time())
         self._sync_card()
+        await self._card.request_refresh()
 
     async def adjust_duration(self, delta_seconds: int) -> None:
-        """Adjust the timer duration.
+        """Add (or subtract) seconds to/from the configured duration.
+
+        Resets the running countdown to the new duration so adjustments
+        are immediately visible.
 
         Parameters
         ----------
@@ -444,6 +525,7 @@ class TimerController:
         self.remaining = self.duration
         log.info("Timer duration: %s", self.format_time())
         self._sync_card()
+        await self._card.request_refresh()
 
     def _sync_card(self) -> None:
         """Push the timer display into the card binding."""
@@ -462,27 +544,52 @@ class TimerController:
 
         @self._card.on("increase_duration")
         async def _increase(steps: int) -> None:
-            await self.adjust_duration(steps * 30)
+            await self.adjust_duration(steps * self.ADJUST_STEP_S)
 
         @self._card.on("decrease_duration")
         async def _decrease(steps: int) -> None:
-            await self.adjust_duration(-abs(steps) * 30)
+            await self.adjust_duration(-abs(steps) * self.ADJUST_STEP_S)
+
+    async def _tick_loop(self) -> None:
+        """Decrement *remaining* once per second while running."""
+        try:
+            while True:
+                await asyncio.sleep(self.TICK_INTERVAL_S)
+                if not self.is_running:
+                    continue
+                if self.remaining > 0:
+                    self.remaining -= 1
+                    self._sync_card()
+                    await self._card.request_refresh()
+                if self.remaining <= 0 and self.is_running:
+                    self.is_running = False
+                    log.info("Timer finished")
+                    self._sync_card()
+                    await self._card.request_refresh()
+        except asyncio.CancelledError:
+            pass
 
 
 class DashboardController:
-    """Dashboard card controller showing time, weather, and deck brightness.
+    """Dashboard card -- live clock, mock weather, deck-brightness control.
 
-    Loads the ``DashboardCard.dui`` package.  Brightness encoder events
-    update both the internal state and the physical deck brightness via
-    the *deck* handle passed to :meth:`bind_deck`.
+    Loads ``DashboardCard.dui``.  Brightness encoder events update both
+    the internal state and the physical deck via the *deck* handle
+    passed to :meth:`bind_deck`.  An asyncio task ticks every second to
+    keep the displayed clock accurate.
+
+    Use :meth:`start_runtime` once the deck is connected and
+    :meth:`stop_runtime` to clean up on disconnect.
 
     Parameters
     ----------
     deck_brightness : int, default=60
         Initial deck brightness percentage (0 -- 100).
     packages_dir : Path | None
-        Directory containing ``.dui`` packages.
+        Directory containing ``DashboardCard.dui``.
     """
+
+    CLOCK_INTERVAL_S = 1.0
 
     def __init__(
         self,
@@ -493,63 +600,65 @@ class DashboardController:
         self.temperature: str = "22C"
         self.humidity: str = "45%"
         self._deck: Any = None
+        self._clock_task: asyncio.Task[None] | None = None
 
         pkg_dir = packages_dir or EXAMPLES_DIR
-        spec = load_package(pkg_dir / "DashboardCard.dui")
-        self._card = DuiCard(spec)
+        self._card = DuiCard(load_package(pkg_dir / "DashboardCard.dui"))
 
         self._sync_card()
         self._bind_events()
 
     @property
     def card(self) -> DuiCard:
-        """The wired DuiCard ready to install on a screen."""
+        """The :class:`DuiCard` ready to install on a screen."""
         return self._card
 
     def bind_deck(self, deck: Any) -> None:
-        """Attach the deck handle so brightness changes reach the hardware.
-
-        Parameters
-        ----------
-        deck
-            The :class:`~deckui.runtime.deck.Deck` instance.
-        """
+        """Attach the deck handle so brightness changes reach the hardware."""
         self._deck = deck
 
-    def get_date(self) -> str:
-        """Return the current date formatted as ``YYYY-MM-DD``.
-
-        Returns
-        -------
-        str
-            Formatted date string.
-        """
+    @staticmethod
+    def get_date() -> str:
+        """Return today's date as ``YYYY-MM-DD``."""
         return datetime.datetime.now().strftime("%Y-%m-%d")
 
-    def get_time(self) -> str:
-        """Return the current time formatted as ``HH:MM``.
-
-        Returns
-        -------
-        str
-            Formatted time string.
-        """
+    @staticmethod
+    def get_time() -> str:
+        """Return the current local time as ``HH:MM``."""
         return datetime.datetime.now().strftime("%H:%M")
 
     async def set_brightness(self, value: int) -> None:
-        """Set the deck brightness.
+        """Set the deck brightness (clamped to 0 -- 100).
 
-        Updates both internal state and the physical deck (if bound).
-
-        Parameters
-        ----------
-        value : int
-            Brightness percentage (0 -- 100).
+        Updates internal state, the bound physical deck, and the slider
+        binding on the card.
         """
         self.deck_brightness = max(0, min(100, value))
         log.info("Deck brightness: %d%%", self.deck_brightness)
+        self._card.set_range(
+            "deck_brightness",
+            self.deck_brightness,
+            min_val=0,
+            max_val=100,
+        )
         if self._deck is not None:
             await self._deck.set_brightness(self.deck_brightness)
+
+    async def start_runtime(self) -> None:
+        """Start the background clock-tick task (idempotent)."""
+        if self._clock_task is None or self._clock_task.done():
+            self._clock_task = asyncio.create_task(
+                self._clock_loop(), name="dashboard-clock"
+            )
+
+    async def stop_runtime(self) -> None:
+        """Cancel the clock-tick task."""
+        task = self._clock_task
+        self._clock_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
     def _sync_card(self) -> None:
         """Push the full dashboard state into card bindings."""
@@ -577,73 +686,41 @@ class DashboardController:
 
         @card.on("brightness_down")
         async def _bright_down(steps: int) -> None:
-            new = card.adjust_range("deck_brightness", -abs(steps), min_val=0, max_val=100)
+            new = card.adjust_range(
+                "deck_brightness", -abs(steps), min_val=0, max_val=100
+            )
             await self.set_brightness(int(new))
 
+    async def _clock_loop(self) -> None:
+        """Refresh the clock display every second.
 
-class SceneController:
-    """Scene-activation key controller.
-
-    Loads the ``IconKey.dui`` package and creates one :class:`~deckui.DuiKey`
-    per scene definition.  Each key click logs the scene name.
-
-    Parameters
-    ----------
-    scenes : list[dict[str, str]]
-        Scene definitions, each with ``label`` and ``icon``.
-    packages_dir : Path | None
-        Directory containing ``.dui`` packages.
-    """
-
-    def __init__(
-        self,
-        scenes: list[dict[str, str]],
-        packages_dir: Path | None = None,
-    ) -> None:
-        self._scenes = scenes
-        pkg_dir = packages_dir or EXAMPLES_DIR
-        self._spec = load_package(pkg_dir / "IconKey.dui")
-        self._keys: list[DuiKey] = []
-
-        for scene in self._scenes:
-            key = DuiKey(self._spec)
-            key.set("label", scene["label"])
-            key.set("icon", scene["icon"])
-
-            @key.on_event("click")
-            async def _click(name: str = scene["label"]) -> None:
-                log.info("Scene activated: %s", name)
-
-            self._keys.append(key)
-
-    @property
-    def keys(self) -> list[DuiKey]:
-        """The created scene keys (same order as *scenes*)."""
-        return list(self._keys)
-
-    def install(self, screen: Any, positions: list[int]) -> None:
-        """Place scene keys onto a screen at the given positions.
-
-        Only installs as many keys as there are positions (or keys),
-        whichever is fewer.
-
-        Parameters
-        ----------
-        screen
-            The :class:`~deckui.ui.screen.Screen` to install keys on.
-        positions : list[int]
-            Key indices to place the scene keys at.
+        Only marks the card dirty when the visible value actually changes
+        so we don't churn the SVG renderer 60x per minute.
         """
-        for pos, key in zip(positions, self._keys, strict=False):
-            screen.set_key(pos, key)
+        last_time = ""
+        last_date = ""
+        try:
+            while True:
+                await asyncio.sleep(self.CLOCK_INTERVAL_S)
+                t = self.get_time()
+                d = self.get_date()
+                if t == last_time and d == last_date:
+                    continue
+                last_time, last_date = t, d
+                self._card.set_many(time=t, date=d)
+                await self._card.request_refresh()
+        except asyncio.CancelledError:
+            pass
 
 
 class FavoritesController:
-    """Favourite-media key controller.
+    """Favourite-media keys -- one :class:`DuiKey` per catalog entry.
 
-    Loads the ``PictureKey.dui`` package and creates one
-    :class:`~deckui.DuiKey` per favourite.  Clicking a key calls
-    :meth:`AudioController.play` with the associated track.
+    Loads ``PictureKey.dui`` once and instantiates a key per favourite.
+    Clicking a key calls :meth:`AudioController.play` with the matching
+    track.  The audio controller refreshes the AudioCard automatically
+    via ``card.request_refresh()`` -- which now works from key handlers
+    too thanks to the deck wiring callbacks on every key/card.
 
     Parameters
     ----------
@@ -652,7 +729,7 @@ class FavoritesController:
     audio : AudioController
         The audio controller that handles playback.
     packages_dir : Path | None
-        Directory containing ``.dui`` packages.
+        Directory containing ``PictureKey.dui``.
     """
 
     def __init__(
@@ -670,11 +747,12 @@ class FavoritesController:
         for media in self._catalog:
             key = DuiKey(self._spec)
 
-            # Load the album cover and set it on the key
             cover_path = pkg_dir / media["cover"]
             if cover_path.exists():
                 key.set("picture", Image.open(cover_path))
 
+            # Late-bind *media* per iteration so each handler captures
+            # its own dict instead of the loop variable.
             @key.on_event("click")
             async def _click(m: dict[str, str] = media) -> None:
                 log.info("Favourite pressed: %s -- %s", m["artist"], m["title"])
@@ -688,86 +766,324 @@ class FavoritesController:
         return list(self._keys)
 
     def install(self, screen: Any, positions: list[int]) -> None:
-        """Place favourite keys onto a screen at the given positions.
+        """Place favourite keys onto *screen* at the given *positions*.
 
-        Only installs as many keys as there are positions (or keys),
-        whichever is fewer.
-
-        Parameters
-        ----------
-        screen
-            The :class:`~deckui.ui.screen.Screen` to install keys on.
-        positions : list[int]
-            Key indices to place the favourite keys at.
+        Installs ``min(len(keys), len(positions))`` keys.
         """
         for pos, key in zip(positions, self._keys, strict=False):
             screen.set_key(pos, key)
 
 
-# ===================================================================
-# Main application
-# ===================================================================
+class SceneController:
+    """Scene-activation keys -- one :class:`DuiKey` per scene definition.
 
+    Loads ``IconKey.dui`` once and instantiates a key per scene.  Each
+    key's click handler logs the scene name; replace the body with your
+    own automation.
 
-async def run() -> None:
-    """Start the Stream Deck demo application.
-
-    Creates controllers, registers connect/disconnect handlers, and runs
-    until interrupted.  Works with any Stream Deck model -- touchscreen
-    cards are only installed when the device supports them.
+    Parameters
+    ----------
+    scenes : list[dict[str, str]]
+        Scene definitions, each with ``label`` and ``icon`` (an Iconify
+        identifier such as ``"mdi:cinema"``).
+    packages_dir : Path | None
+        Directory containing ``IconKey.dui``.
     """
-    audio = AudioController(MEDIA_CATALOG, initial_volume=0.3)
-    lights = LightsController(brightness=80, kelvin=4000)
-    timer = TimerController(initial_seconds=300)
-    dashboard = DashboardController(deck_brightness=60)
-    scenes = SceneController(SCENE_DEFS)
-    favorites = FavoritesController(MEDIA_CATALOG, audio)
 
-    manager = DeckManager(brightness=60, auto_reconnect=True)
+    def __init__(
+        self,
+        scenes: list[dict[str, str]],
+        packages_dir: Path | None = None,
+    ) -> None:
+        self._scenes = scenes
+        pkg_dir = packages_dir or EXAMPLES_DIR
+        self._spec = load_package(pkg_dir / "IconKey.dui")
+        self._keys: list[DuiKey] = []
 
-    @manager.on_connect()
-    async def on_deck_connect(deck: Any) -> None:
-        """Handle a new deck connection -- set up the full UI."""
+        for scene in self._scenes:
+            key = DuiKey(self._spec)
+            key.set_many(label=scene["label"], icon=scene["icon"])
+
+            @key.on_event("click")
+            async def _click(name: str = scene["label"]) -> None:
+                log.info("Scene activated: %s", name)
+
+            self._keys.append(key)
+
+    @property
+    def keys(self) -> list[DuiKey]:
+        """The created scene keys (same order as *scenes*)."""
+        return list(self._keys)
+
+    def install(self, screen: Any, positions: list[int]) -> None:
+        """Place scene keys onto *screen* at the given *positions*."""
+        for pos, key in zip(positions, self._keys, strict=False):
+            screen.set_key(pos, key)
+
+
+class NavigationController:
+    """A single key that toggles the deck between two screens.
+
+    Demonstrates :meth:`Deck.set_screen` -- screens are independent
+    layouts that swap atomically, so you can reuse the same physical
+    keys/encoders for completely different functionality.
+
+    Parameters
+    ----------
+    primary : str
+        Name of the primary screen.
+    secondary : str
+        Name of the secondary screen.
+    label_primary, label_secondary : str
+        Labels shown on the key in each mode.
+    icon_primary, icon_secondary : str
+        Iconify icons shown in each mode.
+    packages_dir : Path | None
+        Directory containing ``IconKey.dui``.
+    """
+
+    def __init__(
+        self,
+        primary: str,
+        secondary: str,
+        *,
+        label_primary: str = "Settings",
+        label_secondary: str = "Back",
+        icon_primary: str = "mdi:cog",
+        icon_secondary: str = "mdi:arrow-left",
+        packages_dir: Path | None = None,
+    ) -> None:
+        pkg_dir = packages_dir or EXAMPLES_DIR
+        self._primary = primary
+        self._secondary = secondary
+        self._labels = (label_primary, label_secondary)
+        self._icons = (icon_primary, icon_secondary)
+        self._deck: Any = None
+        self._on_secondary = False
+
+        self._key = DuiKey(load_package(pkg_dir / "IconKey.dui"))
+        self._render_label()
+
+        @self._key.on_event("click")
+        async def _click() -> None:
+            await self._toggle()
+
+    @property
+    def key(self) -> DuiKey:
+        """The navigation :class:`DuiKey`."""
+        return self._key
+
+    def bind_deck(self, deck: Any) -> None:
+        """Attach the deck so the controller can call ``set_screen``."""
+        self._deck = deck
+
+    async def _toggle(self) -> None:
+        """Swap between primary and secondary screens."""
+        if self._deck is None:
+            return
+        target = self._primary if self._on_secondary else self._secondary
+        self._on_secondary = not self._on_secondary
+        self._render_label()
+        log.info("Navigating to screen: %s", target)
+        await self._deck.set_screen(target)
+
+    def _render_label(self) -> None:
+        """Update the key label/icon for the current mode."""
+        idx = 1 if self._on_secondary else 0
+        self._key.set_many(label=self._labels[idx], icon=self._icons[idx])
+
+
+# ===========================================================================
+# Application
+# ===========================================================================
+
+
+class StreamDeckApp:
+    """Top-level demo app -- glues controllers to the deck.
+
+    Build the controllers once, then :meth:`build_screens` is called from
+    the manager's ``on_connect`` callback to install them on the
+    appropriate screens for the connected device.
+
+    Parameters
+    ----------
+    catalog : list[dict[str, str]]
+        Media catalog used by the audio + favourites controllers.
+    scene_defs : list[dict[str, str]]
+        Scene definitions used by the scene controller.
+    packages_dir : Path | None
+        Directory containing the ``.dui`` packages.
+    """
+
+    def __init__(
+        self,
+        catalog: list[dict[str, str]],
+        scene_defs: list[dict[str, str]],
+        packages_dir: Path | None = None,
+    ) -> None:
+        self._packages_dir = packages_dir or EXAMPLES_DIR
+        self.audio = AudioController(
+            catalog, initial_volume=0.3, packages_dir=self._packages_dir
+        )
+        self.lights = LightsController(
+            brightness=80, kelvin=4000, packages_dir=self._packages_dir
+        )
+        self.timer = TimerController(
+            initial_seconds=300, packages_dir=self._packages_dir
+        )
+        self.dashboard = DashboardController(
+            deck_brightness=60, packages_dir=self._packages_dir
+        )
+        self.favorites = FavoritesController(
+            catalog, self.audio, packages_dir=self._packages_dir
+        )
+        self.scenes = SceneController(
+            scene_defs, packages_dir=self._packages_dir
+        )
+        self.nav = NavigationController(
+            primary="main",
+            secondary="settings",
+            packages_dir=self._packages_dir,
+        )
+
+    async def on_connect(self, deck: Any) -> None:
+        """Configure screens for *deck* and start the demo.
+
+        Parameters
+        ----------
+        deck
+            The :class:`~deckui.runtime.deck.Deck` handle from the
+            manager's ``on_connect`` callback.
+        """
         caps = deck.capabilities
         log.info(
-            "Deck connected: %s (%d keys, %d encoders)",
+            "Deck connected: %s (%d keys, %d encoders, touchscreen=%s)",
             caps.deck_type,
             caps.key_count,
             caps.dial_count,
+            "yes" if caps.has_touchscreen else "no",
         )
 
-        dashboard.bind_deck(deck)
+        # Wire deck-aware controllers
+        self.dashboard.bind_deck(deck)
+        self.nav.bind_deck(deck)
+
+        # Build both screens up-front so the navigation controller can
+        # switch between them at any time.
+        self._build_main_screen(deck)
+        self._build_settings_screen(deck)
+
+        # Activate the main screen.  This also wires every key/card's
+        # request_refresh() to deck.refresh() under the hood.
+        await deck.set_screen("main")
+
+        # Start background tasks AFTER the screen is active so their
+        # request_refresh() calls go to the right place.
+        await self.timer.start_runtime()
+        await self.dashboard.start_runtime()
+
+        log.info("Deck ready -- try the encoders, keys, and Settings button!")
+
+    async def on_disconnect(self, info: DeviceInfo) -> None:
+        """Stop background tasks when the deck goes away."""
+        log.warning("Deck disconnected: %s -- waiting for reconnect...", info.serial)
+        await self.timer.stop_runtime()
+        await self.dashboard.stop_runtime()
+
+    # -- screen construction -------------------------------------------
+
+    def _build_main_screen(self, deck: Any) -> None:
+        """Layout: favourites + scenes on keys, all four cards on the strip.
+
+        Parameters
+        ----------
+        deck
+            Open deck handle.
+        """
+        caps = deck.capabilities
         screen = deck.screen("main")
 
-        # Touch-strip cards -- only on devices with encoders + touchscreen
         if screen.touch_strip is not None:
             screen.touch_strip.background_color = "#1c1c1c"
-            screen.set_card(0, audio.card)
-            screen.set_card(1, lights.card)
-            screen.set_card(2, timer.card)
-            screen.set_card(3, dashboard.card)
+            screen.set_card(0, self.audio.card)
+            screen.set_card(1, self.lights.card)
+            screen.set_card(2, self.timer.card)
+            screen.set_card(3, self.dashboard.card)
 
-        # Physical keys: 0-3 favourites, 4-7 scenes, rest empty
-        num_favs = min(len(MEDIA_CATALOG), caps.key_count)
-        num_scenes = min(len(SCENE_DEFS), max(0, caps.key_count - num_favs))
-        favorites.install(screen, list(range(num_favs)))
-        scenes.install(screen, list(range(num_favs, num_favs + num_scenes)))
+        # Favourites first, then scenes, then a single navigation key at
+        # the very last position if there's room.
+        num_favs = min(len(self.favorites.keys), caps.key_count)
+        remaining = max(0, caps.key_count - num_favs)
+        num_scenes = min(len(self.scenes.keys), remaining)
 
-        await deck.set_screen("main")
-        log.info("Deck ready!")
+        self.favorites.install(screen, list(range(num_favs)))
+        self.scenes.install(screen, list(range(num_favs, num_favs + num_scenes)))
+
+        # Reserve the last key for navigation if at least one slot is free.
+        nav_index = caps.key_count - 1
+        if nav_index >= num_favs + num_scenes:
+            screen.set_key(nav_index, self.nav.key)
+
+    def _build_settings_screen(self, deck: Any) -> None:
+        """Layout: just the navigation key + dashboard card.
+
+        Demonstrates that the same controller can appear on multiple
+        screens -- DeckUI does not care, it simply renders whatever's
+        installed when the screen is active.
+
+        Parameters
+        ----------
+        deck
+            Open deck handle.
+        """
+        screen = deck.screen("settings")
+        if screen.touch_strip is not None:
+            screen.touch_strip.background_color = "#0a0a0a"
+            screen.set_card(0, self.dashboard.card)
+            screen.set_card(1, self.lights.card)
+
+        # Place the navigation key at slot 0 so users always know where
+        # to go to get back.
+        if deck.capabilities.key_count > 0:
+            screen.set_key(0, self.nav.key)
+
+
+# ===========================================================================
+# Entry point
+# ===========================================================================
+
+
+async def run() -> None:
+    """Build the app, attach to :class:`DeckManager`, and run forever.
+
+    This is the canonical DeckUI lifecycle:
+
+    1. Construct your controllers.
+    2. Create a :class:`DeckManager`.
+    3. Register ``on_connect`` / ``on_disconnect`` handlers.
+    4. ``async with`` the manager and ``await manager.wait_closed()``.
+    """
+    app = StreamDeckApp(MEDIA_CATALOG, SCENE_DEFS)
+    manager = DeckManager(brightness=60, auto_reconnect=True)
+
+    @manager.on_connect()
+    async def _on_connect(deck: Any) -> None:
+        await app.on_connect(deck)
 
     @manager.on_disconnect
-    async def on_deck_disconnect(info: DeviceInfo) -> None:
-        """Log when a deck disconnects."""
-        log.warning("Deck disconnected: %s -- waiting for reconnect...", info.serial)
+    async def _on_disconnect(info: DeviceInfo) -> None:
+        await app.on_disconnect(info)
 
     async with manager:
         await manager.wait_closed()
 
 
 def main() -> None:
-    """Entry point for the Stream Deck demo."""
-    asyncio.run(run())
+    """Entry point for ``python examples/streamdeck.py``."""
+    try:
+        asyncio.run(run())
+    except KeyboardInterrupt:
+        log.info("Bye!")
 
 
 if __name__ == "__main__":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - Architecture: architecture.md
   - Guides:
       - Creating DUI Packages: guides/creating-dui-packages.md
+  - Example: example.md
   - API Reference: reference/
 
 plugins:
@@ -43,3 +44,20 @@ plugins:
             members_order: source
             show_root_heading: true
             show_root_full_path: false
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path: ["."]
+      check_paths: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true

--- a/src/deckui/dui/card.py
+++ b/src/deckui/dui/card.py
@@ -270,7 +270,7 @@ class DuiCard(Card):
         """
 
         def decorator(fn: AsyncHandler) -> AsyncHandler:
-            self._events.on(event_name, fn)
+            self._events.on(event_name, self._wrap_handler(fn))
             return fn
 
         return decorator
@@ -285,7 +285,44 @@ class DuiCard(Card):
         handler
             The async callable to invoke.
         """
-        self._events.on(event_name, handler)
+        self._events.on(event_name, self._wrap_handler(handler))
+
+    def _wrap_handler(self, fn: AsyncHandler) -> AsyncHandler:
+        """Wrap *fn* so any state changes trigger a refresh after it runs.
+
+        For events dispatched synchronously from the deck's event loop
+        (key press, encoder press, non-accumulated turns) the deck
+        already calls ``refresh()`` when the card is dirty after the
+        handler runs.  But several event paths fire from detached
+        asyncio tasks where the dispatcher is no longer in scope:
+
+        * Accumulator flushes (``accumulate: true`` encoder turns).
+        * Hold timers (``encoder_hold`` / ``key_hold``).
+
+        Without this wrapper, those handlers can mutate bindings
+        without ever triggering a render -- the user's display goes
+        silently stale (e.g. brightness slider lagging behind rapid
+        encoder spins).  Wrapping at the registration boundary makes
+        every handler self-refreshing, regardless of how it's
+        dispatched.
+
+        The wrapper:
+
+        * Is a no-op when no refresh callback is wired (i.e. before the
+          card is installed on a screen).
+        * Is idempotent when the handler already calls
+          :meth:`request_refresh` itself -- the second call finds the
+          card clean and skips re-rendering.
+        """
+
+        async def _wrapped(*args: Any, **kwargs: Any) -> None:
+            await fn(*args, **kwargs)
+            if self.is_dirty:
+                await self.request_refresh()
+
+        # Preserve the original for testing / introspection.
+        _wrapped.__wrapped__ = fn  # type: ignore[attr-defined]
+        return _wrapped
 
     def render(self) -> Image.Image:
         """Render the SVG layout with current bindings to a PIL Image.

--- a/src/deckui/dui/key.py
+++ b/src/deckui/dui/key.py
@@ -270,7 +270,7 @@ class DuiKey(KeySlot):
         """
 
         def decorator(fn: AsyncHandler) -> AsyncHandler:
-            self._events.on(event_name, fn)
+            self._events.on(event_name, self._wrap_handler(fn))
             return fn
 
         return decorator
@@ -285,7 +285,25 @@ class DuiKey(KeySlot):
         handler
             The async callable to invoke.
         """
-        self._events.on(event_name, handler)
+        self._events.on(event_name, self._wrap_handler(handler))
+
+    def _wrap_handler(self, fn: AsyncHandler) -> AsyncHandler:
+        """Wrap *fn* so any state changes trigger a refresh after it runs.
+
+        Mirrors :meth:`DuiCard._wrap_handler`.  Without this, hold-timer
+        handlers (``key_hold``) -- which fire from a detached asyncio
+        task -- would mutate bindings without ever triggering a render.
+        Wrapping at the registration boundary makes every handler
+        self-refreshing regardless of how it's dispatched.
+        """
+
+        async def _wrapped(*args: Any, **kwargs: Any) -> None:
+            await fn(*args, **kwargs)
+            if self.is_dirty:
+                await self.request_refresh()
+
+        _wrapped.__wrapped__ = fn  # type: ignore[attr-defined]
+        return _wrapped
 
     def render_image(
         self,

--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -267,6 +267,11 @@ class Deck:
     async def set_screen(self, name: str) -> None:
         """Switch to a named screen, rendering all keys and cards.
 
+        Wires up refresh callbacks on every key and card so that any
+        handler or background task can call ``request_refresh()`` to
+        trigger a re-render without needing a direct reference to the
+        deck.
+
         Parameters
         ----------
         name
@@ -278,11 +283,30 @@ class Deck:
         self._active_screen = self._screens[name]
         logger.info("Switching to screen: %s", name)
 
+        self._wire_refresh_callbacks()
+
         await self._render_all_keys()
         if self._active_screen.touch_strip is not None:
             await self._render_touchscreen()
         if self._active_screen.info_screen is not None:
             await self._render_info_screen()
+
+    def _wire_refresh_callbacks(self) -> None:
+        """Register ``self.refresh`` on every key and card of the active screen.
+
+        Called by :meth:`set_screen`.  Allows handlers and background
+        tasks to call :meth:`KeySlot.request_refresh` /
+        :meth:`Card.request_refresh` to trigger re-renders without
+        needing a direct deck reference.
+        """
+        screen = self._active_screen
+        if screen is None:
+            return
+        for key_slot in screen.keys.values():
+            key_slot.set_refresh_callback(self.refresh)
+        if screen.touch_strip is not None:
+            for card in screen.touch_strip.cards:
+                card.set_refresh_callback(self.refresh)
 
     @property
     def active_screen(self) -> Screen | None:
@@ -583,7 +607,6 @@ class Deck:
                 await encoder.dispatch_press(event.pressed)
             if screen.touch_strip is not None:
                 card = screen.touch_strip.card(event.encoder)
-                card.set_refresh_callback(self.refresh)
                 if event.pressed:
                     await card.dispatch_encoder_press()
                 else:

--- a/src/deckui/ui/controls/key_slot.py
+++ b/src/deckui/ui/controls/key_slot.py
@@ -29,11 +29,35 @@ class KeySlot:
         self._release_handler: AsyncHandler | None = None
         self._image_bytes: bytes | None = None
         self._dirty = True
+        self._request_refresh: AsyncHandler | None = None
 
     @property
     def index(self) -> int:
         """The key index on the device."""
         return self._index
+
+    def set_refresh_callback(self, callback: AsyncHandler) -> None:
+        """Register an async callback the key can invoke to request a refresh.
+
+        This is set automatically by :class:`~deckui.runtime.deck.Deck`
+        when a screen is activated, so any code path (key handler,
+        background task, external state change) can call
+        :meth:`request_refresh` to trigger a re-render.
+
+        Parameters
+        ----------
+        callback
+            Async callable that triggers a deck refresh.
+        """
+        self._request_refresh = callback
+
+    async def request_refresh(self) -> None:
+        """Ask the deck to re-render the active screen.
+
+        No-op if no refresh callback has been registered.
+        """
+        if self._request_refresh is not None:
+            await self._request_refresh()
 
     def on_press(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for key press events.

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -126,6 +126,45 @@ class TestDeckActivePage:
         assert deck.active_screen is None
 
 
+class TestDeckWireRefreshCallbacks:
+    """Tests for the screen-wide refresh-callback wiring."""
+
+    async def test_wires_keys_and_cards_on_set_screen(self, deck):
+        """set_screen wires deck.refresh on every key and card."""
+        screen = deck.screen("main")
+        key = screen.key(0)
+        card = _TestCard(0)
+        screen.set_card(0, card)
+
+        deck._render_all_keys = AsyncMock()
+        deck._render_touchscreen = AsyncMock()
+
+        # Patch BEFORE set_screen so the bound method captured by the
+        # wiring is the mock.
+        with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
+            await deck.set_screen("main")
+            await key.request_refresh()
+            await card.request_refresh()
+            assert mock_refresh.await_count == 2
+
+    async def test_request_refresh_from_key_handler_triggers_refresh(self, deck):
+        """A key handler can call request_refresh after set_screen."""
+        screen = deck.screen("main")
+        key = screen.key(0)
+
+        deck._render_all_keys = AsyncMock()
+        deck._render_touchscreen = AsyncMock()
+
+        @key.on_press
+        async def _press() -> None:
+            await key.request_refresh()
+
+        with patch.object(deck, "refresh", new_callable=AsyncMock) as mock_refresh:
+            await deck.set_screen("main")
+            await deck._dispatch(KeyEvent(key=0, pressed=True))
+            mock_refresh.assert_awaited()
+
+
 class TestDeckRefresh:
     async def test_no_active_screen(self, deck):
         """refresh() is a no-op when no active page."""

--- a/tests/test_dui_card.py
+++ b/tests/test_dui_card.py
@@ -374,7 +374,10 @@ class TestDuiCardEvents:
         card.handle_encoder_press()
         callbacks = card.drain_pending_callbacks()
         assert len(callbacks) == 1
-        assert callbacks[0][0] is handler
+        # The registered callable wraps the user's handler so any
+        # state changes auto-trigger a refresh; the original handler
+        # is preserved on the wrapper for introspection.
+        assert callbacks[0][0].__wrapped__ is handler
 
     def test_encoder_turn_routes_to_handler(self):
         spec = _make_card_spec(
@@ -519,3 +522,137 @@ class TestDuiCardDirtyTracking:
         card.set_rendered(img)
         assert card.is_dirty is False
         assert card.rendered is img
+
+
+class TestDuiCardHandlerAutoRefresh:
+    """Registered handlers that mutate state must auto-trigger a refresh.
+
+    Regression tests for the bug where accumulator-driven and hold-timer
+    handlers fired from detached asyncio tasks, mutating bindings without
+    ever causing a render.
+    """
+
+    @pytest.fixture
+    def card(self):
+        spec = _make_card_spec(
+            bindings={"title": TextBinding(node="title", default="")},
+            events=(
+                EventMapping(
+                    name="bump",
+                    source="encoder_turn",
+                    direction="right",
+                    accumulate=True,
+                ),
+                EventMapping(name="press", source="encoder_press"),
+                EventMapping(name="hold", source="encoder_hold", hold_ms=50),
+            ),
+        )
+        return DuiCard(spec)
+
+    async def test_handler_dirties_card_triggers_refresh(self, card):
+        """Wrapper calls request_refresh when handler leaves card dirty."""
+        refreshed = 0
+
+        async def _refresh() -> None:
+            nonlocal refreshed
+            refreshed += 1
+            card.mark_clean()
+
+        card.set_refresh_callback(_refresh)
+        card.mark_clean()
+
+        @card.on("press")
+        async def _press():
+            card.set("title", "changed")
+
+        # Invoke the wrapped handler directly (mirrors what
+        # accumulator/hold tasks do once they fire).
+        card.handle_encoder_press()
+        for handler, args in card.drain_pending_callbacks():
+            await handler(*args)
+
+        assert refreshed == 1
+
+    async def test_clean_handler_no_extra_refresh(self, card):
+        """Wrapper is a no-op when the handler doesn't dirty the card."""
+        refreshed = 0
+
+        async def _refresh() -> None:
+            nonlocal refreshed
+            refreshed += 1
+            card.mark_clean()
+
+        card.set_refresh_callback(_refresh)
+        card.mark_clean()
+
+        @card.on("press")
+        async def _press():
+            pass  # no state change
+
+        card.handle_encoder_press()
+        for handler, args in card.drain_pending_callbacks():
+            await handler(*args)
+
+        assert refreshed == 0
+
+    async def test_explicit_request_refresh_not_doubled(self, card):
+        """A handler that calls request_refresh itself doesn't trigger a 2nd refresh.
+
+        After the handler's explicit refresh, the deck (here, the stub)
+        marks the card clean.  The wrapper's post-call dirty check then
+        finds nothing to do, so we get exactly one refresh -- not two.
+        """
+        refreshed = 0
+
+        async def _refresh() -> None:
+            nonlocal refreshed
+            refreshed += 1
+            card.mark_clean()
+
+        card.set_refresh_callback(_refresh)
+        card.mark_clean()
+
+        @card.on("press")
+        async def _press():
+            card.set("title", "changed")
+            await card.request_refresh()
+
+        card.handle_encoder_press()
+        for handler, args in card.drain_pending_callbacks():
+            await handler(*args)
+
+        assert refreshed == 1
+
+    async def test_accumulator_flush_triggers_refresh(self, card):
+        """The whole point: accumulated turns refresh after the debounce.
+
+        Before this fix, the flush task fired the user's callback in a
+        detached coroutine that never re-entered the dispatcher, so a
+        rapid encoder spin could leave the display stale.
+        """
+        import asyncio
+
+        refreshed = 0
+
+        async def _refresh() -> None:
+            nonlocal refreshed
+            refreshed += 1
+            card.mark_clean()
+
+        card.set_refresh_callback(_refresh)
+        card.mark_clean()
+
+        @card.on("bump")
+        async def _bump(_steps: int):
+            card.set("title", "changed")
+
+        # Simulate a burst of 5 ticks; the accumulator collapses them
+        # into one debounced call to the wrapped handler.
+        for _ in range(5):
+            card.handle_encoder_turn(1)
+        # Wait for the default 0.25s debounce window to elapse plus
+        # a tiny buffer for the flush task to run.
+        await asyncio.sleep(0.4)
+
+        assert refreshed == 1
+        assert card.get("title") == "changed"

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -657,13 +657,22 @@ class TestSceneController:
     async def test_press_release_requests_refresh(
         self, ctrl: SceneController
     ) -> None:
-        """Press and release each call request_refresh on the key."""
+        """Press and release each call request_refresh on the key.
+
+        The stub mimics ``Deck.refresh`` by clearing the dirty flag,
+        which is what makes the auto-refresh wrapper idempotent in
+        production: when a handler explicitly calls ``request_refresh``,
+        the card is rendered and marked clean, so the wrapper's
+        post-handler ``if is_dirty: refresh()`` check finds nothing to
+        do.
+        """
         key = ctrl.keys[0]
         refreshes = 0
 
         async def _refresh() -> None:
             nonlocal refreshes
             refreshes += 1
+            key.mark_clean()
 
         key.set_refresh_callback(_refresh)
         await key.dispatch(pressed=True)

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -11,6 +11,7 @@ import pytest
 from deckui.dui.card import DuiCard
 from deckui.dui.key import DuiKey
 from deckui.dui.schema import (
+    ColorBinding,
     EventMapping,
     IconifyBinding,
     ImageBinding,
@@ -82,9 +83,12 @@ _DASH_SVG = (
 
 _KEY_SVG = (
     '<svg id="TestKey" xmlns="http://www.w3.org/2000/svg" width="120" height="120">'
-    '<rect id="background" width="120" height="120" fill="#1c1c1c"/>'
+    '<rect id="background" color="#1c1c1c" fill="currentColor" '
+    'width="120" height="120"/>'
+    '<g id="foreground" color="#dedede">'
     '<g id="icon"></g>'
-    '<text id="label" x="60" y="100" font-size="14" fill="#fff">Key</text>'
+    '<text id="label" x="60" y="100" font-size="14" fill="currentColor">Key</text>'
+    "</g>"
     "</svg>"
 )
 
@@ -292,7 +296,9 @@ def _iconkey_spec() -> PackageSpec:
     Returns
     -------
     PackageSpec
-        Spec with label, icon bindings and click event.
+        Spec mirroring ``IconKey.dui`` -- label, icon, background and
+        foreground colour bindings, plus ``click``, ``press``, and
+        ``release`` events.
     """
     return PackageSpec(
         name="IconKey",
@@ -302,9 +308,17 @@ def _iconkey_spec() -> PackageSpec:
         bindings={
             "label": TextBinding(node="label", default="Key"),
             "icon": IconifyBinding(node="icon", size=55, default="ph:placeholder-bold"),
+            "background": ColorBinding(
+                node="background", attribute="color", default="#1c1c1c"
+            ),
+            "foreground": ColorBinding(
+                node="foreground", attribute="color", default="#dedede"
+            ),
         },
         events=(
             EventMapping(name="click", source="key_press_release", max_duration_ms=300),
+            EventMapping(name="press", source="key_press"),
+            EventMapping(name="release", source="key_release"),
         ),
     )
 
@@ -618,6 +632,53 @@ class TestSceneController:
         screen = MagicMock()
         ctrl.install(screen, list(range(10)))
         assert screen.set_key.call_count == len(SCENE_DEFS)
+
+    def test_initial_colors_are_defaults(self, ctrl: SceneController) -> None:
+        """Each key starts with default background/foreground colors."""
+        for key in ctrl.keys:
+            assert key.get("background") == SceneController.DEFAULT_BACKGROUND
+            assert key.get("foreground") == SceneController.DEFAULT_FOREGROUND
+
+    async def test_press_swaps_colors(self, ctrl: SceneController) -> None:
+        """key.dispatch(pressed=True) swaps fg/bg via the press handler."""
+        key = ctrl.keys[0]
+        await key.dispatch(pressed=True)
+        assert key.get("background") == SceneController.DEFAULT_FOREGROUND
+        assert key.get("foreground") == SceneController.DEFAULT_BACKGROUND
+
+    async def test_release_restores_colors(self, ctrl: SceneController) -> None:
+        """A release after a press restores the original colors."""
+        key = ctrl.keys[0]
+        await key.dispatch(pressed=True)
+        await key.dispatch(pressed=False)
+        assert key.get("background") == SceneController.DEFAULT_BACKGROUND
+        assert key.get("foreground") == SceneController.DEFAULT_FOREGROUND
+
+    async def test_press_release_requests_refresh(
+        self, ctrl: SceneController
+    ) -> None:
+        """Press and release each call request_refresh on the key."""
+        key = ctrl.keys[0]
+        refreshes = 0
+
+        async def _refresh() -> None:
+            nonlocal refreshes
+            refreshes += 1
+
+        key.set_refresh_callback(_refresh)
+        await key.dispatch(pressed=True)
+        await key.dispatch(pressed=False)
+        assert refreshes == 2
+
+    async def test_each_key_has_independent_handlers(
+        self, ctrl: SceneController
+    ) -> None:
+        """Closure capture is per-key: pressing one key only affects that key."""
+        first, second = ctrl.keys[0], ctrl.keys[1]
+        await first.dispatch(pressed=True)
+        # First is inverted, second is untouched.
+        assert first.get("background") == SceneController.DEFAULT_FOREGROUND
+        assert second.get("background") == SceneController.DEFAULT_BACKGROUND
 
 
 # ===================================================================

--- a/tests/test_key_slot.py
+++ b/tests/test_key_slot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 from deckui.ui.controls.key_slot import KeySlot
 
 
@@ -48,6 +50,19 @@ class TestKeySlotEventHandlers:
             pass
 
         assert key_slot._release_handler is handler
+
+
+class TestKeySlotRefreshCallback:
+    async def test_request_refresh_no_callback(self, key_slot: KeySlot):
+        """request_refresh is a no-op when no callback is registered."""
+        await key_slot.request_refresh()
+
+    async def test_set_and_request_refresh(self, key_slot: KeySlot):
+        """request_refresh awaits the registered callback."""
+        cb = AsyncMock()
+        key_slot.set_refresh_callback(cb)
+        await key_slot.request_refresh()
+        cb.assert_awaited_once()
 
 
 class TestKeySlotRendering:


### PR DESCRIPTION
## Summary

Rewrites `examples/streamdeck.py` to be a clean, accurate tutorial of the DeckUI library and fixes a small library limitation that prevented cards from refreshing when state changed outside of an encoder press.

## Library changes

- **`Deck._wire_refresh_callbacks`** is now called from `Deck.set_screen` to register `self.refresh` as the `request_refresh` callback on every key and card on the active screen. Previously the callback was only set during the encoder-press dispatch path, which meant that calling `card.request_refresh()` from a key handler or background task was a silent no-op until the user pressed the corresponding encoder.
- **`KeySlot.set_refresh_callback` / `KeySlot.request_refresh`** mirror the existing `Card` API so any key handler can request a redraw.

## Example changes

- **TimerCard is now a real countdown.** Starting the timer kicks off an asyncio task that decrements `remaining` once per second and calls `card.request_refresh()`, so the display updates live. The task is cancelled cleanly on disconnect.
- **DashboardCard ticks every second** to keep the displayed clock accurate, only marking the card dirty when the visible value actually changes.
- **Favorite-key press now refreshes the AudioCard immediately** (previously it only updated after pressing the audio encoder), thanks to the library wiring fix above.
- **New `NavigationController`** + **settings screen** demonstrate `Deck.set_screen` for multi-layout decks.
- **Use `DuiCard` helpers consistently**: `set_many`, `set_range`, `adjust_range` instead of manual percentage normalisation.
- **Restructure** under a single `StreamDeckApp` that bundles controllers and exposes `on_connect` / `on_disconnect` lifecycle hooks. Docstrings updated to read top-to-bottom as a tutorial.

## Testing

- All existing tests pass (1115 tests).
- New tests cover `KeySlot.set_refresh_callback` / `request_refresh` and the screen-wide refresh wiring.
- Coverage: 96.94% (threshold 95%).
- `ruff check .` passes.
- `mypy src` passes.