### PR TITLE
fix: clean up encoder turn semantics (suppress while pressed + post-release grace)

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -283,9 +283,11 @@ events:
 | `encoder_press` | Encoder pressed down |
 | `encoder_release` | Encoder released (always) |
 | `encoder_press_release` | Released within `max_duration_ms` (suppressed if hold fired) |
-| `encoder_turn` | Encoder rotated; filter with `direction` |
-| `encoder_press_turn` | Rotated while pressed; filter with `direction` |
+| `encoder_turn` | Encoder rotated **while not pressed**; filter with `direction` |
+| `encoder_press_turn` | Rotated **while pressed**; filter with `direction` |
 | `encoder_hold` | Held for `hold_ms` |
+
+`encoder_turn` and `encoder_press_turn` are mutually exclusive at runtime. While the encoder is pressed, only `encoder_press_turn` mappings are eligible — turning a pressed encoder will never fire `encoder_turn`, even if no `encoder_press_turn` is declared (or its `direction` filter doesn't match). Any turn while pressed cancels a pending `encoder_hold`.
 
 **Touch sources** (for regions):
 

--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -289,6 +289,8 @@ events:
 
 `encoder_turn` and `encoder_press_turn` are mutually exclusive at runtime. While the encoder is pressed, only `encoder_press_turn` mappings are eligible — turning a pressed encoder will never fire `encoder_turn`, even if no `encoder_press_turn` is declared (or its `direction` filter doesn't match). Any turn while pressed cancels a pending `encoder_hold`.
 
+After releasing the encoder following a press cycle that included at least one turn, plain `encoder_turn` events are suppressed for a short grace window (150 ms by default). This debounces the very common ergonomic mistake of letting a finger continue to nudge the dial while lifting off, so a `press_turn` gesture cannot accidentally bleed into an unrelated `encoder_turn` handler. Releases without an intervening turn — and `encoder_press_turn` events themselves — are never suppressed.
+
 **Touch sources** (for regions):
 
 | Source | Fires when |

--- a/src/deckui/dui/event_map.py
+++ b/src/deckui/dui/event_map.py
@@ -28,8 +28,14 @@ class EventMap:
       the handler after ``hold_ms`` while the key/encoder is still held.
       Suppresses any ``press_release`` or ``release`` event for that
       press–release cycle.
+    - ``encoder_turn``: fires turn events only while the encoder is
+      **not** pressed.  Turning while pressed never falls through to
+      this mapping.
     - ``encoder_press_turn``: fires turn events only while the encoder
-      is held down.
+      is held down.  When declared with a direction filter, mismatching
+      turns while pressed are silent — there is no fallback to
+      ``encoder_turn``.  Any turn while pressed cancels a pending
+      ``encoder_hold`` regardless of whether a handler fires.
     - Direction filtering: ``encoder_turn`` with ``direction: left``
       only fires for counter-clockwise turns.
 
@@ -167,6 +173,7 @@ class EventMap:
                     h = self._handlers.get(mapping.name)
                     if h is not None:
                         return h
+            return None
 
         for mapping in self._by_source.get("encoder_turn", []):
             if self._direction_matches(mapping, direction):

--- a/src/deckui/dui/event_map.py
+++ b/src/deckui/dui/event_map.py
@@ -8,6 +8,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from ..ui.controls.dial_accumulator import DialAccumulator
+from .schema import DEFAULT_RELEASE_TURN_GRACE_MS
 
 if TYPE_CHECKING:
     from ..runtime.events import AsyncHandler, EventType
@@ -30,7 +31,10 @@ class EventMap:
       press–release cycle.
     - ``encoder_turn``: fires turn events only while the encoder is
       **not** pressed.  Turning while pressed never falls through to
-      this mapping.
+      this mapping.  Immediately after releasing a press cycle that
+      included at least one turn, ``encoder_turn`` is suppressed for
+      ``release_turn_grace_ms`` to debounce the spurious tick a finger
+      often produces while lifting off the dial.
     - ``encoder_press_turn``: fires turn events only while the encoder
       is held down.  When declared with a direction filter, mismatching
       turns while pressed are silent — there is no fallback to
@@ -45,12 +49,19 @@ class EventMap:
         Event mappings from the package manifest.
     regions
         Touch regions from the package manifest.
+    release_turn_grace_ms
+        Suppression window (in milliseconds) applied to plain
+        ``encoder_turn`` events immediately after the encoder is released
+        following a press cycle that included at least one turn.  Defaults
+        to :data:`~deckui.dui.schema.DEFAULT_RELEASE_TURN_GRACE_MS`.  Pass
+        ``0`` to disable.
     """
 
     def __init__(
         self,
         events: tuple[EventMapping, ...],
         regions: tuple[Region, ...] = (),
+        release_turn_grace_ms: int = DEFAULT_RELEASE_TURN_GRACE_MS,
     ) -> None:
         self._mappings = events
         self._regions = regions
@@ -61,6 +72,10 @@ class EventMap:
 
         self._hold_task: asyncio.Task[None] | None = None
         self._hold_fired = False
+
+        self._press_had_turn = False
+        self._release_turn_grace_s = max(0, release_turn_grace_ms) / 1000.0
+        self._turn_suppressed_until = 0.0
 
         self._by_source: dict[str, list[EventMapping]] = {}
         for mapping in events:
@@ -163,6 +178,7 @@ class EventMap:
         """
         if self._pressed:
             self._cancel_hold_timer()
+            self._press_had_turn = True
 
             for mapping in self._by_source.get("encoder_press_turn", []):
                 if self._direction_matches(mapping, direction):
@@ -173,6 +189,9 @@ class EventMap:
                     h = self._handlers.get(mapping.name)
                     if h is not None:
                         return h
+            return None
+
+        if time.monotonic() < self._turn_suppressed_until:
             return None
 
         for mapping in self._by_source.get("encoder_turn", []):
@@ -201,6 +220,7 @@ class EventMap:
         self._press_time = time.monotonic()
         self._pressed = True
         self._hold_fired = False
+        self._press_had_turn = False
 
         self._start_hold_timer("encoder_hold")
 
@@ -220,6 +240,10 @@ class EventMap:
         fired for this press–release cycle (since the interaction was
         a hold, not a press-release gesture).
 
+        If at least one turn occurred during the press cycle, opens a
+        ``release_turn_grace_ms`` window during which subsequent plain
+        ``encoder_turn`` events are ignored.
+
         Returns
         -------
         list[AsyncHandler]
@@ -230,6 +254,12 @@ class EventMap:
 
         hold_fired = self._hold_fired
         self._hold_fired = False
+
+        if self._press_had_turn and self._release_turn_grace_s > 0:
+            self._turn_suppressed_until = (
+                time.monotonic() + self._release_turn_grace_s
+            )
+        self._press_had_turn = False
 
         handlers: list[AsyncHandler] = []
 

--- a/src/deckui/dui/schema.py
+++ b/src/deckui/dui/schema.py
@@ -224,6 +224,16 @@ DEFAULT_MAX_DURATION_MS: int = 500
 DEFAULT_HOLD_MS: int = 500
 """Default hold duration (ms) for ``*_hold`` events."""
 
+DEFAULT_RELEASE_TURN_GRACE_MS: int = 150
+"""Default suppression window (ms) after a press cycle that included a turn.
+
+After releasing the encoder following a press during which one or more turns
+occurred, plain ``encoder_turn`` events are ignored for this many milliseconds.
+This debounces the very common ergonomic mistake of letting a finger continue
+to nudge the dial as it lifts off, preventing a ``encoder_press_turn`` gesture
+from accidentally bleeding into a ``encoder_turn`` event.
+"""
+
 
 @dataclass(frozen=True, slots=True)
 class Region:

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -81,6 +81,56 @@ class TestEncoderTurn:
             em.handle_encoder_turn(-1) is None
         )
 
+    def test_turn_suppressed_while_pressed_when_no_press_turn_declared(self):
+        """encoder_turn must not fire while the encoder is pressed."""
+        events = _make_events(("scroll", "encoder_turn"))
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        result = em.handle_encoder_turn(1)
+        assert result is None
+        handler.assert_not_called()
+
+    def test_turn_resumes_after_release(self):
+        """encoder_turn fires again once the encoder is released."""
+        events = _make_events(("scroll", "encoder_turn"))
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        assert em.handle_encoder_turn(1) is None
+        em.handle_encoder_release()
+
+        result = em.handle_encoder_turn(1)
+        assert _handler(result) is handler
+
+    async def test_accumulator_tick_not_delivered_while_pressed(self):
+        """Accumulated encoder_turn ticks are dropped while the encoder is pressed."""
+        events = _make_events(
+            ("scroll", "encoder_turn", {"accumulate": True, "accumulate_delay": 0.02}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_turn(1)
+        em.handle_encoder_turn(-1)
+
+        await asyncio.sleep(0.1)
+        handler.assert_not_called()
+
+        em.handle_encoder_release()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_turn(1)
+
+        await asyncio.sleep(0.1)
+        handler.assert_awaited_once_with(2)
+
 
 class TestEncoderPressRelease:
     def test_simple_press(self):
@@ -249,8 +299,8 @@ class TestEncoderPressTurn:
         result = em.handle_encoder_turn(1)
         assert _handler(result) is seek_handler
 
-    def test_regular_turn_fires_when_press_turn_direction_mismatches(self):
-        """Falls back to encoder_turn when press_turn direction doesn't match."""
+    def test_press_turn_direction_mismatch_does_not_fall_back(self):
+        """When pressed, a direction-mismatched press_turn does NOT fall back to encoder_turn."""
         events = _make_events(
             ("scroll", "encoder_turn"),
             ("seek_fwd", "encoder_press_turn", {"direction": "right"}),
@@ -263,7 +313,9 @@ class TestEncoderPressTurn:
 
         em.handle_encoder_press()
         result = em.handle_encoder_turn(-1)
-        assert _handler(result) is scroll_handler
+        assert result is None
+        scroll_handler.assert_not_called()
+        seek_handler.assert_not_called()
 
 
 class TestKeyEvents:
@@ -615,7 +667,12 @@ class TestEncoderHold:
         hold_handler.assert_not_awaited()
 
     async def test_encoder_hold_cancelled_by_turn_without_press_turn_mapping(self):
-        """encoder_hold is cancelled by turn even without encoder_press_turn mapping."""
+        """encoder_hold is cancelled by turn even without encoder_press_turn mapping.
+
+        With no ``encoder_press_turn`` declared, the turn itself is silent — the
+        ``encoder_turn`` handler must not fire while the encoder is pressed —
+        but the physical motion still cancels the pending hold timer.
+        """
         events = _make_events(
             ("scroll", "encoder_turn"),
             ("enc_hold", "encoder_hold", {"hold_ms": 50}),
@@ -627,7 +684,9 @@ class TestEncoderHold:
         em.on("enc_hold", hold_handler)
 
         em.handle_encoder_press()
-        em.handle_encoder_turn(1)
+        result = em.handle_encoder_turn(1)
+        assert result is None
+        scroll_handler.assert_not_called()
 
         await asyncio.sleep(0.1)
         hold_handler.assert_not_awaited()

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -94,9 +94,14 @@ class TestEncoderTurn:
         handler.assert_not_called()
 
     def test_turn_resumes_after_release(self):
-        """encoder_turn fires again once the encoder is released."""
+        """encoder_turn fires again once the encoder is released.
+
+        Uses ``release_turn_grace_ms=0`` so the post-release suppression
+        window (covered separately in :class:`TestPostReleaseTurnGrace`)
+        does not interfere with this assertion.
+        """
         events = _make_events(("scroll", "encoder_turn"))
-        em = EventMap(events)
+        em = EventMap(events, release_turn_grace_ms=0)
         handler = AsyncMock()
         em.on("scroll", handler)
 
@@ -112,7 +117,7 @@ class TestEncoderTurn:
         events = _make_events(
             ("scroll", "encoder_turn", {"accumulate": True, "accumulate_delay": 0.02}),
         )
-        em = EventMap(events)
+        em = EventMap(events, release_turn_grace_ms=0)
         handler = AsyncMock()
         em.on("scroll", handler)
 
@@ -316,6 +321,129 @@ class TestEncoderPressTurn:
         assert result is None
         scroll_handler.assert_not_called()
         seek_handler.assert_not_called()
+
+
+class TestPostReleaseTurnGrace:
+    """Suppression of encoder_turn for a short window after a press+turn cycle.
+
+    Mirrors the real ergonomic problem: a finger lifting off a rotary encoder
+    after a press_turn gesture often produces a stray tick, which would
+    spuriously fire the unrelated encoder_turn handler (e.g. brightness on
+    DashboardCard) without this grace window.
+    """
+
+    async def test_turn_after_release_with_intervening_turn_is_suppressed(self):
+        events = _make_events(
+            ("scroll", "encoder_turn"),
+            ("seek", "encoder_press_turn"),
+        )
+        em = EventMap(events, release_turn_grace_ms=80)
+        scroll_handler = AsyncMock()
+        seek_handler = AsyncMock()
+        em.on("scroll", scroll_handler)
+        em.on("seek", seek_handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_release()
+
+        result = em.handle_encoder_turn(1)
+        assert result is None
+        scroll_handler.assert_not_called()
+
+    async def test_turn_after_release_without_intervening_turn_fires(self):
+        """A clean press-release with no turn must NOT open a suppression window."""
+        events = _make_events(("scroll", "encoder_turn"))
+        em = EventMap(events, release_turn_grace_ms=80)
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_release()
+
+        result = em.handle_encoder_turn(1)
+        assert _handler(result) is handler
+
+    async def test_grace_window_expires(self):
+        events = _make_events(
+            ("scroll", "encoder_turn"),
+            ("seek", "encoder_press_turn"),
+        )
+        em = EventMap(events, release_turn_grace_ms=30)
+        scroll_handler = AsyncMock()
+        em.on("scroll", scroll_handler)
+        em.on("seek", AsyncMock())
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_release()
+
+        await asyncio.sleep(0.06)
+
+        result = em.handle_encoder_turn(1)
+        assert _handler(result) is scroll_handler
+
+    async def test_grace_triggered_even_when_turn_was_silent(self):
+        """A silent turn-while-pressed (no press_turn declared) still opens the window."""
+        events = _make_events(("scroll", "encoder_turn"))
+        em = EventMap(events, release_turn_grace_ms=80)
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)  # silent — no press_turn declared
+        em.handle_encoder_release()
+
+        result = em.handle_encoder_turn(1)
+        assert result is None
+        handler.assert_not_called()
+
+    async def test_press_turn_during_grace_is_not_suppressed(self):
+        """Suppression only blocks plain encoder_turn, not encoder_press_turn."""
+        events = _make_events(
+            ("scroll", "encoder_turn"),
+            ("seek", "encoder_press_turn"),
+        )
+        em = EventMap(events, release_turn_grace_ms=80)
+        seek_handler = AsyncMock()
+        em.on("scroll", AsyncMock())
+        em.on("seek", seek_handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_release()
+
+        em.handle_encoder_press()
+        result = em.handle_encoder_turn(1)
+        assert _handler(result) is seek_handler
+
+    async def test_default_grace_window_is_active(self):
+        """The default grace window (DEFAULT_RELEASE_TURN_GRACE_MS) is non-zero."""
+        events = _make_events(("scroll", "encoder_turn"))
+        em = EventMap(events)  # default grace
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_release()
+
+        result = em.handle_encoder_turn(1)
+        assert result is None
+        handler.assert_not_called()
+
+    async def test_grace_zero_disables_suppression(self):
+        events = _make_events(("scroll", "encoder_turn"))
+        em = EventMap(events, release_turn_grace_ms=0)
+        handler = AsyncMock()
+        em.on("scroll", handler)
+
+        em.handle_encoder_press()
+        em.handle_encoder_turn(1)
+        em.handle_encoder_release()
+
+        result = em.handle_encoder_turn(1)
+        assert _handler(result) is handler
 
 
 class TestKeyEvents:


### PR DESCRIPTION
Two related ergonomic fixes to `EventMap` for rotary encoders. Both address the same surprise: a `.dui` package's `encoder_turn` handler firing when the user did not intend a plain turn gesture.

## 1. Suppress `encoder_turn` while the encoder is pressed

`handle_encoder_turn` no longer falls back to `encoder_turn` mappings while the encoder is pressed. Press-mode is strict: only `encoder_press_turn` mappings are eligible. A direction-mismatched `encoder_press_turn` is silent rather than firing the plain turn handler. Hold cancellation is preserved — any physical turn while pressed still cancels a pending `encoder_hold`.

## 2. Grace window after a press+turn release

After releasing the encoder following a press cycle that included at least one turn, plain `encoder_turn` events are suppressed for `DEFAULT_RELEASE_TURN_GRACE_MS = 150 ms`. This debounces the very common ergonomic mistake of letting a finger continue to nudge the dial as it lifts off, so a `press_turn` gesture cannot accidentally bleed into an unrelated `encoder_turn`. The window:

- only opens when at least one turn occurred during the press cycle (clean press-release stays instant),
- only blocks plain `encoder_turn` (`encoder_press_turn` itself is never suppressed),
- is configurable via the new `EventMap(..., release_turn_grace_ms=...)` parameter — pass `0` to disable.

## Why

`examples/DashboardCard.dui` declares `brightness_down`/`brightness_up` as `encoder_turn` and `next_screen` as `encoder_press_release`. Two failure modes were observed in `examples/streamdeck.py`:

- Pressing the encoder to switch screens, with an inadvertent rotation while pressed, nudged brightness even though no `encoder_press_turn` was declared. Fix #1 closes this.
- After a deliberate `encoder_press_turn` gesture, lifting the finger off frequently produced a stray turn tick that fired `encoder_turn`. Fix #2 closes this.

Both fixes follow the user-stated principle: **only events declared in the manifest should be emitted, and never as an accidental by-product of an adjacent gesture.** The library has no users yet; no compatibility shim was added.

## Test plan

- [x] `pytest tests/test_dui_event_map.py -v` — 73 pass, including a new `TestPostReleaseTurnGrace` class covering: suppression-on, suppression-off after window expires, no suppression for clean release, suppression triggered by silent turn-while-pressed, `encoder_press_turn` not affected, default window active, `release_turn_grace_ms=0` disables.
- [x] Strengthened `test_encoder_hold_cancelled_by_turn_without_press_turn_mapping` to also assert the turn handler is not called.
- [x] Inverted `test_press_turn_direction_mismatch_does_not_fall_back` (was the old permissive-fallback test).
- [x] Full suite: `pytest --cov=deckui --cov-fail-under=95` — 1146 pass, coverage 96.98% (`event_map.py` 100%).
- [x] `ruff check .` clean, `mypy src/deckui` clean.
- [ ] Manual on-device with `python examples/streamdeck.py` against a Stream Deck+ — requires hardware:
  - Turn encoder (no press): brightness changes.
  - Quick press-release (<250 ms): screen switches, brightness unchanged.
  - Press, rotate while pressed, release, finger drifts: **brightness does not change** during the press OR in the 150 ms after release.
  - Wait >150 ms after release, then turn: brightness changes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
