### PR TITLE
Add explicit GITHUB_TOKEN permissions to reusable workflows

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,5 +1,8 @@
 name: Reusable Python CI
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/python-gitleaks.yml
+++ b/.github/workflows/python-gitleaks.yml
@@ -1,5 +1,8 @@
 name: Reusable Gitleaks
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,5 +1,8 @@
 name: Reusable Python Lint
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,5 +1,8 @@
 name: Reusable Release
 
+permissions:
+  contents: write
+
 on:
   workflow_call:
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,8 @@
 name: Reusable Python Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/python-typecheck.yml
+++ b/.github/workflows/python-typecheck.yml
@@ -1,5 +1,8 @@
 name: Reusable Python Type Check
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary
- Adds explicit `permissions` blocks to 6 reusable workflows that were missing them, resolving the GitHub security warning about unlimited GITHUB_TOKEN permissions.
- All workflows get `contents: read` except `python-release.yml` which needs `contents: write` for creating GitHub releases.