### PR TITLE
Cycle screens via dashboard encoder, drop nav key

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -26,7 +26,9 @@ action is logged to the console.
 - **A live dashboard clock** that updates only when the displayed value
   changes.
 - **Multi-screen navigation** — a `main` screen and a `settings` screen
-  swap atomically via `Deck.set_screen`.
+  swap atomically via `Deck.set_screen`. The dashboard encoder's
+  press-release cycles screens via the `next_screen` event declared in
+  `DashboardCard.dui` — no key needed.
 - **All three key event sources** — `press`, `release`, and the
   higher-level `click`. Scene keys flash their colours while held to
   prove that all three fire.
@@ -44,8 +46,9 @@ StreamDeckApp
 ├── TimerController        ── TimerCard.dui      (touch-strip card 2)
 ├── DashboardController    ── DashboardCard.dui  (touch-strip card 3)
 ├── FavoritesController    ── PictureKey.dui     (keys 0..N favourites)
-├── SceneController        ── IconKey.dui        (keys after favourites)
-└── NavigationController   ── IconKey.dui        (last key, screen switch)
+├── SceneController        ── IconKey.dui        (remaining keys)
+└── ScreenCycler           ── (no widget; bound to dashboard's
+                                 ``next_screen`` event)
 ```
 
 Controllers never talk to the deck directly. They mutate their card's
@@ -128,20 +131,42 @@ async def _click():
     log.info("Scene activated: %s", label)
 ```
 
-### Two screens, one set of controllers
+### Two screens, cycled by an encoder press
 
-`NavigationController` swaps between a busy `main` screen (favourites,
-scenes, all four cards) and a focused `settings` screen (just the
-dashboard and lights). The same controllers appear on both — DeckUI
-re-renders whatever is installed on the active screen.
+`ScreenCycler` swaps between a busy `main` screen (favourites, scenes,
+all four cards) and a focused `settings` screen (dashboard and lights
+only). The same controllers appear on both — DeckUI re-renders
+whatever is installed on the active screen.
+
+The cycler doesn't own any widget. Instead, `DashboardCard.dui`
+declares a `next_screen` event mapped to an encoder press-release, and
+the cycler binds a handler to that event:
 
 ```python
-async def _toggle(self) -> None:
-    target = self._primary if self._on_secondary else self._secondary
-    self._on_secondary = not self._on_secondary
-    self._render_label()
-    await self._deck.set_screen(target)
+class ScreenCycler:
+    def attach(self, card: DuiCard, event: str = "next_screen") -> None:
+        @card.on(event)
+        async def _trigger() -> None:
+            await self.advance()
+
+    async def advance(self) -> None:
+        if self._deck is None:
+            return
+        self._index = (self._index + 1) % len(self._screens)
+        await self._deck.set_screen(self._screens[self._index])
 ```
+
+The corresponding manifest fragment in `DashboardCard.dui`:
+
+```yaml
+events:
+  - name: next_screen
+    source: encoder_press_release
+    max_duration_ms: 250
+```
+
+This keeps every key slot available for favourites and scenes while
+still giving the user a one-press way to flip between layouts.
 
 ## Try it
 
@@ -158,7 +183,7 @@ Once running, here are some interactions to try:
 | Click the timer encoder | Start or pause the countdown |
 | Hold the timer encoder | Reset the timer |
 | Turn the timer encoder | Add/remove 30 seconds |
-| Press the Settings key | Switch to the settings screen |
+| Press the dashboard encoder | Cycle to the next screen |
 
 ## Full source
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -135,8 +135,10 @@ async def _click():
 
 `ScreenCycler` swaps between a busy `main` screen (favourites, scenes,
 all four cards) and a focused `settings` screen (dashboard and lights
-only). The same controllers appear on both — DeckUI re-renders
-whatever is installed on the active screen.
+only). The dashboard card stays in the same slot on every screen so
+the encoder used to cycle screens is always the rightmost one. The
+same controllers appear on both — DeckUI re-renders whatever is
+installed on the active screen.
 
 The cycler doesn't own any widget. Instead, `DashboardCard.dui`
 declares a `next_screen` event mapped to an encoder press-release, and

--- a/examples/DashboardCard.dui/manifest.yaml
+++ b/examples/DashboardCard.dui/manifest.yaml
@@ -55,6 +55,10 @@ events:
     accumulate: true
     accumulate_delay: 0.05
 
+  - name: next_screen
+    source: encoder_press_release
+    max_duration_ms: 250
+    
 regions:
   card:
     x: 0

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -17,7 +17,9 @@ What it demonstrates
   :meth:`~deckui.DuiCard.request_refresh`.
 * A live, asyncio-driven countdown ``TimerCard`` and a dashboard clock
   that ticks every second.
-* Multi-screen navigation -- a ``main`` screen and a ``settings`` screen.
+* Multi-screen navigation -- a ``main`` screen and a ``settings``
+  screen, cycled by an encoder press-release on the dashboard card
+  (see ``DashboardCard.dui``'s ``next_screen`` event).
 
 Running
 -------
@@ -873,76 +875,74 @@ class SceneController:
             screen.set_key(pos, key)
 
 
-class NavigationController:
-    """A single key that toggles the deck between two screens.
+class ScreenCycler:
+    """Cycles the deck through a list of screens.
 
-    Demonstrates :meth:`Deck.set_screen` -- screens are independent
-    layouts that swap atomically, so you can reuse the same physical
-    keys/encoders for completely different functionality.
+    Wires itself to a card event (the dashboard's ``next_screen`` event,
+    emitted by an encoder press-release) and advances to the next screen
+    on each trigger, wrapping around at the end.
+
+    Demonstrates two ideas at once:
+
+    * :meth:`Deck.set_screen` -- screens are independent layouts that
+      swap atomically, so the same encoders/keys can host completely
+      different functionality on each one.
+    * Card-level events -- a ``.dui`` package can declare arbitrary
+      events (here ``encoder_press_release`` named ``next_screen``) and
+      controllers bind handlers to them, with no key required.
 
     Parameters
     ----------
-    primary : str
-        Name of the primary screen.
-    secondary : str
-        Name of the secondary screen.
-    label_primary, label_secondary : str
-        Labels shown on the key in each mode.
-    icon_primary, icon_secondary : str
-        Iconify icons shown in each mode.
-    packages_dir : Path | None
-        Directory containing ``IconKey.dui``.
+    screens : list[str]
+        Ordered screen names. The cycler starts on the first one and
+        advances to the next on each trigger, wrapping around.
+
+    Raises
+    ------
+    ValueError
+        If *screens* is empty.
     """
 
-    def __init__(
-        self,
-        primary: str,
-        secondary: str,
-        *,
-        label_primary: str = "Settings",
-        label_secondary: str = "Back",
-        icon_primary: str = "mdi:cog",
-        icon_secondary: str = "mdi:arrow-left",
-        packages_dir: Path | None = None,
-    ) -> None:
-        pkg_dir = packages_dir or EXAMPLES_DIR
-        self._primary = primary
-        self._secondary = secondary
-        self._labels = (label_primary, label_secondary)
-        self._icons = (icon_primary, icon_secondary)
+    def __init__(self, screens: list[str]) -> None:
+        if not screens:
+            raise ValueError("ScreenCycler requires at least one screen")
+        self._screens = list(screens)
+        self._index = 0
         self._deck: Any = None
-        self._on_secondary = False
-
-        self._key = DuiKey(load_package(pkg_dir / "IconKey.dui"))
-        self._render_label()
-
-        @self._key.on_event("click")
-        async def _click() -> None:
-            await self._toggle()
 
     @property
-    def key(self) -> DuiKey:
-        """The navigation :class:`DuiKey`."""
-        return self._key
+    def current(self) -> str:
+        """Name of the screen the cycler currently points to."""
+        return self._screens[self._index]
 
     def bind_deck(self, deck: Any) -> None:
         """Attach the deck so the controller can call ``set_screen``."""
         self._deck = deck
 
-    async def _toggle(self) -> None:
-        """Swap between primary and secondary screens."""
+    def attach(self, card: DuiCard, event: str = "next_screen") -> None:
+        """Register the cycler on *card*'s *event*.
+
+        Parameters
+        ----------
+        card : DuiCard
+            Card whose event will trigger screen changes (typically the
+            dashboard card).
+        event : str, default="next_screen"
+            Name of the event declared in the card's manifest.
+        """
+
+        @card.on(event)
+        async def _trigger() -> None:
+            await self.advance()
+
+    async def advance(self) -> None:
+        """Move to the next screen, wrapping at the end."""
         if self._deck is None:
             return
-        target = self._primary if self._on_secondary else self._secondary
-        self._on_secondary = not self._on_secondary
-        self._render_label()
-        log.info("Navigating to screen: %s", target)
+        self._index = (self._index + 1) % len(self._screens)
+        target = self._screens[self._index]
+        log.info("Cycling to screen: %s", target)
         await self._deck.set_screen(target)
-
-    def _render_label(self) -> None:
-        """Update the key label/icon for the current mode."""
-        idx = 1 if self._on_secondary else 0
-        self._key.set_many(label=self._labels[idx], icon=self._icons[idx])
 
 
 # ===========================================================================
@@ -992,11 +992,10 @@ class StreamDeckApp:
         self.scenes = SceneController(
             scene_defs, packages_dir=self._packages_dir
         )
-        self.nav = NavigationController(
-            primary="main",
-            secondary="settings",
-            packages_dir=self._packages_dir,
-        )
+        # Cycle "main" -> "settings" -> back via the dashboard encoder
+        # press-release (the manifest declares it as ``next_screen``).
+        self.nav = ScreenCycler(["main", "settings"])
+        self.nav.attach(self.dashboard.card)
 
     async def on_connect(self, deck: Any) -> None:
         """Configure screens for *deck* and start the demo.
@@ -1062,8 +1061,9 @@ class StreamDeckApp:
             screen.set_card(2, self.timer.card)
             screen.set_card(3, self.dashboard.card)
 
-        # Favourites first, then scenes, then a single navigation key at
-        # the very last position if there's room.
+        # Favourites first, then scenes -- using every available key.
+        # Screen cycling is driven by the dashboard encoder, so no
+        # navigation key is needed.
         num_favs = min(len(self.favorites.keys), caps.key_count)
         remaining = max(0, caps.key_count - num_favs)
         num_scenes = min(len(self.scenes.keys), remaining)
@@ -1071,17 +1071,14 @@ class StreamDeckApp:
         self.favorites.install(screen, list(range(num_favs)))
         self.scenes.install(screen, list(range(num_favs, num_favs + num_scenes)))
 
-        # Reserve the last key for navigation if at least one slot is free.
-        nav_index = caps.key_count - 1
-        if nav_index >= num_favs + num_scenes:
-            screen.set_key(nav_index, self.nav.key)
-
     def _build_settings_screen(self, deck: Any) -> None:
-        """Layout: just the navigation key + dashboard card.
+        """Layout: focused settings view -- dashboard + lights cards only.
 
-        Demonstrates that the same controller can appear on multiple
+        Demonstrates that the same controllers can appear on multiple
         screens -- DeckUI does not care, it simply renders whatever's
-        installed when the screen is active.
+        installed when the screen is active. The dashboard card is
+        reused here so the user can keep cycling screens with its
+        encoder press-release.
 
         Parameters
         ----------
@@ -1093,11 +1090,6 @@ class StreamDeckApp:
             screen.touch_strip.background_color = "#0a0a0a"
             screen.set_card(0, self.dashboard.card)
             screen.set_card(1, self.lights.card)
-
-        # Place the navigation key at slot 0 so users always know where
-        # to go to get back.
-        if deck.capabilities.key_count > 0:
-            screen.set_key(0, self.nav.key)
 
 
 # ===========================================================================

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -1088,8 +1088,10 @@ class StreamDeckApp:
         screen = deck.screen("settings")
         if screen.touch_strip is not None:
             screen.touch_strip.background_color = "#0a0a0a"
-            screen.set_card(0, self.dashboard.card)
-            screen.set_card(1, self.lights.card)
+            # Keep the dashboard in the same slot on every screen so the
+            # encoder used to cycle screens is always the rightmost one.
+            screen.set_card(0, self.lights.card)
+            screen.set_card(3, self.dashboard.card)
 
 
 # ===========================================================================

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -34,6 +34,7 @@ from streamdeck import (
     FavoritesController,
     LightsController,
     SceneController,
+    ScreenCycler,
     TimerController,
 )
 
@@ -285,6 +286,11 @@ def _dash_spec() -> PackageSpec:
                 source="encoder_turn",
                 direction="left",
                 accumulate=True,
+            ),
+            EventMapping(
+                name="next_screen",
+                source="encoder_press_release",
+                max_duration_ms=250,
             ),
         ),
     )
@@ -730,3 +736,88 @@ class TestFavoritesController:
         screen = MagicMock()
         ctrl.install(screen, [0, 1])
         assert screen.set_key.call_count == 2
+
+
+# ===================================================================
+# ScreenCycler tests
+# ===================================================================
+
+
+class TestScreenCycler:
+    """Tests for the ScreenCycler controller."""
+
+    def test_rejects_empty_screen_list(self) -> None:
+        with pytest.raises(ValueError):
+            ScreenCycler([])
+
+    def test_starts_on_first_screen(self) -> None:
+        cycler = ScreenCycler(["main", "settings", "info"])
+        assert cycler.current == "main"
+
+    async def test_advance_wraps_around(self) -> None:
+        cycler = ScreenCycler(["a", "b", "c"])
+        deck = MagicMock()
+        deck.set_screen = AsyncMock()
+        cycler.bind_deck(deck)
+
+        await cycler.advance()
+        assert cycler.current == "b"
+        deck.set_screen.assert_awaited_with("b")
+
+        await cycler.advance()
+        assert cycler.current == "c"
+
+        await cycler.advance()
+        assert cycler.current == "a"
+        # Three calls in total, in order.
+        targets = [c.args[0] for c in deck.set_screen.await_args_list]
+        assert targets == ["b", "c", "a"]
+
+    async def test_advance_without_deck_is_noop(self) -> None:
+        cycler = ScreenCycler(["a", "b"])
+        # No bind_deck() -- must not raise and must not advance index.
+        await cycler.advance()
+        assert cycler.current == "a"
+
+    async def test_attach_binds_event_to_advance(self) -> None:
+        spec = _dash_spec()
+        card = DuiCard(spec)
+        cycler = ScreenCycler(["a", "b"])
+        deck = MagicMock()
+        deck.set_screen = AsyncMock()
+        cycler.bind_deck(deck)
+
+        cycler.attach(card)
+        # The cycler registers a handler against the manifest event;
+        # invoke it the same way the deck would.
+        handler = card._events._handlers["next_screen"]
+        await handler()
+        assert cycler.current == "b"
+        deck.set_screen.assert_awaited_with("b")
+
+    async def test_attach_custom_event_name(self) -> None:
+        # Build a dashboard-shaped spec but with a differently-named event.
+        spec = PackageSpec(
+            name="DashboardCard",
+            type=PackageType.TOUCH_STRIP_CARD,
+            version=1,
+            svg_source=_DASH_SVG,
+            bindings=_dash_spec().bindings,
+            events=(
+                EventMapping(
+                    name="rotate_screen",
+                    source="encoder_press_release",
+                    max_duration_ms=250,
+                ),
+            ),
+        )
+        card = DuiCard(spec)
+        cycler = ScreenCycler(["x", "y"])
+        deck = MagicMock()
+        deck.set_screen = AsyncMock()
+        cycler.bind_deck(deck)
+
+        cycler.attach(card, event="rotate_screen")
+        handler = card._events._handlers["rotate_screen"]
+        await handler()
+        assert cycler.current == "y"


### PR DESCRIPTION
## Summary

Replace the dedicated `NavigationController` + IconKey with a lightweight `ScreenCycler` that attaches to the new `next_screen` event on `DashboardCard.dui`. An encoder press-release on the dashboard now advances through the configured screens (wrapping at the end), freeing every key slot on every layout for favourites and scenes.

## Changes

- **`examples/DashboardCard.dui/manifest.yaml`**: declare `next_screen` event on `encoder_press_release` with `max_duration_ms: 250`.
- **`examples/streamdeck.py`**: replace `NavigationController` (one IconKey, two-state toggle) with `ScreenCycler` (no widget, list of screens, wraps). `StreamDeckApp` wires it via `cycler.attach(self.dashboard.card)`. Both screen layouts no longer reserve a key slot for navigation.
- **`tests/test_example_streamdeck.py`**: add `next_screen` event to the dashboard test spec; six new `TestScreenCycler` tests cover empty-list guard, initial state, advance/wrap, no-deck noop, default event attachment, and custom event name.
- **`docs/example.md`**: refresh layout tree, walkthrough section, and interactions table to describe the encoder-driven cycle.

## Quality gate

- `pytest` 1130 passed, coverage 96.96% (gate 95%)
- `ruff check .` clean
- `mypy src` clean
- `mkdocs build --strict` clean