### PR TITLE
Fix timer flash restoring inverted colors and read defaults from manifest

### DIFF
--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -436,8 +436,6 @@ class TimerController:
     ADJUST_STEP_S = 30
     FLASH_COUNT = 6
     FLASH_INTERVAL_S = 0.3
-    DEFAULT_BACKGROUND = "#dedede"
-    DEFAULT_FOREGROUND = "#1c1c1c"
 
     def __init__(
         self,
@@ -451,6 +449,11 @@ class TimerController:
         pkg_dir = packages_dir or EXAMPLES_DIR
         self._card = DuiCard(load_package(pkg_dir / "TimerCard.dui"))
         self._tick_task: asyncio.Task[None] | None = None
+
+        # Read default colours from the manifest so the controller stays
+        # in sync with the .dui package.
+        self._default_background: str = self._card.get("background")
+        self._default_foreground: str = self._card.get("foreground")
 
         self._sync_card()
         self._bind_events()
@@ -569,21 +572,21 @@ class TimerController:
             swapped = not swapped
             if swapped:
                 self._card.set_many(
-                    background=self.DEFAULT_FOREGROUND,
-                    foreground=self.DEFAULT_BACKGROUND,
+                    background=self._default_foreground,
+                    foreground=self._default_background,
                 )
             else:
                 self._card.set_many(
-                    background=self.DEFAULT_BACKGROUND,
-                    foreground=self.DEFAULT_FOREGROUND,
+                    background=self._default_background,
+                    foreground=self._default_foreground,
                 )
             await self._card.request_refresh()
             await asyncio.sleep(self.FLASH_INTERVAL_S)
 
         # Ensure colors are restored to their original values.
         self._card.set_many(
-            background=self.DEFAULT_BACKGROUND,
-            foreground=self.DEFAULT_FOREGROUND,
+            background=self._default_background,
+            foreground=self._default_foreground,
         )
         await self._card.request_refresh()
 
@@ -837,10 +840,6 @@ class SceneController:
         Directory containing ``IconKey.dui``.
     """
 
-    # Defaults match the IconKey.dui manifest.
-    DEFAULT_BACKGROUND = "#1c1c1c"
-    DEFAULT_FOREGROUND = "#dedede"
-
     def __init__(
         self,
         scenes: list[dict[str, str]],
@@ -856,8 +855,6 @@ class SceneController:
             key.set_many(
                 label=scene["label"],
                 icon=scene["icon"],
-                background=self.DEFAULT_BACKGROUND,
-                foreground=self.DEFAULT_FOREGROUND,
             )
 
             # Bind handlers via a helper so each key captures its own
@@ -869,7 +866,10 @@ class SceneController:
         """Attach press/release/click handlers to *key*.
 
         Splitting this into a helper guarantees correct closure capture
-        for *key* and *label* per iteration.
+        for *key* and *label* per iteration.  The original background and
+        foreground colours are read from the key's current bindings (set
+        by the manifest defaults) so the controller stays in sync with
+        the ``.dui`` package.
 
         Parameters
         ----------
@@ -878,22 +878,18 @@ class SceneController:
         label : str
             Scene label, logged on click.
         """
+        bg = key.get("background")
+        fg = key.get("foreground")
 
         @key.on_event("press")
         async def _press() -> None:
             # Invert colours by swapping background <-> foreground.
-            key.set_many(
-                background=self.DEFAULT_FOREGROUND,
-                foreground=self.DEFAULT_BACKGROUND,
-            )
+            key.set_many(background=fg, foreground=bg)
             await key.request_refresh()
 
         @key.on_event("release")
         async def _release() -> None:
-            key.set_many(
-                background=self.DEFAULT_BACKGROUND,
-                foreground=self.DEFAULT_FOREGROUND,
-            )
+            key.set_many(background=bg, foreground=fg)
             await key.request_refresh()
 
         @key.on_event("click")

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -68,6 +68,8 @@ _LIGHT_SVG = (
 
 _TIMER_SVG = (
     '<svg id="TimerCard" xmlns="http://www.w3.org/2000/svg" width="197" height="98">'
+    '<rect id="background" width="197" height="98" fill="#1c1c1c"/>'
+    '<rect id="foreground" width="197" height="98" fill="#dedede"/>'
     '<text id="timer" x="4" y="50" font-size="20" fill="#fff">00:00:00</text>'
     "</svg>"
 )
@@ -232,6 +234,12 @@ def _timer_spec() -> PackageSpec:
         svg_source=_TIMER_SVG,
         bindings={
             "timer": TextBinding(node="timer", default="00:00:00"),
+            "background": ColorBinding(
+                node="background", attribute="color", default="#1c1c1c"
+            ),
+            "foreground": ColorBinding(
+                node="foreground", attribute="color", default="#dedede"
+            ),
         },
         events=(
             EventMapping(name="toggle", source="encoder_press_release", max_duration_ms=300),
@@ -640,25 +648,25 @@ class TestSceneController:
         assert screen.set_key.call_count == len(SCENE_DEFS)
 
     def test_initial_colors_are_defaults(self, ctrl: SceneController) -> None:
-        """Each key starts with default background/foreground colors."""
+        """Each key starts with default background/foreground colors from manifest."""
         for key in ctrl.keys:
-            assert key.get("background") == SceneController.DEFAULT_BACKGROUND
-            assert key.get("foreground") == SceneController.DEFAULT_FOREGROUND
+            assert key.get("background") == "#1c1c1c"
+            assert key.get("foreground") == "#dedede"
 
     async def test_press_swaps_colors(self, ctrl: SceneController) -> None:
         """key.dispatch(pressed=True) swaps fg/bg via the press handler."""
         key = ctrl.keys[0]
         await key.dispatch(pressed=True)
-        assert key.get("background") == SceneController.DEFAULT_FOREGROUND
-        assert key.get("foreground") == SceneController.DEFAULT_BACKGROUND
+        assert key.get("background") == "#dedede"
+        assert key.get("foreground") == "#1c1c1c"
 
     async def test_release_restores_colors(self, ctrl: SceneController) -> None:
         """A release after a press restores the original colors."""
         key = ctrl.keys[0]
         await key.dispatch(pressed=True)
         await key.dispatch(pressed=False)
-        assert key.get("background") == SceneController.DEFAULT_BACKGROUND
-        assert key.get("foreground") == SceneController.DEFAULT_FOREGROUND
+        assert key.get("background") == "#1c1c1c"
+        assert key.get("foreground") == "#dedede"
 
     async def test_press_release_requests_refresh(
         self, ctrl: SceneController
@@ -692,8 +700,8 @@ class TestSceneController:
         first, second = ctrl.keys[0], ctrl.keys[1]
         await first.dispatch(pressed=True)
         # First is inverted, second is untouched.
-        assert first.get("background") == SceneController.DEFAULT_FOREGROUND
-        assert second.get("background") == SceneController.DEFAULT_BACKGROUND
+        assert first.get("background") == "#dedede"
+        assert second.get("background") == "#1c1c1c"
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- **Fix**: `TimerController._flash_notification()` was restoring inverted background/foreground colors after flashing because `DEFAULT_BACKGROUND` and `DEFAULT_FOREGROUND` constants were swapped.
- **Improvement**: Removed hardcoded color constants from both `TimerController` and `SceneController`. Both now read default colors from the DUI card/key bindings (sourced from the manifest), keeping controllers in sync with the `.dui` packages.
- Updated tests to add `background`/`foreground` bindings to the timer test spec and replace references to removed class constants.