### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in DeckUI, please report it responsibly.
+
+**Do not open a public issue.**
+
+Instead, please use [GitHub Security Advisories](https://github.com/graphras-com/DeckUI/security/advisories/new) to report the vulnerability privately.
+
+You can expect:
+
+- An acknowledgement within **48 hours**.
+- A status update within **7 days**.
+- A fix or mitigation plan for confirmed vulnerabilities as soon as reasonably possible.
+
+Thank you for helping keep DeckUI and its users safe.


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` to resolve the missing "Security policy" item on the community standards checklist
- Directs vulnerability reporters to GitHub Security Advisories for private disclosure