### PR TITLE
chore: add default pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+What does this PR do and why?
+
+## Changes
+
+Describe the key changes made.
+
+## Validation
+
+- [ ] `python -m pytest tests/ --cov=deckui --cov-report=term-missing --cov-fail-under=95`
+- [ ] Added or updated tests where applicable
+- [ ] Updated docs where applicable
+
+## Notes
+
+Anything reviewers should pay attention to, or follow-up items.


### PR DESCRIPTION
## Summary

Adds a default pull_request_template.md so PRs that don't match the bug or feature templates still get a consistent structure.

The existing PULL_REQUEST_TEMPLATE/bug.md and PULL_REQUEST_TEMPLATE/feature.md remain unchanged -- this template serves as the fallback default.