### PR TITLE
Fix text ellipsis truncation to use pixel-accurate font metrics

### DIFF
--- a/src/deckui/dui/svg_renderer.py
+++ b/src/deckui/dui/svg_renderer.py
@@ -89,24 +89,62 @@ def _fit_image(
     return resized.crop((left, top, left + target_w, top + target_h))
 
 
-def _truncate_text(text: str, max_width: int, overflow: OverflowMode) -> str:
-    """Truncate text to approximate a pixel max_width.
+def _truncate_text(
+    text: str,
+    max_width: int,
+    overflow: OverflowMode,
+    font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None,
+) -> str:
+    """Truncate single-line text so it fits within *max_width* pixels.
 
-    Uses a simple character-width heuristic (0.6 * font-size per char)
-    since we cannot measure the exact rendered width before CairoSVG
-    rasterises.  The SVG font-size is not available here, so we use
-    the max_width as a rough character limit with an average ratio.
+    When a Pillow *font* is provided, pixel-accurate measurement via
+    :meth:`~PIL.ImageFont.ImageFont.getlength` is used.  Otherwise
+    falls back to a simple character-width heuristic (7 px per char).
+
+    Parameters
+    ----------
+    text : str
+        The text string to truncate.
+    max_width : int
+        Maximum allowed width in pixels.
+    overflow : OverflowMode
+        How to handle overflow (``ELLIPSIS`` appends ``…``, ``CLIP``
+        returns the original text unchanged).
+    font : ImageFont.FreeTypeFont | ImageFont.ImageFont | None, optional
+        Pillow font used for pixel-accurate measurement.  When *None*,
+        a character-width heuristic is used as a fallback.
+
+    Returns
+    -------
+    str
+        The (possibly truncated) text.
     """
     if overflow == OverflowMode.CLIP:
         return text
 
+    ellipsis = "\u2026"
+
+    if font is not None:
+        if font.getlength(text) <= max_width:
+            return text
+        # Binary-search for the longest prefix that fits with ellipsis.
+        lo, hi = 0, len(text)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if font.getlength(text[:mid] + ellipsis) <= max_width:
+                lo = mid
+            else:
+                hi = mid - 1
+        return text[: max(1, lo)].rstrip() + ellipsis
+
+    # Fallback: character-width heuristic (no font available).
     avg_char_width = 7
     max_chars = max(1, max_width // avg_char_width)
 
     if len(text) <= max_chars:
         return text
 
-    return text[: max(1, max_chars - 1)] + "\u2026"
+    return text[: max(1, max_chars - 1)] + ellipsis
 
 
 _DEFAULT_FONT_FAMILY = "sans-serif"
@@ -489,7 +527,9 @@ class SvgRenderer:
             return
 
         if binding.max_width is not None:
-            text = _truncate_text(text, binding.max_width, binding.overflow)
+            family, size_f = _resolve_font_attrs(root, elem)
+            font = _load_font(family, int(size_f))
+            text = _truncate_text(text, binding.max_width, binding.overflow, font=font)
         elem.text = text
 
     def _apply_wrapped_text(

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 
 import pytest
-from PIL import Image
+from PIL import Image, ImageFont
 
 from deckui.dui.schema import (
     ColorBinding,
@@ -114,6 +114,42 @@ class TestTextTruncation:
     def test_very_small_max_width(self):
         result = _truncate_text("Hello World", 7, OverflowMode.ELLIPSIS)
         assert len(result) <= 2
+
+    def test_font_based_short_text_unchanged(self):
+        """Short text that fits within max_width is returned unchanged with font."""
+        font = ImageFont.load_default()
+        short = "Hi"
+        result = _truncate_text(short, 500, OverflowMode.ELLIPSIS, font=font)
+        assert result == short
+
+    def test_font_based_long_text_truncated(self):
+        """Long text is truncated with ellipsis using pixel-accurate font measurement."""
+        font = ImageFont.load_default()
+        long_text = "A" * 200
+        result = _truncate_text(long_text, 80, OverflowMode.ELLIPSIS, font=font)
+        assert result.endswith("\u2026")
+        assert font.getlength(result) <= 80
+
+    def test_font_based_clip_unchanged(self):
+        """Clip mode returns original text even with font."""
+        font = ImageFont.load_default()
+        long_text = "A" * 200
+        assert _truncate_text(long_text, 80, OverflowMode.CLIP, font=font) == long_text
+
+    def test_font_based_large_font_truncates_sooner(self):
+        """Larger font size causes truncation at fewer characters."""
+        try:
+            small_font = ImageFont.truetype("sans-serif", 12)
+            large_font = ImageFont.truetype("sans-serif", 24)
+        except OSError:
+            small_font = ImageFont.load_default()
+            large_font = ImageFont.load_default()
+            pytest.skip("TrueType fonts not available for size comparison")
+        text = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        small_result = _truncate_text(text, 120, OverflowMode.ELLIPSIS, font=small_font)
+        large_result = _truncate_text(text, 120, OverflowMode.ELLIPSIS, font=large_font)
+        # Large font should truncate to fewer characters
+        assert len(large_result) <= len(small_result)
 
 
 class TestImageFit:


### PR DESCRIPTION
## Summary

- **Bug**: `_truncate_text` used a hardcoded 7px/char heuristic, ignoring actual font size. With `max_width=185`, this allowed ~26 chars regardless of font size — too many for font-size 20 (bold), causing text to overflow off-screen, while font-size 12 worked fine.
- **Fix**: When `max_width` is set (without `wrap`), the renderer now resolves the SVG element's font family/size and uses Pillow's `font.getlength()` for pixel-accurate measurement. A binary search finds the optimal truncation point. The old heuristic is retained as a fallback when no font is available.
- Adds 4 new tests for font-based truncation; all 1134 tests pass with 97% coverage.