### PR TITLE
refactor!: remove .index property from KeySlot, EncoderSlot, and Card

### DIFF
--- a/src/deckui/dui/card.py
+++ b/src/deckui/dui/card.py
@@ -54,7 +54,7 @@ class DuiCard(Card):
     """
 
     def __init__(self, spec: PackageSpec) -> None:
-        super().__init__(-1)
+        super().__init__()
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events, spec.regions)

--- a/src/deckui/dui/key.py
+++ b/src/deckui/dui/key.py
@@ -56,7 +56,7 @@ class DuiKey(KeySlot):
     """
 
     def __init__(self, spec: PackageSpec) -> None:
-        super().__init__(-1)
+        super().__init__()
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events)

--- a/src/deckui/ui/cards/base.py
+++ b/src/deckui/ui/cards/base.py
@@ -43,8 +43,7 @@ class Card(ABC):
             print("Card tapped!")
     """
 
-    def __init__(self, index: int) -> None:
-        self._index = index
+    def __init__(self) -> None:
         self._tap_handler: AsyncHandler | None = None
         self._long_press_handler: AsyncHandler | None = None
         self._drag_handler: AsyncHandler | None = None
@@ -55,18 +54,6 @@ class Card(ABC):
         self._rendered: Image.Image | None = None
         self._dirty = True
         self._request_refresh: AsyncHandler | None = None
-
-    @property
-    def index(self) -> int:
-        """The index this card was constructed with.
-
-        Informational only — this is **not** updated when the card is
-        installed on a touch strip via :meth:`TouchStrip.set_card`.
-        A single ``Card`` may live on multiple screens at different
-        slot indices; the touch strip's slot list is the authoritative
-        source of truth.
-        """
-        return self._index
 
     def on_tap(self, handler: AsyncHandler) -> AsyncHandler:
         """Decorator to register a handler for short tap events in this zone.

--- a/src/deckui/ui/controls/encoder_slot.py
+++ b/src/deckui/ui/controls/encoder_slot.py
@@ -26,8 +26,7 @@ class EncoderSlot:
             print(f"Turned by {direction}")
     """
 
-    def __init__(self, index: int) -> None:
-        self._index = index
+    def __init__(self) -> None:
         self._turn_handler: AsyncHandler | None = None
         self._press_handler: AsyncHandler | None = None
         self._release_handler: AsyncHandler | None = None
@@ -35,11 +34,6 @@ class EncoderSlot:
         self._accumulator: DialAccumulator | None = None
         self._press_turn_accumulator: DialAccumulator | None = None
         self._pressed: bool = False
-
-    @property
-    def index(self) -> int:
-        """The encoder index on the device."""
-        return self._index
 
     # -- Turn handlers -------------------------------------------------------
 

--- a/src/deckui/ui/controls/key_slot.py
+++ b/src/deckui/ui/controls/key_slot.py
@@ -23,25 +23,12 @@ class KeySlot:
             print("pressed!")
     """
 
-    def __init__(self, index: int) -> None:
-        self._index = index
+    def __init__(self) -> None:
         self._press_handler: AsyncHandler | None = None
         self._release_handler: AsyncHandler | None = None
         self._image_bytes: bytes | None = None
         self._dirty = True
         self._request_refresh: AsyncHandler | None = None
-
-    @property
-    def index(self) -> int:
-        """The index this key slot was constructed with.
-
-        Informational only — this is **not** updated when the key is
-        installed on a screen via :meth:`Screen.set_key`.  A single
-        ``KeySlot`` (or :class:`~deckui.dui.DuiKey`) may live on multiple
-        screens at different slot indices; the screen's slot map is the
-        authoritative source of truth.
-        """
-        return self._index
 
     def set_refresh_callback(self, callback: AsyncHandler) -> None:
         """Register an async callback the key can invoke to request a refresh.

--- a/src/deckui/ui/screen.py
+++ b/src/deckui/ui/screen.py
@@ -97,7 +97,7 @@ class Screen:
             )
 
         if index not in self._keys:
-            self._keys[index] = KeySlot(index)
+            self._keys[index] = KeySlot()
         return self._keys[index]
 
     def set_key(self, index: int, key: KeySlot) -> None:
@@ -151,7 +151,7 @@ class Screen:
             )
 
         if index not in self._encoders:
-            self._encoders[index] = EncoderSlot(index)
+            self._encoders[index] = EncoderSlot()
         return self._encoders[index]
 
     def card(self, index: int) -> Card:

--- a/src/deckui/ui/touch_strip.py
+++ b/src/deckui/ui/touch_strip.py
@@ -31,7 +31,7 @@ class TouchStrip:
         background_color: str = "black",
     ) -> None:
         self._panel_count = panel_count
-        self._cards: list[Card] = [BlankCard(i) for i in range(panel_count)]
+        self._cards: list[Card] = [BlankCard() for _ in range(panel_count)]
         self._background_color = background_color
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,14 +309,14 @@ def dui_packages_dir(tmp_path):
 
 @pytest.fixture
 def key_slot():
-    """A fresh KeySlot at index 0."""
-    return KeySlot(0)
+    """A fresh KeySlot."""
+    return KeySlot()
 
 
 @pytest.fixture
 def encoder():
-    """A fresh EncoderSlot at index 0."""
-    return EncoderSlot(0)
+    """A fresh EncoderSlot."""
+    return EncoderSlot()
 
 
 @pytest.fixture

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -133,7 +133,7 @@ class TestDeckWireRefreshCallbacks:
         """set_screen wires deck.refresh on every key and card."""
         screen = deck.screen("main")
         key = screen.key(0)
-        card = _TestCard(0)
+        card = _TestCard()
         screen.set_card(0, card)
 
         deck._render_all_keys = AsyncMock()
@@ -282,7 +282,7 @@ class TestDeckDispatch:
     async def test_encoder_turn_dispatches_to_card(self, deck):
         """Encoder turn is forwarded to the card at that zone."""
         p = deck.screen("main")
-        card = _TestCard(1)
+        card = _TestCard()
         p.set_card(1, card)
         deck._active_screen = p
 
@@ -328,7 +328,7 @@ class TestDeckDispatch:
     async def test_encoder_press_dispatches_to_card(self, deck):
         """Encoder press is forwarded to the card's dispatch_encoder_press."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
 
@@ -343,7 +343,7 @@ class TestDeckDispatch:
     async def test_encoder_release_dispatches_to_card(self, deck):
         """Encoder release is forwarded to the card's dispatch_encoder_release."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
 
@@ -356,7 +356,7 @@ class TestDeckDispatch:
     async def test_encoder_press_release_does_not_call_press_handler(self, deck):
         """Card on_encoder_press is NOT called for release events."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
 
@@ -429,7 +429,7 @@ class TestDeckDispatchCardCallbacks:
     async def test_encoder_turn_calls_card_encoder_turn_handler(self, deck):
         """Card on_encoder_turn handler is called on EncoderTurnEvent."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
 
@@ -444,7 +444,7 @@ class TestDeckDispatchCardCallbacks:
     async def test_encoder_turn_order_encoder_then_card(self, deck):
         """Dispatch order: encoder handler -> card encoder handler."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
 
@@ -463,7 +463,7 @@ class TestDeckDispatchCardCallbacks:
 
     async def test_drain_card_callbacks_helper(self, deck):
         """_drain_card_callbacks awaits all pending callbacks in order."""
-        card = _TestCard(0)
+        card = _TestCard()
         results = []
 
         async def h1(v: float):
@@ -482,7 +482,7 @@ class TestDeckDispatchCardCallbacks:
     async def test_refresh_drains_pending_callbacks(self, deck):
         """Programmatic queue_pending_callback + refresh drains callbacks."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
         deck._render_touchscreen = AsyncMock()
@@ -532,7 +532,7 @@ class TestDeckRenderTouchscreen:
         deck._caps = STREAM_DECK_PLUS
         deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         p.set_card(0, card)
         deck._active_screen = p
 
@@ -705,7 +705,7 @@ class TestDeckCheckTimeouts:
     async def test_expired_timeout_triggers_refresh(self, deck):
         """Card with expired timeout triggers a refresh."""
         p = deck.screen("main")
-        card = _TestCard(0)
+        card = _TestCard()
         card.check_selection_timeout = lambda: True
         p.set_card(0, card)
         deck._active_screen = p

--- a/tests/test_dui_card.py
+++ b/tests/test_dui_card.py
@@ -51,17 +51,15 @@ class TestDuiCardIsCard:
         card = DuiCard(card_package_spec)
         assert isinstance(card, Card)
 
-    def test_set_card_does_not_mutate_card_index(self, card_package_spec):
-        """set_card installs the card on the strip without mutating it.
+    def test_set_card_installs_at_slot(self, card_package_spec):
+        """set_card stores the card in the strip's slot list.
 
-        The card's ``index`` reflects the constructor value only -- the
-        touch strip's slot list is the authoritative source of truth.
+        The card itself carries no slot identity -- the strip's slot
+        list is the authoritative source of truth.
         """
         card = DuiCard(card_package_spec)
-        original_index = card.index
         screen = Screen("test")
         screen.set_card(2, card)
-        assert card.index == original_index
         assert screen.touch_strip is not None
         assert screen.touch_strip.cards[2] is card
 

--- a/tests/test_dui_integration.py
+++ b/tests/test_dui_integration.py
@@ -88,7 +88,7 @@ class TestScreenSetKey:
 
     def test_set_key_accepts_regular_key_slot(self):
         screen = Screen("test")
-        key = KeySlot(0)
+        key = KeySlot()
         screen.set_key(0, key)
         assert screen.keys[0] is key
 
@@ -113,7 +113,7 @@ class TestDeckDuiKeyRendering:
     def test_is_dui_key_false_for_regular(self):
         from deckui.runtime.deck import Deck
 
-        key = KeySlot(0)
+        key = KeySlot()
         assert Deck._is_dui_key(key) is False
 
 

--- a/tests/test_dui_key.py
+++ b/tests/test_dui_key.py
@@ -47,18 +47,16 @@ class TestDuiKeyIsKeySlot:
         key = DuiKey(spec)
         assert isinstance(key, KeySlot)
 
-    def test_set_key_does_not_mutate_key_index(self):
-        """set_key installs the key on the screen without mutating it.
+    def test_set_key_installs_at_slot(self):
+        """set_key stores the key in the screen's slot map.
 
-        The key's ``index`` reflects the constructor value only -- the
-        screen's slot map is the authoritative source of truth.
+        The key itself carries no slot identity -- the screen's slot
+        map is the authoritative source of truth.
         """
         spec = _make_key_spec()
         key = DuiKey(spec)
-        original_index = key.index
         screen = Screen("test")
         screen.set_key(3, key)
-        assert key.index == original_index
         assert screen.keys[3] is key
 
     def test_has_spec(self):

--- a/tests/test_encoder_slot.py
+++ b/tests/test_encoder_slot.py
@@ -9,18 +9,11 @@ from deckui.ui.controls.encoder_slot import EncoderSlot
 
 
 class TestEncoderSlotInit:
-    def test_index(self, encoder: EncoderSlot):
-        assert encoder.index == 0
-
     def test_no_handlers_by_default(self, encoder: EncoderSlot):
         assert encoder._turn_handler is None
         assert encoder._press_handler is None
         assert encoder._release_handler is None
         assert encoder._press_turn_handler is None
-
-    def test_custom_index(self):
-        e = EncoderSlot(3)
-        assert e.index == 3
 
     def test_no_accumulator_by_default(self, encoder: EncoderSlot):
         assert encoder._accumulator is None

--- a/tests/test_key_slot.py
+++ b/tests/test_key_slot.py
@@ -8,16 +8,11 @@ from deckui.ui.controls.key_slot import KeySlot
 
 
 class TestKeySlotInit:
-    def test_index(self, key_slot: KeySlot):
-        assert key_slot.index == 0
-
     def test_defaults(self, key_slot: KeySlot):
         assert key_slot.image_bytes is None
         assert key_slot.is_dirty is True
-
-    def test_custom_index(self):
-        k = KeySlot(7)
-        assert k.index == 7
+        assert key_slot._press_handler is None
+        assert key_slot._release_handler is None
 
 
 class TestKeySlotEventHandlers:

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -52,7 +52,7 @@ class TestScreenForMini:
         screen = Screen("mini", STREAM_DECK_MINI)
         for i in range(6):
             k = screen.key(i)
-            assert k.index == i
+            assert screen.keys[i] is k
         with pytest.raises(IndexError, match="Key index must be 0-5"):
             screen.key(6)
 
@@ -92,7 +92,7 @@ class TestPageKey:
     def test_creates_key_slot(self, page: Screen):
         k = page.key(0)
         assert isinstance(k, KeySlot)
-        assert k.index == 0
+        assert page.keys[0] is k
 
     def test_same_instance(self, page: Screen):
         a = page.key(0)
@@ -102,7 +102,7 @@ class TestPageKey:
     def test_creates_all_indices(self, page: Screen):
         for i in range(8):
             k = page.key(i)
-            assert k.index == i
+            assert page.keys[i] is k
 
     def test_different_indices_different_instances(self, page: Screen):
         a = page.key(0)
@@ -129,7 +129,7 @@ class TestPageEncoder:
     def test_creates_encoder_slot(self, page: Screen):
         e = page.encoder(0)
         assert isinstance(e, EncoderSlot)
-        assert e.index == 0
+        assert page.encoders[0] is e
 
     def test_same_instance(self, page: Screen):
         a = page.encoder(0)
@@ -139,7 +139,7 @@ class TestPageEncoder:
     def test_creates_all_indices(self, page: Screen):
         for i in range(4):
             e = page.encoder(i)
-            assert e.index == i
+            assert page.encoders[i] is e
 
     def test_stored_in_encoders_dict(self, page: Screen):
         e = page.encoder(2)
@@ -195,16 +195,16 @@ class TestPageSetCard:
     def test_set_card_replaces(self, page: Screen):
         from tests.test_touch_strip import _ConcreteWidget
 
-        cw = _ConcreteWidget(0)
+        cw = _ConcreteWidget()
         page.set_card(0, cw)
         assert page.card(0) is cw
 
     def test_replace_preserves_others(self, page: Screen):
         original_1 = page.card(1)
-        page.set_card(0, BlankCard(0))
+        page.set_card(0, BlankCard())
         assert page.card(1) is original_1
 
     def test_set_card_no_touchscreen(self):
         screen = Screen("mini", STREAM_DECK_MINI)
         with pytest.raises(IndexError, match="no touchscreen"):
-            screen.set_card(0, BlankCard(0))
+            screen.set_card(0, BlankCard())

--- a/tests/test_touch_strip.py
+++ b/tests/test_touch_strip.py
@@ -21,50 +21,42 @@ class _ConcreteWidget(Card):
 class TestWidgetAbstractBase:
     def test_cannot_instantiate_directly(self):
         with pytest.raises(TypeError):
-            Card(0)
-
-    def test_index(self):
-        w = _ConcreteWidget(0)
-        assert w.index == 0
-
-    def test_custom_index(self):
-        w = _ConcreteWidget(3)
-        assert w.index == 3
+            Card()
 
     def test_initially_dirty(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         assert w.is_dirty is True
 
     def test_mark_clean(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         w.mark_clean()
         assert w.is_dirty is False
 
     def test_mark_dirty(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         w.mark_clean()
         w.mark_dirty()
         assert w.is_dirty is True
 
     def test_rendered_initially_none(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         assert w.rendered is None
 
     def test_set_rendered(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         img = Image.new("RGB", (PANEL_WIDTH, PANEL_HEIGHT))
         w.set_rendered(img)
         assert w.rendered is img
         assert w.is_dirty is False
 
     def test_set_rendered_none(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         w.set_rendered(None)
         assert w.rendered is None
         assert w.is_dirty is False
 
     def test_on_tap(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         @w.on_tap
         async def handler():
@@ -73,7 +65,7 @@ class TestWidgetAbstractBase:
         assert w._tap_handler is handler
 
     def test_on_long_press(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         @w.on_long_press
         async def handler():
@@ -82,7 +74,7 @@ class TestWidgetAbstractBase:
         assert w._long_press_handler is handler
 
     def test_on_drag(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         @w.on_drag
         async def handler(x, y, x_out, y_out):
@@ -91,7 +83,7 @@ class TestWidgetAbstractBase:
         assert w._drag_handler is handler
 
     def test_on_tap_returns_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler():
             pass
@@ -100,7 +92,7 @@ class TestWidgetAbstractBase:
         assert result is handler
 
     def test_on_long_press_returns_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler():
             pass
@@ -109,7 +101,7 @@ class TestWidgetAbstractBase:
         assert result is handler
 
     def test_on_drag_returns_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler(x, y, x_out, y_out):
             pass
@@ -118,30 +110,30 @@ class TestWidgetAbstractBase:
         assert result is handler
 
     def test_handle_encoder_turn_noop(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         w.handle_encoder_turn(1)
 
     def test_handle_encoder_press_noop(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         w.handle_encoder_press()
 
     def test_handle_encoder_release_noop(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         w.handle_encoder_release()
 
     def test_check_selection_timeout_returns_false(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         assert w.check_selection_timeout() is False
 
     def test_render_returns_image(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         img = w.render()
         assert img.size == (PANEL_WIDTH, PANEL_HEIGHT)
 
 
 class TestWidgetEncoderDecorators:
     def test_on_encoder_turn(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         @w.on_encoder_turn
         async def handler(direction: int):
@@ -150,7 +142,7 @@ class TestWidgetEncoderDecorators:
         assert w._encoder_turn_handler is handler
 
     def test_on_encoder_turn_returns_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler(direction: int):
             pass
@@ -159,7 +151,7 @@ class TestWidgetEncoderDecorators:
         assert result is handler
 
     def test_on_encoder_press(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         @w.on_encoder_press
         async def handler():
@@ -168,7 +160,7 @@ class TestWidgetEncoderDecorators:
         assert w._encoder_press_handler is handler
 
     def test_on_encoder_press_returns_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler():
             pass
@@ -177,7 +169,7 @@ class TestWidgetEncoderDecorators:
         assert result is handler
 
     def test_on_encoder_release(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         @w.on_encoder_release
         async def handler():
@@ -186,7 +178,7 @@ class TestWidgetEncoderDecorators:
         assert w._encoder_release_handler is handler
 
     def test_on_encoder_release_returns_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler():
             pass
@@ -195,7 +187,7 @@ class TestWidgetEncoderDecorators:
         assert result is handler
 
     def test_encoder_handlers_initially_none(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         assert w._encoder_turn_handler is None
         assert w._encoder_press_handler is None
         assert w._encoder_release_handler is None
@@ -203,11 +195,11 @@ class TestWidgetEncoderDecorators:
 
 class TestWidgetPendingCallbacks:
     def test_initially_empty(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         assert w.drain_pending_callbacks() == []
 
     def test_queue_and_drain(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler(value: float):
             pass
@@ -218,7 +210,7 @@ class TestWidgetPendingCallbacks:
         assert callbacks[0] == (handler, (42.0,))
 
     def test_drain_clears_queue(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def handler(value: float):
             pass
@@ -228,7 +220,7 @@ class TestWidgetPendingCallbacks:
         assert w.drain_pending_callbacks() == []
 
     def test_multiple_callbacks_preserved_in_order(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
 
         async def h1(value: float):
             pass
@@ -246,7 +238,7 @@ class TestWidgetPendingCallbacks:
 
 class TestWidgetDispatch:
     async def test_dispatch_encoder_turn_with_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called_with = []
 
         @w.on_encoder_turn
@@ -257,11 +249,11 @@ class TestWidgetDispatch:
         assert called_with == [3]
 
     async def test_dispatch_encoder_turn_no_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         await w.dispatch_encoder_turn(1)
 
     async def test_dispatch_encoder_press_with_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called = []
 
         @w.on_encoder_press
@@ -272,7 +264,7 @@ class TestWidgetDispatch:
         assert called == [True]
 
     async def test_dispatch_encoder_release_with_handler(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called = []
 
         @w.on_encoder_release
@@ -285,7 +277,7 @@ class TestWidgetDispatch:
     async def test_dispatch_touch_tap(self):
         from deckui.runtime.events import EventType, TouchEvent
 
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called = []
 
         @w.on_tap
@@ -298,7 +290,7 @@ class TestWidgetDispatch:
     async def test_dispatch_touch_long_press(self):
         from deckui.runtime.events import EventType, TouchEvent
 
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called = []
 
         @w.on_long_press
@@ -311,7 +303,7 @@ class TestWidgetDispatch:
     async def test_dispatch_touch_drag(self):
         from deckui.runtime.events import EventType, TouchEvent
 
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called = []
 
         @w.on_drag
@@ -326,13 +318,13 @@ class TestWidgetDispatch:
     async def test_dispatch_touch_no_handler(self):
         from deckui.runtime.events import EventType, TouchEvent
 
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         await w.dispatch_touch(TouchEvent(event_type=EventType.TOUCH_SHORT, x=10, y=10))
 
 
 class TestWidgetRefreshCallback:
     async def test_set_and_request_refresh(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         called = []
 
         async def refresh():
@@ -343,39 +335,31 @@ class TestWidgetRefreshCallback:
         assert called == [True]
 
     async def test_request_refresh_no_callback(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         await w.request_refresh()
 
     async def test_prepare_assets_noop(self):
-        w = _ConcreteWidget(0)
+        w = _ConcreteWidget()
         await w.prepare_assets()
 
 
 class TestBlankCard:
     def test_is_card(self):
-        b = BlankCard(0)
+        b = BlankCard()
         assert isinstance(b, Card)
 
-    def test_index(self):
-        b = BlankCard(2)
-        assert b.index == 2
-
     def test_render_returns_none(self):
-        b = BlankCard(0)
+        b = BlankCard()
         assert b.render() is None
 
     def test_initially_dirty(self):
-        b = BlankCard(0)
+        b = BlankCard()
         assert b.is_dirty is True
 
 
 class TestTouchStripInit:
     def test_creates_four_cards(self, touchscreen: TouchStrip):
         assert len(touchscreen.cards) == 4
-
-    def test_card_indices(self, touchscreen: TouchStrip):
-        for i in range(4):
-            assert touchscreen.cards[i].index == i
 
     def test_default_cards_are_blank(self, touchscreen: TouchStrip):
         for w in touchscreen.cards:
@@ -387,7 +371,7 @@ class TestTouchStripCard:
         for i in range(4):
             w = touchscreen.card(i)
             assert isinstance(w, Card)
-            assert w.index == i
+            assert touchscreen.cards[i] is w
 
     def test_same_instance(self, touchscreen: TouchStrip):
         """card(i) returns the same object each time."""
@@ -406,24 +390,24 @@ class TestTouchStripCard:
 
 class TestTouchStripSetCard:
     def test_replace_with_custom_card(self, touchscreen: TouchStrip):
-        cw = _ConcreteWidget(2)
+        cw = _ConcreteWidget()
         touchscreen.set_card(2, cw)
         assert touchscreen.card(2) is cw
 
     def test_replace_with_blank(self, touchscreen: TouchStrip):
-        cw = _ConcreteWidget(0)
+        cw = _ConcreteWidget()
         touchscreen.set_card(0, cw)
-        blank = BlankCard(0)
+        blank = BlankCard()
         touchscreen.set_card(0, blank)
         assert touchscreen.card(0) is blank
 
     def test_index_too_low(self, touchscreen: TouchStrip):
         with pytest.raises(IndexError, match="Card index must be 0-3"):
-            touchscreen.set_card(-1, _ConcreteWidget(0))
+            touchscreen.set_card(-1, _ConcreteWidget())
 
     def test_index_too_high(self, touchscreen: TouchStrip):
         with pytest.raises(IndexError, match="Card index must be 0-3"):
-            touchscreen.set_card(4, _ConcreteWidget(0))
+            touchscreen.set_card(4, _ConcreteWidget())
 
     def test_rejects_non_card(self, touchscreen: TouchStrip):
         with pytest.raises(TypeError, match="Expected a Card instance"):


### PR DESCRIPTION
## Summary

Follow-up to PR #141. After we stopped mutating `_index` on `Screen.set_key` / `TouchStrip.set_card`, the `.index` property became a misleading artefact:

- For fresh `DuiKey(spec)` / `DuiCard(spec)` it always returned `-1` (the value the subclass passed up to `super().__init__(-1)`).
- For `KeySlot(N)` / `EncoderSlot(N)` it just echoed the constructor argument that nothing internal actually used.

Routing has always been screen-side via `screen._keys` / `screen.touch_strip._cards`, so the property carried no real information beyond "what number got stuffed into `__init__`."

This PR removes it cleanly. The library has no external users, so no compatibility shim.

## Changes

**Source** (16 files, +92/-156):

- `KeySlot`, `EncoderSlot`, `Card`: dropped the `index` constructor parameter, the `_index` field, and the `.index` property.
- `DuiKey` / `DuiCard`: dropped the redundant `super().__init__(-1)` — now just `super().__init__()`.
- `TouchStrip`: `BlankCard()` with no index in its default construction loop.
- `Screen.key()` / `Screen.encoder()`: `KeySlot()` / `EncoderSlot()` with no index.

**Tests**: dropped `.index` assertions everywhere they appeared. Where the test was *asserting* the post-install routing was correct, it now asserts via `screen.keys[i] is key` / `screen.touch_strip.cards[i] is card` (the screen-side dict / list which is the real source of truth). The two cross-screen tests added in PR #141 still pass and still lock in the regression invariant.

## Test plan

- [x] `pytest --cov=deckui --cov-fail-under=95` — 1141 pass, coverage **97.78%** (essentially unchanged from PR #141's 97.79%).
- [x] `ruff check .` clean, `mypy src/deckui` clean.
- [x] `examples/streamdeck.py` smoke-imports cleanly with no real device.

The Stream Deck+ on-device behaviour is unchanged — this is purely a public-API cleanup. The cross-screen tests from PR #141 protect the runtime invariant either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
