### PR TITLE
Make Stream Deck example strictly event-driven; add AsyncEvent + Deck state-change events

### DIFF
--- a/examples/mock_backend.py
+++ b/examples/mock_backend.py
@@ -1,13 +1,21 @@
 """Mock backend services for the Stream Deck demo.
 
-This module contains pure-Python domain logic with **no DeckUI imports**.
-Each service simulates a real-world backend (audio player, smart lights,
-countdown timer, dashboard telemetry) so that ``streamdeck.py`` can focus
-exclusively on demonstrating DeckUI's API.
+This module contains pure-Python domain logic with **no DeckUI imports
+beyond the** :class:`~deckui.AsyncEvent` **primitive**.  Each service
+simulates a real-world backend (audio player, smart lights, countdown
+timer, dashboard telemetry, scene activator) and emits events when its
+state actually changes.
 
-Services emit async events when their state changes, allowing controllers
-to react and update the UI accordingly -- exactly as a real integration
-(Spotify, Home Assistant, etc.) would work.
+These services are intentionally hardware- and UI-ignorant:
+
+* Values are kept in **domain units** (volume in percent 0-100, timer
+  remaining in seconds, temperature in degrees Celsius).  No
+  normalisation to slider ranges.  No formatted strings.
+* Events carry the changed value, not pre-rendered text.
+
+The controllers in :mod:`streamdeck` translate domain values to
+presentation, exactly as a real integration with Spotify, Home
+Assistant, etc. would do.
 
 Swap these classes for real integrations and the DeckUI wiring in
 ``streamdeck.py`` stays the same.
@@ -15,10 +23,12 @@ Swap these classes for real integrations and the DeckUI wiring in
 
 from __future__ import annotations
 
-import datetime
+import asyncio
+import contextlib
 import logging
-from collections.abc import Awaitable, Callable
-from typing import Any
+import random
+
+from deckui import AsyncEvent
 
 log = logging.getLogger(__name__)
 
@@ -62,67 +72,6 @@ SCENE_DEFS: list[dict[str, str]] = [
 
 
 # ===========================================================================
-# Async event helper
-# ===========================================================================
-
-
-class AsyncEvent:
-    """A simple async event that can have multiple subscribers.
-
-    Subscribers are registered with the call operator (used as a
-    decorator) and invoked with :meth:`emit`.  This mirrors the
-    pattern a real backend SDK would expose for property-change
-    notifications.
-
-    Examples
-    --------
-    ::
-
-        svc = SomeService()
-
-        @svc.on_brightness_changed
-        async def _handle(value: int) -> None:
-            print(f"brightness is now {value}")
-
-        await svc.on_brightness_changed.emit(75)
-    """
-
-    def __init__(self) -> None:
-        self._handlers: list[Callable[..., Awaitable[None]]] = []
-
-    def __call__(
-        self, fn: Callable[..., Awaitable[None]]
-    ) -> Callable[..., Awaitable[None]]:
-        """Register *fn* as a subscriber (decorator usage).
-
-        Parameters
-        ----------
-        fn : Callable[..., Awaitable[None]]
-            Async callback to invoke when the event fires.
-
-        Returns
-        -------
-        Callable[..., Awaitable[None]]
-            The original function, unmodified.
-        """
-        self._handlers.append(fn)
-        return fn
-
-    async def emit(self, *args: Any, **kwargs: Any) -> None:
-        """Invoke all registered handlers with the given arguments.
-
-        Parameters
-        ----------
-        *args : Any
-            Positional arguments forwarded to each handler.
-        **kwargs : Any
-            Keyword arguments forwarded to each handler.
-        """
-        for handler in self._handlers:
-            await handler(*args, **kwargs)
-
-
-# ===========================================================================
 # Mock services
 # ===========================================================================
 
@@ -136,42 +85,40 @@ class MockAudioService:
         Emitted when the current track or playback state changes.
         Signature: ``(track: dict[str, str], is_playing: bool) -> None``.
     on_volume_changed : AsyncEvent
-        Emitted when volume level or mute state changes.
-        Signature: ``(volume_level: float, volume_text: str) -> None``.
+        Emitted when the volume value changes.
+        Signature: ``(volume: int) -> None`` -- domain percent in
+        ``[0, 100]``.
+    on_mute_changed : AsyncEvent
+        Emitted when the mute state changes.
+        Signature: ``(is_muted: bool) -> None``.
 
     Parameters
     ----------
     catalog : list[dict[str, str]]
         Media entries with ``artist``, ``album``, ``title``, ``cover``.
-    initial_volume : float, default=0.3
-        Starting volume (0.0 -- 1.0).
+    initial_volume : int, default=50
+        Starting volume in percent (0-100, clamped).
     """
 
     def __init__(
         self,
         catalog: list[dict[str, str]],
-        initial_volume: float = 0.3,
+        initial_volume: int = 50,
     ) -> None:
         self._catalog = list(catalog)
         self._index = 0
-        self.volume_level: float = initial_volume
+        self.volume: int = max(0, min(100, initial_volume))
         self.is_muted: bool = False
         self.is_playing: bool = False
 
-        self.on_track_changed = AsyncEvent()
-        self.on_volume_changed = AsyncEvent()
+        self.on_track_changed: AsyncEvent = AsyncEvent()
+        self.on_volume_changed: AsyncEvent = AsyncEvent()
+        self.on_mute_changed: AsyncEvent = AsyncEvent()
 
     @property
     def current_track(self) -> dict[str, str]:
         """The currently selected media entry."""
         return self._catalog[self._index]
-
-    @property
-    def volume_text(self) -> str:
-        """Human-readable volume or ``'Muted'``."""
-        if self.is_muted:
-            return "Muted"
-        return f"{int(self.volume_level * 100)}%"
 
     async def play(self, track: dict[str, str] | None = None) -> None:
         """Start playback, optionally jumping to *track*.
@@ -229,23 +176,28 @@ class MockAudioService:
         await self.on_track_changed.emit(t, self.is_playing)
         return t
 
-    async def set_volume(self, level: float) -> None:
-        """Set volume in [0.0, 1.0] (clamped).
+    async def set_volume(self, value: int) -> None:
+        """Set volume in percent ``[0, 100]`` (clamped).
+
+        Idempotent: a same-value call neither logs nor emits.
 
         Parameters
         ----------
-        level : float
-            Volume between 0.0 and 1.0.
+        value : int
+            Target volume in percent.
         """
-        self.volume_level = max(0.0, min(1.0, level))
-        log.info("Volume: %.0f%%", self.volume_level * 100)
-        await self.on_volume_changed.emit(self.volume_level, self.volume_text)
+        clamped = max(0, min(100, value))
+        if clamped == self.volume:
+            return
+        self.volume = clamped
+        log.info("Volume: %d%%", self.volume)
+        await self.on_volume_changed.emit(self.volume)
 
     async def toggle_mute(self) -> None:
-        """Toggle mute."""
+        """Toggle mute and emit :attr:`on_mute_changed`."""
         self.is_muted = not self.is_muted
         log.info("Muted: %s", self.is_muted)
-        await self.on_volume_changed.emit(self.volume_level, self.volume_text)
+        await self.on_mute_changed.emit(self.is_muted)
 
 
 class MockLightsService:
@@ -288,9 +240,9 @@ class MockLightsService:
         self.brightness: int = brightness
         self.kelvin: int = kelvin
 
-        self.on_toggled = AsyncEvent()
-        self.on_brightness_changed = AsyncEvent()
-        self.on_kelvin_changed = AsyncEvent()
+        self.on_toggled: AsyncEvent = AsyncEvent()
+        self.on_brightness_changed: AsyncEvent = AsyncEvent()
+        self.on_kelvin_changed: AsyncEvent = AsyncEvent()
 
     async def toggle(self) -> None:
         """Toggle lights on/off."""
@@ -301,12 +253,17 @@ class MockLightsService:
     async def set_brightness(self, value: int) -> None:
         """Set brightness percentage (clamped to 0 -- 100).
 
+        Idempotent: a same-value call emits nothing.
+
         Parameters
         ----------
         value : int
             Target brightness.
         """
-        self.brightness = max(self.BRIGHTNESS_MIN, min(self.BRIGHTNESS_MAX, value))
+        clamped = max(self.BRIGHTNESS_MIN, min(self.BRIGHTNESS_MAX, value))
+        if clamped == self.brightness:
+            return
+        self.brightness = clamped
         log.info("Brightness: %d%%", self.brightness)
         await self.on_brightness_changed.emit(self.brightness)
 
@@ -318,7 +275,10 @@ class MockLightsService:
         value : int
             Target colour temperature.
         """
-        self.kelvin = max(self.KELVIN_MIN, min(self.KELVIN_MAX, value))
+        clamped = max(self.KELVIN_MIN, min(self.KELVIN_MAX, value))
+        if clamped == self.kelvin:
+            return
+        self.kelvin = clamped
         log.info("Kelvin: %dK", self.kelvin)
         await self.on_kelvin_changed.emit(self.kelvin)
 
@@ -326,14 +286,19 @@ class MockLightsService:
 class MockTimerService:
     """Simulated countdown timer -- duration, remaining, start/pause/reset.
 
+    All times are in **seconds**.  Conversion to display strings is the
+    controller's responsibility.
+
     Events
     ------
-    on_timer_changed : AsyncEvent
-        Emitted when the timer display should update (toggle, reset,
-        adjust, or tick).
-        Signature: ``(formatted_time: str) -> None``.
+    on_remaining_changed : AsyncEvent
+        Emitted whenever ``remaining`` changes.
+        Signature: ``(remaining_seconds: int) -> None``.
+    on_running_changed : AsyncEvent
+        Emitted when the timer transitions between running and paused.
+        Signature: ``(is_running: bool) -> None``.
     on_finished : AsyncEvent
-        Emitted when the countdown reaches zero.
+        Emitted once when the countdown reaches zero while running.
         Signature: ``() -> None``.
 
     Parameters
@@ -342,86 +307,51 @@ class MockTimerService:
         Starting countdown duration in seconds.
     """
 
-    COARSE_STEP_S = 600
-    """Seconds added/removed per encoder-turn step (no hold) -- 10 minutes."""
-    FINE_STEP_S = 30
-    """Seconds added/removed per encoder-hold-turn step -- 30 seconds."""
-
     def __init__(self, initial_seconds: int) -> None:
         self._default_duration: int = initial_seconds
         self.duration: int = initial_seconds
         self.remaining: int = initial_seconds
         self.is_running: bool = False
 
-        self.on_timer_changed = AsyncEvent()
-        self.on_finished = AsyncEvent()
-
-    @staticmethod
-    def parse_hhmmss(text: str) -> int:
-        """Parse an ``HH:MM:SS`` string into total seconds.
-
-        Parameters
-        ----------
-        text : str
-            Time string in ``HH:MM:SS`` format.
-
-        Returns
-        -------
-        int
-            Total number of seconds.
-
-        Raises
-        ------
-        ValueError
-            If *text* does not match the expected format.
-        """
-        parts = text.strip().split(":")
-        if len(parts) != 3:
-            raise ValueError(f"Expected HH:MM:SS, got {text!r}")
-        hours, minutes, seconds = (int(p) for p in parts)
-        return hours * 3600 + minutes * 60 + seconds
-
-    def format_time(self) -> str:
-        """Format ``remaining`` as ``HH:MM:SS``.
-
-        Returns
-        -------
-        str
-            Zero-padded ``HH:MM:SS`` string.
-        """
-        h, rem = divmod(max(0, self.remaining), 3600)
-        m, s = divmod(rem, 60)
-        return f"{h:02d}:{m:02d}:{s:02d}"
+        self.on_remaining_changed: AsyncEvent = AsyncEvent()
+        self.on_running_changed: AsyncEvent = AsyncEvent()
+        self.on_finished: AsyncEvent = AsyncEvent()
 
     async def toggle(self) -> None:
         """Start or pause the countdown.
 
-        When starting, the current ``remaining`` value is captured as the
-        new default duration.  If the timer was paused at zero, it restarts
-        from the current default.
+        When starting, the current ``remaining`` value is captured as
+        the new default duration.  If the timer was paused at zero, it
+        restarts from the current default.
         """
         if not self.is_running:
             if self.remaining <= 0:
                 self.remaining = self._default_duration
+                await self.on_remaining_changed.emit(self.remaining)
             self._default_duration = self.remaining
             self.duration = self.remaining
             log.info(
-                "Timer started -- %s (new default: %d s)",
-                self.format_time(),
+                "Timer started -- %d s (new default: %d s)",
+                self.remaining,
                 self._default_duration,
             )
         else:
-            log.info("Timer paused -- %s", self.format_time())
+            log.info("Timer paused -- %d s", self.remaining)
         self.is_running = not self.is_running
-        await self.on_timer_changed.emit(self.format_time())
+        await self.on_running_changed.emit(self.is_running)
 
     async def reset(self) -> None:
         """Stop the countdown and reload the current default duration."""
+        was_running = self.is_running
         self.is_running = False
         self.duration = self._default_duration
+        previous_remaining = self.remaining
         self.remaining = self._default_duration
-        log.info("Timer reset -- %s", self.format_time())
-        await self.on_timer_changed.emit(self.format_time())
+        log.info("Timer reset -- %d s", self.remaining)
+        if was_running:
+            await self.on_running_changed.emit(False)
+        if previous_remaining != self.remaining:
+            await self.on_remaining_changed.emit(self.remaining)
 
     async def adjust_duration(self, delta_seconds: int) -> None:
         """Add (or subtract) seconds to/from the configured duration.
@@ -431,57 +361,163 @@ class MockTimerService:
         delta_seconds : int
             Seconds to add (positive) or subtract (negative).
         """
-        self.duration = max(0, self.duration + delta_seconds)
-        self.remaining = self.duration
-        log.info("Timer duration: %s", self.format_time())
-        await self.on_timer_changed.emit(self.format_time())
+        new_duration = max(0, self.duration + delta_seconds)
+        if new_duration == self.duration:
+            return
+        self.duration = new_duration
+        self.remaining = new_duration
+        log.info("Timer duration: %d s", self.remaining)
+        await self.on_remaining_changed.emit(self.remaining)
 
     async def tick(self) -> None:
         """Decrement *remaining* by one second if running.
 
-        Emits :attr:`on_timer_changed` on every active tick and
+        Emits :attr:`on_remaining_changed` on every active tick and
         :attr:`on_finished` when the countdown reaches zero.
         """
         if not self.is_running or self.remaining <= 0:
             return
         self.remaining -= 1
-        await self.on_timer_changed.emit(self.format_time())
+        await self.on_remaining_changed.emit(self.remaining)
         if self.remaining <= 0 and self.is_running:
             self.is_running = False
             log.info("Timer finished")
+            await self.on_running_changed.emit(False)
             await self.on_finished.emit()
 
 
 class MockDashboardService:
-    """Simulated dashboard telemetry backend -- weather and clock.
+    """Simulated dashboard telemetry backend -- weather telemetry.
 
-    This service represents an external data source (e.g. a weather API
-    or home-automation hub) that provides read-only telemetry.  Device
-    control (deck brightness, screen cycling) is application logic and
-    belongs in the controller layer, not here.
+    Represents an external sensor / weather-API integration that pushes
+    updates to its subscribers.  In a real system this would be a
+    long-lived MQTT subscription, a websocket connection, etc.; here we
+    simulate it with a background coroutine that nudges the readings
+    every :attr:`UPDATE_INTERVAL_S` seconds.
+
+    Clock display is intentionally **not** the dashboard service's
+    concern -- the system clock is a poll-driven ambient signal, so the
+    controller just reads :func:`datetime.datetime.now` directly.
+
+    Events
+    ------
+    on_telemetry_changed : AsyncEvent
+        Emitted whenever a telemetry value changes.
+        Signature: ``(temperature_c: float, humidity_pct: int) -> None``.
 
     Parameters
     ----------
-    temperature : str, default="22C"
-        Initial temperature reading.
-    humidity : str, default="45%"
-        Initial humidity reading.
+    temperature_c : float, default=22.0
+        Initial temperature in degrees Celsius.
+    humidity_pct : int, default=45
+        Initial relative humidity in percent (0 -- 100).
     """
+
+    UPDATE_INTERVAL_S = 5.0
+    """Seconds between simulated telemetry pushes."""
 
     def __init__(
         self,
-        temperature: str = "22C",
-        humidity: str = "45%",
+        temperature_c: float = 22.0,
+        humidity_pct: int = 45,
     ) -> None:
-        self.temperature: str = temperature
-        self.humidity: str = humidity
+        self.temperature_c: float = temperature_c
+        self.humidity_pct: int = max(0, min(100, humidity_pct))
 
-    @staticmethod
-    def get_date() -> str:
-        """Return today's date as ``YYYY-MM-DD``."""
-        return datetime.datetime.now().strftime("%Y-%m-%d")
+        self.on_telemetry_changed: AsyncEvent = AsyncEvent()
+        self._task: asyncio.Task[None] | None = None
 
-    @staticmethod
-    def get_time() -> str:
-        """Return the current local time as ``HH:MM``."""
-        return datetime.datetime.now().strftime("%H:%M")
+    async def set_telemetry(
+        self, temperature_c: float, humidity_pct: int
+    ) -> None:
+        """Push new telemetry values.
+
+        Idempotent: emits only if at least one value has changed.
+
+        Parameters
+        ----------
+        temperature_c : float
+            New temperature reading (°C).
+        humidity_pct : int
+            New humidity reading (percent, clamped).
+        """
+        new_humidity = max(0, min(100, humidity_pct))
+        if (
+            temperature_c == self.temperature_c
+            and new_humidity == self.humidity_pct
+        ):
+            return
+        self.temperature_c = temperature_c
+        self.humidity_pct = new_humidity
+        await self.on_telemetry_changed.emit(
+            self.temperature_c, self.humidity_pct
+        )
+
+    async def start(self) -> None:
+        """Start the telemetry-simulator background task (idempotent)."""
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(
+                self._simulate(), name="dashboard-telemetry"
+            )
+
+    async def stop(self) -> None:
+        """Cancel the simulator and wait for it to exit."""
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def _simulate(self) -> None:
+        """Nudge readings periodically to demonstrate event-driven push."""
+        try:
+            while True:
+                await asyncio.sleep(self.UPDATE_INTERVAL_S)
+                temperature = round(
+                    self.temperature_c + random.uniform(-0.4, 0.4), 1
+                )
+                humidity = max(
+                    0,
+                    min(100, self.humidity_pct + random.randint(-2, 2)),
+                )
+                await self.set_telemetry(temperature, humidity)
+        except asyncio.CancelledError:
+            pass
+
+
+class MockScenesService:
+    """Simulated scene activator -- "set the room to Cinema mode".
+
+    A real implementation would call out to Home Assistant, Hue, etc.
+    Here we just track the most recently activated scene and emit an
+    event so subscribers (e.g. a UI controller) can react.
+
+    Events
+    ------
+    on_scene_activated : AsyncEvent
+        Emitted on every successful :meth:`activate` call.
+        Signature: ``(label: str) -> None``.
+
+    Attributes
+    ----------
+    active_scene : str | None
+        Label of the most recently activated scene, or ``None`` before
+        the first activation.
+    """
+
+    def __init__(self) -> None:
+        self.active_scene: str | None = None
+        self.on_scene_activated: AsyncEvent = AsyncEvent()
+
+    async def activate(self, label: str) -> None:
+        """Activate the named scene and emit :attr:`on_scene_activated`.
+
+        Parameters
+        ----------
+        label : str
+            Scene label to activate.
+        """
+        self.active_scene = label
+        log.info("Scene activated: %s", label)
+        await self.on_scene_activated.emit(label)

--- a/examples/mock_backend.py
+++ b/examples/mock_backend.py
@@ -414,7 +414,6 @@ class MockDashboardService:
     """
 
     UPDATE_INTERVAL_S = 5.0
-    """Seconds between simulated telemetry pushes."""
 
     def __init__(
         self,

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -449,9 +449,7 @@ class TimerController:
     FLASH_COUNT = 6
     FLASH_INTERVAL_S = 0.3
     COARSE_STEP_S = 600
-    """Seconds added/removed per encoder-turn step (no hold) -- 10 minutes."""
     FINE_STEP_S = 30
-    """Seconds added/removed per encoder-hold-turn step -- 30 seconds."""
 
     def __init__(
         self,

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -6,33 +6,50 @@ any connected Stream Deck.  It is designed to read top-to-bottom as a
 tutorial -- each section introduces one feature.
 
 Domain logic (audio playback, smart lights, timer countdown, dashboard
-telemetry) lives in :mod:`mock_backend` so this file focuses purely on
-DeckUI wiring.  Swap those mock services for real integrations and the
-code below stays the same.
+telemetry, scene activation) lives in :mod:`mock_backend` so this file
+focuses purely on DeckUI wiring.  Swap those mock services for real
+integrations and the code below stays the same.
 
-**Event-driven architecture** -- controllers never update the UI directly
-in response to user input.  Instead, DUI event handlers call service
-methods (e.g. ``svc.set_brightness(80)``), and the service emits an
-async event (e.g. ``on_brightness_changed``) once the state has actually
-changed.  The controller subscribes to that event and updates the card
-bindings there.  This is the same pattern a real backend would use:
-the UI always reflects *confirmed* state, not *requested* state.
+**Event-driven architecture**
+-----------------------------
+
+Every controller follows the same one-way data flow:
+
+    DUI / device input  --->  service.method(...)
+                                   |
+                                   v
+                         service emits change event
+                                   |
+                                   v
+                         controller subscriber
+                                   |
+                                   v
+                         card.set(...) + request_refresh()
+
+DUI event handlers in this file **never** mutate card bindings
+directly.  They only call service methods.  The service updates its
+state and fires an async event with the *new value in domain units*;
+the controller's subscriber is the single place that translates a
+domain value into UI bindings (formatting, normalisation, etc.).
+
+The same rule applies to deck-owned state:
+:meth:`deckui.Deck.set_brightness` and :meth:`deckui.Deck.set_screen`
+each emit an event, so brightness/screen UI updates only reflect
+*confirmed* hardware/screen state.
 
 What it demonstrates
 --------------------
 * :class:`~deckui.DeckManager` for auto-discovery and hot-plug.
+* :class:`~deckui.AsyncEvent` as the property-change-notification
+  primitive both for backend services and for ``Deck`` itself.
 * Loading ``.dui`` packages via :func:`~deckui.load_package` and using
   :class:`~deckui.DuiCard` / :class:`~deckui.DuiKey`.
-* Using :meth:`~deckui.DuiCard.set` / :meth:`~deckui.DuiCard.set_many`
-  / :meth:`~deckui.DuiCard.set_range` / :meth:`~deckui.DuiCard.adjust_range`
-  helpers instead of manual normalisation.
-* Triggering re-renders from key handlers and background tasks via
+* Triggering re-renders from background tasks via
   :meth:`~deckui.DuiCard.request_refresh`.
 * A live, asyncio-driven countdown ``TimerCard`` and a dashboard clock
-  that ticks every second.
+  that ticks every second; weather telemetry pushed by a simulator.
 * Multi-screen navigation -- a ``main`` screen and a ``settings``
-  screen, cycled by an encoder press-release on the dashboard card
-  (see ``DashboardCard.dui``'s ``next_screen`` event).
+  screen, cycled by an encoder press-release on the dashboard card.
 
 Running
 -------
@@ -48,6 +65,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import datetime
 import logging
 from pathlib import Path
 from typing import Any
@@ -58,11 +76,12 @@ from mock_backend import (
     MockAudioService,
     MockDashboardService,
     MockLightsService,
+    MockScenesService,
     MockTimerService,
 )
 from PIL import Image
 
-from deckui import DeckManager, DeviceInfo, DuiCard, DuiKey, load_package
+from deckui import Deck, DeckManager, DeviceInfo, DuiCard, DuiKey, load_package
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
@@ -75,23 +94,6 @@ EXAMPLES_DIR = Path(__file__).resolve().parent
 # ===========================================================================
 # Controllers
 # ===========================================================================
-#
-# Each controller owns one ``.dui`` widget (card or key) and a mock
-# service from ``mock_backend``.
-#
-# The flow is:
-#
-#   1. A DUI event fires (encoder turn, key press, etc.).
-#   2. The controller's event handler calls the *service* method
-#      (e.g. ``svc.set_brightness(80)``).
-#   3. The service updates its internal state and emits an async event
-#      (e.g. ``on_brightness_changed``).
-#   4. The controller's *subscriber* for that event updates the card
-#      bindings and calls ``request_refresh()``.
-#
-# This decouples "what happened" from "how the UI reacts" -- exactly
-# how a real integration (Spotify, Home Assistant, etc.) would work.
-# ===========================================================================
 
 
 class AudioController:
@@ -99,14 +101,13 @@ class AudioController:
 
     Loads ``AudioCard.dui`` and binds encoder events:
 
-    * encoder hold     -> toggle play/pause
-    * encoder turn     -> volume up/down
-    * encoder click    -> mute toggle
+    * encoder hold       -> toggle play/pause
+    * encoder turn       -> volume up/down
+    * encoder click      -> mute toggle
     * encoder press+turn -> previous/next track
 
-    Favourite keys (see :class:`FavoritesController`) call
-    :meth:`MockAudioService.play` via the service to start a specific
-    track.
+    All UI updates flow through the service's ``on_*`` events; DUI
+    handlers only call service methods.
 
     Parameters
     ----------
@@ -116,6 +117,9 @@ class AudioController:
         Directory containing ``AudioCard.dui``.  Defaults to ``examples/``.
     """
 
+    VOLUME_MIN = 0
+    VOLUME_MAX = 100
+
     def __init__(
         self,
         catalog: list[dict[str, str]],
@@ -124,14 +128,17 @@ class AudioController:
         self._pkg_dir = packages_dir or EXAMPLES_DIR
         self._card = DuiCard(load_package(self._pkg_dir / "AudioCard.dui"))
 
-        # Read the initial volume from the .dui package's range binding
-        # default so the package is the single source of truth.
-        initial_volume: float = self._card.get("volume")
+        # The .dui range default (0.0-1.0) is the source of truth for
+        # the initial volume.  Convert to domain percent and pass to
+        # the service.
+        initial_volume = int(
+            round(self._card.get_range("volume", min_val=0, max_val=100))
+        )
         self._svc = MockAudioService(catalog, initial_volume=initial_volume)
 
-        self._sync_card()
         self._subscribe_events()
         self._bind_dui_events()
+        self._initialize_bindings()
 
     # -- public API -----------------------------------------------------
 
@@ -146,9 +153,9 @@ class AudioController:
         return self._svc
 
     @property
-    def volume_level(self) -> float:
-        """Current volume level (0.0 -- 1.0)."""
-        return self._svc.volume_level
+    def volume(self) -> int:
+        """Current volume in percent (0-100)."""
+        return self._svc.volume
 
     @property
     def is_muted(self) -> bool:
@@ -165,47 +172,66 @@ class AudioController:
         """The currently selected media entry."""
         return self._svc.current_track
 
-    # -- internal -------------------------------------------------------
+    # -- presentation helpers ------------------------------------------
+    #
+    # These are the *only* places that translate domain state into
+    # card bindings.  Subscribers and the initial-binding routine both
+    # call them, so there is one source of truth for "service state ->
+    # bindings".
 
-    def _sync_card(self) -> None:
-        """Push the full player state into card bindings (initial load only)."""
-        t = self._svc.current_track
+    def _apply_track(self, track: dict[str, str], is_playing: bool) -> None:
         self._card.set_many(
-            artist=t["artist"],
-            title=t["title"],
-            album=t["album"],
-            state="Playing" if self._svc.is_playing else "Paused",
+            artist=track["artist"],
+            title=track["title"],
+            album=track["album"],
+            state="Playing" if is_playing else "Paused",
         )
-        cover_path = self._pkg_dir / t["cover"]
+        cover_path = self._pkg_dir / track["cover"]
         if cover_path.exists():
             self._card.set("cover", Image.open(cover_path))
+
+    def _apply_volume(self, volume: int) -> None:
         self._card.set_range(
-            "volume", self._svc.volume_level * 100, min_val=0, max_val=100
+            "volume", volume, min_val=self.VOLUME_MIN, max_val=self.VOLUME_MAX
         )
-        self._card.set("value_text", self._svc.volume_text)
+        if not self._svc.is_muted:
+            self._card.set("value_text", f"{volume}%")
+
+    def _apply_mute(self, is_muted: bool) -> None:
+        if is_muted:
+            self._card.set("value_text", "Muted")
+        else:
+            self._card.set("value_text", f"{self._svc.volume}%")
+
+    # -- internal -------------------------------------------------------
+
+    def _initialize_bindings(self) -> None:
+        """Populate the card from current service state.
+
+        Called once during construction.  The deck's first
+        :meth:`~deckui.Deck.set_screen` performs the actual render, so
+        no ``request_refresh`` is needed here.
+        """
+        self._apply_track(self._svc.current_track, self._svc.is_playing)
+        self._apply_volume(self._svc.volume)
+        self._apply_mute(self._svc.is_muted)
 
     def _subscribe_events(self) -> None:
         """Subscribe to service state-change events."""
 
         @self._svc.on_track_changed
         async def _on_track(track: dict[str, str], is_playing: bool) -> None:
-            self._card.set_many(
-                artist=track["artist"],
-                title=track["title"],
-                album=track["album"],
-                state="Playing" if is_playing else "Paused",
-            )
-            cover_path = self._pkg_dir / track["cover"]
-            if cover_path.exists():
-                self._card.set("cover", Image.open(cover_path))
+            self._apply_track(track, is_playing)
             await self._card.request_refresh()
 
         @self._svc.on_volume_changed
-        async def _on_volume(volume_level: float, volume_text: str) -> None:
-            self._card.set_range(
-                "volume", volume_level * 100, min_val=0, max_val=100
-            )
-            self._card.set("value_text", volume_text)
+        async def _on_volume(volume: int) -> None:
+            self._apply_volume(volume)
+            await self._card.request_refresh()
+
+        @self._svc.on_mute_changed
+        async def _on_mute(is_muted: bool) -> None:
+            self._apply_mute(is_muted)
             await self._card.request_refresh()
 
     def _bind_dui_events(self) -> None:
@@ -218,13 +244,11 @@ class AudioController:
 
         @card.on("volume_up")
         async def _vol_up(steps: int) -> None:
-            new = card.adjust_range("volume", steps, min_val=0, max_val=100)
-            await self._svc.set_volume(new / 100.0)
+            await self._svc.set_volume(self._svc.volume + steps)
 
         @card.on("volume_down")
         async def _vol_down(steps: int) -> None:
-            new = card.adjust_range("volume", -abs(steps), min_val=0, max_val=100)
-            await self._svc.set_volume(new / 100.0)
+            await self._svc.set_volume(self._svc.volume - abs(steps))
 
         @card.on("mute_toggle")
         async def _mute() -> None:
@@ -248,11 +272,8 @@ class LightsController:
     * encoder turn        -> brightness up/down (5 % per step)
     * encoder press+turn  -> kelvin up/down (100 K per step)
 
-    The display ranges (:attr:`BRIGHTNESS_MIN`/``MAX``,
-    :attr:`KELVIN_MIN`/``MAX``) are owned by the controller, not the
-    backend service.  A real backend may clamp differently — keeping the
-    ranges here means the UI is stable when you swap the mock for, say,
-    Home Assistant.
+    Display ranges live on the controller because they are UI choices
+    (a real Hue bridge clamps differently to the physical LEDs).
 
     Parameters
     ----------
@@ -264,6 +285,8 @@ class LightsController:
     BRIGHTNESS_MAX = 100
     KELVIN_MIN = 2000
     KELVIN_MAX = 6500
+    BRIGHTNESS_STEP = 5
+    KELVIN_STEP = 100
 
     def __init__(
         self,
@@ -272,27 +295,34 @@ class LightsController:
         pkg_dir = packages_dir or EXAMPLES_DIR
         self._card = DuiCard(load_package(pkg_dir / "LightCard.dui"))
 
-        # Read initial values from the .dui package defaults.
-        # Slider defaults are normalised (0.0-1.0); denormalise to domain.
-        bright_norm: float = self._card.get("brightness")
-        kelvin_norm: float = self._card.get("kelvin")
-        brightness = int(
-            self.BRIGHTNESS_MIN
-            + bright_norm * (self.BRIGHTNESS_MAX - self.BRIGHTNESS_MIN)
+        # The card defaults are the source of truth for the initial
+        # service state, mirroring the "backend bootstraps from device
+        # last-known values" pattern of a real integration.
+        initial_brightness = int(
+            round(
+                self._card.get_range(
+                    "brightness",
+                    min_val=self.BRIGHTNESS_MIN,
+                    max_val=self.BRIGHTNESS_MAX,
+                )
+            )
         )
-        kelvin = int(
-            self.KELVIN_MIN
-            + kelvin_norm * (self.KELVIN_MAX - self.KELVIN_MIN)
+        initial_kelvin = int(
+            round(
+                self._card.get_range(
+                    "kelvin", min_val=self.KELVIN_MIN, max_val=self.KELVIN_MAX
+                )
+            )
         )
         self._svc = MockLightsService(
             is_on=self._card.get("lights"),
-            brightness=brightness,
-            kelvin=kelvin,
+            brightness=initial_brightness,
+            kelvin=initial_kelvin,
         )
 
-        self._sync_card()
         self._subscribe_events()
         self._bind_dui_events()
+        self._initialize_bindings()
 
     @property
     def card(self) -> DuiCard:
@@ -314,52 +344,49 @@ class LightsController:
         """Current colour temperature in Kelvin."""
         return self._svc.kelvin
 
-    def _sync_card(self) -> None:
-        """Push the full light state into card bindings (initial load only)."""
-        self._card.set("lights", self._svc.is_on)
-        self._card.set("brightness_value_text", f"{self._svc.brightness}%")
+    # -- presentation helpers ------------------------------------------
+
+    def _apply_toggle(self, is_on: bool) -> None:
+        self._card.set("lights", is_on)
+
+    def _apply_brightness(self, brightness: int) -> None:
+        self._card.set("brightness_value_text", f"{brightness}%")
         self._card.set_range(
             "brightness",
-            self._svc.brightness,
+            brightness,
             min_val=self.BRIGHTNESS_MIN,
             max_val=self.BRIGHTNESS_MAX,
         )
-        self._card.set("kelvin_value_text", f"{self._svc.kelvin}K")
+
+    def _apply_kelvin(self, kelvin: int) -> None:
+        self._card.set("kelvin_value_text", f"{kelvin}K")
         self._card.set_range(
-            "kelvin",
-            self._svc.kelvin,
-            min_val=self.KELVIN_MIN,
-            max_val=self.KELVIN_MAX,
+            "kelvin", kelvin, min_val=self.KELVIN_MIN, max_val=self.KELVIN_MAX
         )
+
+    # -- internal -------------------------------------------------------
+
+    def _initialize_bindings(self) -> None:
+        self._apply_toggle(self._svc.is_on)
+        self._apply_brightness(self._svc.brightness)
+        self._apply_kelvin(self._svc.kelvin)
 
     def _subscribe_events(self) -> None:
         """Subscribe to service state-change events."""
 
         @self._svc.on_toggled
         async def _on_toggled(is_on: bool) -> None:
-            self._card.set("lights", is_on)
+            self._apply_toggle(is_on)
             await self._card.request_refresh()
 
         @self._svc.on_brightness_changed
         async def _on_brightness(brightness: int) -> None:
-            self._card.set("brightness_value_text", f"{brightness}%")
-            self._card.set_range(
-                "brightness",
-                brightness,
-                min_val=self.BRIGHTNESS_MIN,
-                max_val=self.BRIGHTNESS_MAX,
-            )
+            self._apply_brightness(brightness)
             await self._card.request_refresh()
 
         @self._svc.on_kelvin_changed
         async def _on_kelvin(kelvin: int) -> None:
-            self._card.set("kelvin_value_text", f"{kelvin}K")
-            self._card.set_range(
-                "kelvin",
-                kelvin,
-                min_val=self.KELVIN_MIN,
-                max_val=self.KELVIN_MAX,
-            )
+            self._apply_kelvin(kelvin)
             await self._card.request_refresh()
 
     def _bind_dui_events(self) -> None:
@@ -371,49 +398,46 @@ class LightsController:
 
         @self._card.on("brightness_up")
         async def _bright_up(steps: int) -> None:
-            await self._svc.set_brightness(self._svc.brightness + steps * 5)
+            await self._svc.set_brightness(
+                self._svc.brightness + steps * self.BRIGHTNESS_STEP
+            )
 
         @self._card.on("brightness_down")
         async def _bright_down(steps: int) -> None:
-            await self._svc.set_brightness(self._svc.brightness - abs(steps) * 5)
+            await self._svc.set_brightness(
+                self._svc.brightness - abs(steps) * self.BRIGHTNESS_STEP
+            )
 
         @self._card.on("kelvin_up")
         async def _kelvin_up(steps: int) -> None:
-            await self._svc.set_kelvin(self._svc.kelvin + steps * 100)
+            await self._svc.set_kelvin(
+                self._svc.kelvin + steps * self.KELVIN_STEP
+            )
 
         @self._card.on("kelvin_down")
         async def _kelvin_down(steps: int) -> None:
-            await self._svc.set_kelvin(self._svc.kelvin - abs(steps) * 100)
+            await self._svc.set_kelvin(
+                self._svc.kelvin - abs(steps) * self.KELVIN_STEP
+            )
 
 
 class TimerController:
     """Live countdown timer -- a real ticking timer driven by an asyncio task.
 
     Loads ``TimerCard.dui`` and reads the initial duration from the
-    package's ``timer`` binding default value (e.g. ``"00:30:00"``),
-    so the ``.dui`` manifest is the single source of truth for the
-    starting time.
+    package's ``timer`` binding default (e.g. ``"00:30:00"``), so the
+    ``.dui`` manifest is the single source of truth for the starting
+    time.
 
     Encoder bindings
     ~~~~~~~~~~~~~~~~
     * **encoder click** -- start / pause the countdown.
     * **encoder hold** -- reset to the current default duration.
-    * **encoder turn** -- coarse adjustment: +/- 10 min per step
-      (``increase_duration`` / ``decrease_duration``).
-    * **encoder hold+turn** -- fine adjustment: +/- 30 s per step
-      (``increase_duration_alt`` / ``decrease_duration_alt``).
+    * **encoder turn** -- coarse adjustment: +/- 10 min per step.
+    * **encoder hold+turn** -- fine adjustment: +/- 30 s per step.
 
-    Default-duration semantics
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Every time the timer is **started**, the value of ``remaining`` at
-    that moment becomes the new default duration.  This means:
-
-    * Adjust the time with the encoder, then press to start -- the
-      adjusted value is now the default.
-    * **Reset** (encoder hold) always returns to the most recent default.
-
-    Use :meth:`start_runtime` once the deck is connected and
-    :meth:`stop_runtime` to clean up on disconnect.
+    Format conversion (``int seconds`` <-> ``"HH:MM:SS"``) is the
+    controller's responsibility -- the service deals only in seconds.
 
     Parameters
     ----------
@@ -424,6 +448,10 @@ class TimerController:
     TICK_INTERVAL_S = 1.0
     FLASH_COUNT = 6
     FLASH_INTERVAL_S = 0.3
+    COARSE_STEP_S = 600
+    """Seconds added/removed per encoder-turn step (no hold) -- 10 minutes."""
+    FINE_STEP_S = 30
+    """Seconds added/removed per encoder-hold-turn step -- 30 seconds."""
 
     def __init__(
         self,
@@ -433,22 +461,20 @@ class TimerController:
         self._card = DuiCard(load_package(pkg_dir / "TimerCard.dui"))
         self._tick_task: asyncio.Task[None] | None = None
 
-        # Read the initial duration from the .dui manifest's timer
-        # binding default (e.g. "00:30:00") so the package is the
-        # single source of truth.
         default_text: str = self._card.get("timer")
-        initial_seconds = MockTimerService.parse_hhmmss(default_text)
-        log.info("TimerCard default: %s (%d s)", default_text, initial_seconds)
+        initial_seconds = self._parse_hhmmss(default_text)
+        log.info(
+            "TimerCard default: %s (%d s)", default_text, initial_seconds
+        )
 
         self._svc = MockTimerService(initial_seconds)
 
-        # Read default colours from the manifest so the controller stays
-        # in sync with the .dui package.
         self._default_background: str = self._card.get("background")
         self._default_foreground: str = self._card.get("foreground")
 
         self._subscribe_events()
         self._bind_dui_events()
+        self._initialize_bindings()
 
     @property
     def card(self) -> DuiCard:
@@ -470,33 +496,61 @@ class TimerController:
         """Current configured duration in seconds."""
         return self._svc.duration
 
-    @property
-    def COARSE_STEP_S(self) -> int:  # noqa: N802
-        """Seconds per coarse encoder-turn step."""
-        return MockTimerService.COARSE_STEP_S
+    @staticmethod
+    def _parse_hhmmss(text: str) -> int:
+        """Parse ``HH:MM:SS`` into seconds.  Controller-side helper.
 
-    @property
-    def FINE_STEP_S(self) -> int:  # noqa: N802
-        """Seconds per fine encoder-hold-turn step."""
-        return MockTimerService.FINE_STEP_S
+        Parameters
+        ----------
+        text : str
+            Time string in ``HH:MM:SS`` format.
 
-    def format_time(self) -> str:
-        """Format ``remaining`` as ``HH:MM:SS``.
+        Returns
+        -------
+        int
+            Total number of seconds.
+
+        Raises
+        ------
+        ValueError
+            If *text* does not match the expected format.
+        """
+        parts = text.strip().split(":")
+        if len(parts) != 3:
+            raise ValueError(f"Expected HH:MM:SS, got {text!r}")
+        hours, minutes, seconds = (int(p) for p in parts)
+        return hours * 3600 + minutes * 60 + seconds
+
+    @staticmethod
+    def _format_hhmmss(seconds: int) -> str:
+        """Format seconds as ``HH:MM:SS``.  Controller-side helper.
+
+        Parameters
+        ----------
+        seconds : int
+            Number of seconds (negative values are treated as zero).
 
         Returns
         -------
         str
             Zero-padded ``HH:MM:SS`` string.
         """
-        return self._svc.format_time()
+        h, rem = divmod(max(0, seconds), 3600)
+        m, s = divmod(rem, 60)
+        return f"{h:02d}:{m:02d}:{s:02d}"
+
+    def format_time(self) -> str:
+        """Format the service's current ``remaining`` as ``HH:MM:SS``.
+
+        Returns
+        -------
+        str
+            Zero-padded ``HH:MM:SS`` string.
+        """
+        return self._format_hhmmss(self._svc.remaining)
 
     async def start_runtime(self) -> None:
-        """Start the background tick task.
-
-        Idempotent -- safe to call multiple times.  Should be called
-        after the screen is active so the first tick can refresh the
-        display.
-        """
+        """Start the background tick task (idempotent)."""
         if self._tick_task is None or self._tick_task.done():
             self._tick_task = asyncio.create_task(
                 self._tick_loop(), name="timer-tick"
@@ -511,12 +565,22 @@ class TimerController:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
 
+    # -- presentation helpers ------------------------------------------
+
+    def _apply_remaining(self, remaining: int) -> None:
+        self._card.set("timer", self._format_hhmmss(remaining))
+
+    # -- internal -------------------------------------------------------
+
+    def _initialize_bindings(self) -> None:
+        self._apply_remaining(self._svc.remaining)
+
     def _subscribe_events(self) -> None:
         """Subscribe to service state-change events."""
 
-        @self._svc.on_timer_changed
-        async def _on_timer(formatted_time: str) -> None:
-            self._card.set("timer", formatted_time)
+        @self._svc.on_remaining_changed
+        async def _on_remaining(remaining: int) -> None:
+            self._apply_remaining(remaining)
             await self._card.request_refresh()
 
         @self._svc.on_finished
@@ -524,20 +588,7 @@ class TimerController:
             await self._flash_notification()
 
     def _bind_dui_events(self) -> None:
-        """Register DUI event handlers -- these only call service methods.
-
-        Events wired here correspond to the ``events`` section in the
-        ``TimerCard.dui`` manifest:
-
-        * ``toggle`` (encoder click) -- start / pause.
-        * ``reset`` (encoder hold) -- reset to default.
-        * ``increase_duration`` / ``decrease_duration`` (encoder turn)
-          -- coarse adjustment, :attr:`MockTimerService.COARSE_STEP_S`
-          per step.
-        * ``increase_duration_alt`` / ``decrease_duration_alt``
-          (encoder hold+turn) -- fine adjustment,
-          :attr:`MockTimerService.FINE_STEP_S` per step.
-        """
+        """Register DUI event handlers -- these only call service methods."""
 
         @self._card.on("toggle")
         async def _toggle() -> None:
@@ -547,33 +598,29 @@ class TimerController:
         async def _reset() -> None:
             await self._svc.reset()
 
-        # -- coarse: encoder turn (no hold) -- +/- 10 min per step ---
-
         @self._card.on("increase_duration")
         async def _increase(steps: int) -> None:
-            await self._svc.adjust_duration(steps * MockTimerService.COARSE_STEP_S)
+            await self._svc.adjust_duration(steps * self.COARSE_STEP_S)
 
         @self._card.on("decrease_duration")
         async def _decrease(steps: int) -> None:
-            await self._svc.adjust_duration(-abs(steps) * MockTimerService.COARSE_STEP_S)
-
-        # -- fine: encoder hold+turn -- +/- 30 s per step ------------
+            await self._svc.adjust_duration(
+                -abs(steps) * self.COARSE_STEP_S
+            )
 
         @self._card.on("increase_duration_alt")
         async def _increase_alt(steps: int) -> None:
-            await self._svc.adjust_duration(steps * MockTimerService.FINE_STEP_S)
+            await self._svc.adjust_duration(steps * self.FINE_STEP_S)
 
         @self._card.on("decrease_duration_alt")
         async def _decrease_alt(steps: int) -> None:
-            await self._svc.adjust_duration(-abs(steps) * MockTimerService.FINE_STEP_S)
+            await self._svc.adjust_duration(-abs(steps) * self.FINE_STEP_S)
 
     async def _flash_notification(self) -> None:
-        """Flash foreground/background colors to signal timer completion.
+        """Flash foreground/background colors when the countdown ends.
 
-        Swaps the foreground and background colors three times with a
-        short interval, then restores the original colors.  This gives
-        a visible pulse on the touch-strip card so the user knows the
-        countdown has ended.
+        This is pure UI animation -- not a backend state transition --
+        so the controller drives the card directly.
         """
         swapped = False
         for _ in range(self.FLASH_COUNT):
@@ -591,7 +638,6 @@ class TimerController:
             await self._card.request_refresh()
             await asyncio.sleep(self.FLASH_INTERVAL_S)
 
-        # Ensure colors are restored to their original values.
         self._card.set_many(
             background=self._default_background,
             foreground=self._default_foreground,
@@ -599,12 +645,7 @@ class TimerController:
         await self._card.request_refresh()
 
     async def _tick_loop(self) -> None:
-        """Call the service's tick once per second.
-
-        The service emits ``on_timer_changed`` and ``on_finished``
-        events as needed -- the controller's subscribers handle the
-        card updates.
-        """
+        """Drive the service tick once per second."""
         try:
             while True:
                 await asyncio.sleep(self.TICK_INTERVAL_S)
@@ -614,20 +655,15 @@ class TimerController:
 
 
 class DashboardController:
-    """Dashboard card -- live clock, mock weather, deck-brightness control.
+    """Dashboard card -- live clock, simulated weather, deck-brightness.
 
-    Loads ``DashboardCard.dui``.  The backend service
-    (:class:`MockDashboardService`) provides read-only telemetry (date,
-    time, temperature, humidity).  Deck brightness is pure application
-    logic: the controller owns the state, clamps it, updates the card
-    bindings, and pushes the value to the hardware via the *deck* handle
-    passed to :meth:`bind_deck`.
-
-    An asyncio task ticks every second to keep the displayed clock
-    accurate.
-
-    Use :meth:`start_runtime` once the deck is connected and
-    :meth:`stop_runtime` to clean up on disconnect.
+    Loads ``DashboardCard.dui``.  Brightness is **deck-owned** state:
+    the controller does not store a brightness value of its own.  It
+    subscribes to :attr:`deckui.Deck.on_brightness_changed` and
+    delegates writes to :meth:`deckui.Deck.set_brightness`.  Telemetry
+    arrives via :attr:`MockDashboardService.on_telemetry_changed`.  The
+    clock is genuinely poll-driven (system time), so a small task ticks
+    once a second.
 
     Parameters
     ----------
@@ -638,27 +674,37 @@ class DashboardController:
     CLOCK_INTERVAL_S = 1.0
     BRIGHTNESS_MIN = 0
     BRIGHTNESS_MAX = 100
+    BRIGHTNESS_STEP = 1
 
     def __init__(
         self,
         packages_dir: Path | None = None,
     ) -> None:
-        self._deck: Any = None
+        self._deck: Deck | None = None
         self._clock_task: asyncio.Task[None] | None = None
 
         pkg_dir = packages_dir or EXAMPLES_DIR
         self._card = DuiCard(load_package(pkg_dir / "DashboardCard.dui"))
 
-        # Read initial brightness from the .dui package's range binding
-        # default (normalised 0.0-1.0) and convert to 0-100 domain.
-        bright_norm: float = self._card.get("deck_brightness")
-        self._deck_brightness: int = int(bright_norm * 100)
+        # Manifest brightness default (normalised) is the cold-start
+        # value; remembered across reconnects so the user's last value
+        # survives ``Deck.start`` resetting hardware to the manager's
+        # startup default.
+        self._last_known_brightness: int = int(
+            round(
+                self._card.get_range(
+                    "deck_brightness",
+                    min_val=self.BRIGHTNESS_MIN,
+                    max_val=self.BRIGHTNESS_MAX,
+                )
+            )
+        )
 
-        # The backend service only provides telemetry (weather, clock).
         self._svc = MockDashboardService()
 
-        self._sync_card()
+        self._subscribe_telemetry()
         self._bind_dui_events()
+        self._initialize_bindings()
 
     @property
     def card(self) -> DuiCard:
@@ -667,132 +713,139 @@ class DashboardController:
 
     @property
     def deck_brightness(self) -> int:
-        """Current deck brightness percentage (0 -- 100)."""
-        return self._deck_brightness
+        """Last confirmed deck brightness (0 -- 100)."""
+        return self._last_known_brightness
 
     @property
-    def temperature(self) -> str:
-        """Current temperature reading."""
-        return self._svc.temperature
+    def temperature_c(self) -> float:
+        """Current temperature reading in degrees Celsius."""
+        return self._svc.temperature_c
 
     @property
-    def humidity(self) -> str:
-        """Current humidity reading."""
-        return self._svc.humidity
+    def humidity_pct(self) -> int:
+        """Current humidity reading in percent."""
+        return self._svc.humidity_pct
 
     @staticmethod
     def get_date() -> str:
         """Return today's date as ``YYYY-MM-DD``."""
-        return MockDashboardService.get_date()
+        return datetime.datetime.now().strftime("%Y-%m-%d")
 
     @staticmethod
     def get_time() -> str:
         """Return the current local time as ``HH:MM``."""
-        return MockDashboardService.get_time()
+        return datetime.datetime.now().strftime("%H:%M")
 
-    def bind_deck(self, deck: Any) -> None:
-        """Attach the deck handle so brightness changes reach the hardware."""
+    async def bind_deck(self, deck: Deck) -> None:
+        """Attach to *deck*: subscribe to brightness events and replay.
+
+        Subscribes to :attr:`Deck.on_brightness_changed` so the slider
+        reflects confirmed hardware state.  Also replays the last-known
+        brightness onto the new deck instance so the user's value
+        survives a disconnect/reconnect (``Deck.start`` resets the
+        hardware to the manager's startup default).
+
+        Parameters
+        ----------
+        deck
+            The connected :class:`~deckui.Deck` instance.
+        """
         self._deck = deck
 
-    async def apply_brightness_to_deck(self) -> None:
-        """Push the current ``deck_brightness`` value to the bound deck.
+        @deck.on_brightness_changed
+        async def _on_brightness(value: int) -> None:
+            self._last_known_brightness = value
+            self._apply_brightness(value)
+            await self._card.request_refresh()
 
-        Used on reconnect: ``Deck.start`` resets the hardware brightness
-        to the manager's startup default, so the application replays the
-        last user-selected value here.  Idempotent and a no-op if no deck
-        is currently bound.
-        """
-        if self._deck is None:
-            return
-        await self._deck.set_brightness(self._deck_brightness)
+        # Replay the user's last value onto the freshly-connected deck.
+        # Idempotent -- if values match, the deck silently returns.
+        await deck.set_brightness(self._last_known_brightness)
 
     async def start_runtime(self) -> None:
-        """Start the background clock-tick task (idempotent)."""
+        """Start the clock tick and the telemetry simulator (idempotent)."""
         if self._clock_task is None or self._clock_task.done():
             self._clock_task = asyncio.create_task(
                 self._clock_loop(), name="dashboard-clock"
             )
+        await self._svc.start()
 
     async def stop_runtime(self) -> None:
-        """Cancel the clock-tick task."""
+        """Cancel the clock tick and stop the telemetry simulator."""
         task = self._clock_task
         self._clock_task = None
         if task is not None and not task.done():
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+        await self._svc.stop()
 
-    async def _set_brightness(self, value: int) -> None:
-        """Clamp and apply deck brightness.
+    # -- presentation helpers ------------------------------------------
 
-        Updates the local state, the card binding, the physical deck
-        (if connected), and requests a card refresh.
-
-        Parameters
-        ----------
-        value : int
-            Target brightness (0 -- 100, clamped).
-        """
-        self._deck_brightness = max(self.BRIGHTNESS_MIN, min(self.BRIGHTNESS_MAX, value))
+    def _apply_brightness(self, brightness: int) -> None:
         self._card.set_range(
             "deck_brightness",
-            self._deck_brightness,
+            brightness,
             min_val=self.BRIGHTNESS_MIN,
             max_val=self.BRIGHTNESS_MAX,
         )
-        log.info("Deck brightness: %d%%", self._deck_brightness)
-        if self._deck is not None:
-            await self._deck.set_brightness(self._deck_brightness)
-        await self._card.request_refresh()
 
-    def _sync_card(self) -> None:
-        """Push the full dashboard state into card bindings (initial load only)."""
+    def _apply_telemetry(
+        self, temperature_c: float, humidity_pct: int
+    ) -> None:
         self._card.set_many(
-            date=self._svc.get_date(),
-            time=self._svc.get_time(),
-            temperature=self._svc.temperature,
-            humidity=self._svc.humidity,
+            temperature=f"{temperature_c:.1f}C",
+            humidity=f"{humidity_pct}%",
         )
-        self._card.set_range(
-            "deck_brightness",
-            self._deck_brightness,
-            min_val=self.BRIGHTNESS_MIN,
-            max_val=self.BRIGHTNESS_MAX,
-        )
+
+    def _apply_clock(self) -> None:
+        self._card.set_many(date=self.get_date(), time=self.get_time())
+
+    # -- internal -------------------------------------------------------
+
+    def _initialize_bindings(self) -> None:
+        self._apply_brightness(self._last_known_brightness)
+        self._apply_telemetry(self._svc.temperature_c, self._svc.humidity_pct)
+        self._apply_clock()
+
+    def _subscribe_telemetry(self) -> None:
+        @self._svc.on_telemetry_changed
+        async def _on_telemetry(temperature_c: float, humidity_pct: int) -> None:
+            self._apply_telemetry(temperature_c, humidity_pct)
+            await self._card.request_refresh()
 
     def _bind_dui_events(self) -> None:
-        """Register DUI event handlers for deck brightness control."""
-        card = self._card
+        """Register DUI event handlers -- these only call deck methods."""
 
-        @card.on("brightness_up")
+        @self._card.on("brightness_up")
         async def _bright_up(steps: int) -> None:
-            new = card.adjust_range(
-                "deck_brightness", steps,
-                min_val=self.BRIGHTNESS_MIN, max_val=self.BRIGHTNESS_MAX,
+            if self._deck is None:
+                return
+            await self._deck.set_brightness(
+                self._deck.brightness + steps * self.BRIGHTNESS_STEP
             )
-            await self._set_brightness(int(new))
 
-        @card.on("brightness_down")
+        @self._card.on("brightness_down")
         async def _bright_down(steps: int) -> None:
-            new = card.adjust_range(
-                "deck_brightness", -abs(steps),
-                min_val=self.BRIGHTNESS_MIN, max_val=self.BRIGHTNESS_MAX,
+            if self._deck is None:
+                return
+            await self._deck.set_brightness(
+                self._deck.brightness - abs(steps) * self.BRIGHTNESS_STEP
             )
-            await self._set_brightness(int(new))
 
     async def _clock_loop(self) -> None:
         """Refresh the clock display every second.
 
-        Only marks the card dirty when the visible value actually changes
-        so we don't churn the SVG renderer 60x per minute.
+        Only marks the card dirty when the visible value actually
+        changes.
         """
         last_time = ""
         last_date = ""
         try:
             while True:
                 await asyncio.sleep(self.CLOCK_INTERVAL_S)
-                t = self._svc.get_time()
-                d = self._svc.get_date()
+                t = self.get_time()
+                d = self.get_date()
                 if t == last_time and d == last_date:
                     continue
                 last_time, last_date = t, d
@@ -805,10 +858,9 @@ class DashboardController:
 class FavoritesController:
     """Favourite-media keys -- one :class:`DuiKey` per catalog entry.
 
-    Loads ``PictureKey.dui`` once and instantiates a key per favourite.
-    Clicking a key calls :meth:`MockAudioService.play` on the audio
-    service.  The audio service emits ``on_track_changed`` which the
-    :class:`AudioController` subscriber picks up to refresh the card.
+    Clicking a favourite calls :meth:`MockAudioService.play`.  The
+    audio service then emits ``on_track_changed``; the
+    :class:`AudioController` subscriber refreshes the audio card.
 
     Parameters
     ----------
@@ -843,7 +895,9 @@ class FavoritesController:
             # its own dict instead of the loop variable.
             @key.on_event("click")
             async def _click(m: dict[str, str] = media) -> None:
-                log.info("Favourite pressed: %s -- %s", m["artist"], m["title"])
+                log.info(
+                    "Favourite pressed: %s -- %s", m["artist"], m["title"]
+                )
                 await self._audio_svc.play(m)
 
             self._keys.append(key)
@@ -854,10 +908,7 @@ class FavoritesController:
         return list(self._keys)
 
     def install(self, screen: Any, positions: list[int]) -> None:
-        """Place favourite keys onto *screen* at the given *positions*.
-
-        Installs ``min(len(keys), len(positions))`` keys.
-        """
+        """Place favourite keys onto *screen* at the given *positions*."""
         for pos, key in zip(positions, self._keys, strict=False):
             screen.set_key(pos, key)
 
@@ -865,24 +916,18 @@ class FavoritesController:
 class SceneController:
     """Scene-activation keys -- one :class:`DuiKey` per scene definition.
 
-    Loads ``IconKey.dui`` once and instantiates a key per scene.  Each
-    key has three handlers, demonstrating that ``press`` and ``release``
-    are emitted alongside the higher-level ``click`` event:
+    Click handlers call :meth:`MockScenesService.activate`.  The
+    service emits ``on_scene_activated``; the controller's subscriber
+    logs and (in a real app) would update an "active scene" indicator.
 
-    * ``press``   -- inverts the foreground / background colours so the
-      key visually flashes while held.
-    * ``release`` -- restores the original colours.
-    * ``click``   -- logs the scene name (replace with your automation).
-
-    The colour swap also showcases how to update bindings from a key
-    handler and call :meth:`DuiKey.request_refresh` to push the change
-    to the device immediately.
+    The press/release colour-swap is **input feedback** for a confirmed
+    device input event -- not a state transition -- so it lives in the
+    key handler.  Same pattern as a button changing colour while held.
 
     Parameters
     ----------
     scenes : list[dict[str, str]]
-        Scene definitions, each with ``label`` and ``icon`` (an Iconify
-        identifier such as ``"mdi:cinema"``).
+        Scene definitions, each with ``label`` and ``icon``.
     packages_dir : Path | None
         Directory containing ``IconKey.dui``.
     """
@@ -895,7 +940,10 @@ class SceneController:
         self._scenes = scenes
         pkg_dir = packages_dir or EXAMPLES_DIR
         self._spec = load_package(pkg_dir / "IconKey.dui")
+        self._svc = MockScenesService()
         self._keys: list[DuiKey] = []
+
+        self._subscribe_events()
 
         for scene in self._scenes:
             key = DuiKey(self._spec)
@@ -903,34 +951,47 @@ class SceneController:
                 label=scene["label"],
                 icon=scene["icon"],
             )
-
-            # Bind handlers via a helper so each key captures its own
-            # *key* reference instead of the loop variable.
             self._bind_handlers(key, scene["label"])
             self._keys.append(key)
+
+    @property
+    def keys(self) -> list[DuiKey]:
+        """The created scene keys (same order as *scenes*)."""
+        return list(self._keys)
+
+    @property
+    def svc(self) -> MockScenesService:
+        """The underlying scenes service."""
+        return self._svc
+
+    def install(self, screen: Any, positions: list[int]) -> None:
+        """Place scene keys onto *screen* at the given *positions*."""
+        for pos, key in zip(positions, self._keys, strict=False):
+            screen.set_key(pos, key)
+
+    def _subscribe_events(self) -> None:
+        @self._svc.on_scene_activated
+        async def _on_activated(label: str) -> None:
+            log.info("Scene confirmed active: %s", label)
 
     def _bind_handlers(self, key: DuiKey, label: str) -> None:
         """Attach press/release/click handlers to *key*.
 
-        Splitting this into a helper guarantees correct closure capture
-        for *key* and *label* per iteration.  The original background and
-        foreground colours are read from the key's current bindings (set
-        by the manifest defaults) so the controller stays in sync with
-        the ``.dui`` package.
+        Press/release swap fg<->bg as visual input feedback.  Click
+        delegates to the scenes service.
 
         Parameters
         ----------
         key : DuiKey
             The key to wire.
         label : str
-            Scene label, logged on click.
+            Scene label, passed to the service on click.
         """
         bg = key.get("background")
         fg = key.get("foreground")
 
         @key.on_event("press")
         async def _press() -> None:
-            # Invert colours by swapping background <-> foreground.
             key.set_many(background=fg, foreground=bg)
             await key.request_refresh()
 
@@ -941,34 +1002,21 @@ class SceneController:
 
         @key.on_event("click")
         async def _click() -> None:
-            log.info("Scene activated: %s", label)
-
-    @property
-    def keys(self) -> list[DuiKey]:
-        """The created scene keys (same order as *scenes*)."""
-        return list(self._keys)
-
-    def install(self, screen: Any, positions: list[int]) -> None:
-        """Place scene keys onto *screen* at the given *positions*."""
-        for pos, key in zip(positions, self._keys, strict=False):
-            screen.set_key(pos, key)
+            await self._svc.activate(label)
 
 
 class ScreenCycler:
     """Cycles the deck through a list of screens.
 
     Wires itself to a card event (the dashboard's ``next_screen`` event,
-    emitted by an encoder press-release) and advances to the next screen
-    on each trigger, wrapping around at the end.
+    emitted by an encoder press-release) and advances to the next
+    screen on each trigger, wrapping around at the end.
 
-    Demonstrates two ideas at once:
-
-    * :meth:`Deck.set_screen` -- screens are independent layouts that
-      swap atomically, so the same encoders/keys can host completely
-      different functionality on each one.
-    * Card-level events -- a ``.dui`` package can declare arbitrary
-      events (here ``encoder_press_release`` named ``next_screen``) and
-      controllers bind handlers to them, with no key required.
+    Source of truth for the *current* screen is
+    :attr:`deckui.Deck.active_screen` -- the cycler does not maintain
+    its own active-screen state.  It does remember the **last-cycled
+    screen name** so that on reconnect the app can resume on the
+    user's last choice.
 
     Parameters
     ----------
@@ -986,17 +1034,26 @@ class ScreenCycler:
         if not screens:
             raise ValueError("ScreenCycler requires at least one screen")
         self._screens = list(screens)
-        self._index = 0
-        self._deck: Any = None
+        self._last_known: str = self._screens[0]
+        self._deck: Deck | None = None
 
     @property
     def current(self) -> str:
-        """Name of the screen the cycler currently points to."""
-        return self._screens[self._index]
+        """Last-known active screen name.
 
-    def bind_deck(self, deck: Any) -> None:
-        """Attach the deck so the controller can call ``set_screen``."""
+        Reflects the most recent ``Deck.on_screen_changed`` event,
+        falling back to the first configured screen before any change
+        has been observed.
+        """
+        return self._last_known
+
+    def bind_deck(self, deck: Deck) -> None:
+        """Attach to *deck* and subscribe to its screen-changed event."""
         self._deck = deck
+
+        @deck.on_screen_changed
+        async def _on_screen(name: str) -> None:
+            self._last_known = name
 
     def attach(self, card: DuiCard, event: str = "next_screen") -> None:
         """Register the cycler on *card*'s *event*.
@@ -1004,10 +1061,9 @@ class ScreenCycler:
         Parameters
         ----------
         card : DuiCard
-            Card whose event will trigger screen changes (typically the
-            dashboard card).
+            Card whose event triggers screen changes.
         event : str, default="next_screen"
-            Name of the event declared in the card's manifest.
+            Event name declared in the card's manifest.
         """
 
         @card.on(event)
@@ -1018,8 +1074,8 @@ class ScreenCycler:
         """Move to the next screen, wrapping at the end."""
         if self._deck is None:
             return
-        self._index = (self._index + 1) % len(self._screens)
-        target = self._screens[self._index]
+        idx = self._screens.index(self._last_known)
+        target = self._screens[(idx + 1) % len(self._screens)]
         log.info("Cycling to screen: %s", target)
         await self._deck.set_screen(target)
 
@@ -1032,8 +1088,8 @@ class ScreenCycler:
 class StreamDeckApp:
     """Top-level demo app -- glues controllers to the deck.
 
-    Build the controllers once, then :meth:`build_screens` is called from
-    the manager's ``on_connect`` callback to install them on the
+    Build the controllers once.  :meth:`on_connect` is called from the
+    manager's ``on_connect`` callback to install controllers on the
     appropriate screens for the connected device.
 
     Parameters
@@ -1053,55 +1109,29 @@ class StreamDeckApp:
         packages_dir: Path | None = None,
     ) -> None:
         self._packages_dir = packages_dir or EXAMPLES_DIR
-        self.audio = AudioController(
-            catalog, packages_dir=self._packages_dir
-        )
-        self.lights = LightsController(
-            packages_dir=self._packages_dir
-        )
-        self.timer = TimerController(
-            packages_dir=self._packages_dir
-        )
-        self.dashboard = DashboardController(
-            packages_dir=self._packages_dir
-        )
+        self.audio = AudioController(catalog, packages_dir=self._packages_dir)
+        self.lights = LightsController(packages_dir=self._packages_dir)
+        self.timer = TimerController(packages_dir=self._packages_dir)
+        self.dashboard = DashboardController(packages_dir=self._packages_dir)
         self.favorites = FavoritesController(
             catalog, self.audio, packages_dir=self._packages_dir
         )
         self.scenes = SceneController(
             scene_defs, packages_dir=self._packages_dir
         )
-        # Cycle "main" -> "settings" -> back via the dashboard encoder
-        # press-release (the manifest declares it as ``next_screen``).
         self.nav = ScreenCycler(["main", "settings"])
         self.nav.attach(self.dashboard.card)
 
-    async def on_connect(self, deck: Any) -> None:
+    async def on_connect(self, deck: Deck) -> None:
         """Configure screens for *deck* and start (or resume) the demo.
 
-        Called once on first connect and again on every reconnect when
-        :class:`DeckManager` has ``auto_reconnect=True``.  Two pieces of
-        UI state must be replayed here because they are *device-side* and
-        therefore lost when the device disappears:
-
-        * **Active screen.**  ``Deck.set_screen`` does not survive a
-          disconnect/reconnect cycle, so we resume on
-          :attr:`ScreenCycler.current` (which tracks the user's last
-          choice on the app side) instead of jumping back to ``"main"``.
-        * **Hardware brightness.**  ``Deck.start`` resets the device to
-          the manager's startup brightness — we push the controller's
-          current value via :meth:`DashboardController.apply_brightness_to_deck`.
-
-        Card binding state, audio/lights/timer service state, and the
-        navigation cycler all live on ``self`` (the app), which is
-        constructed *outside* the manager scope, so they persist across
-        reconnects without any extra work.
+        Called on first connect and again on every reconnect when
+        :class:`DeckManager` has ``auto_reconnect=True``.
 
         Parameters
         ----------
         deck
-            The :class:`~deckui.runtime.deck.Deck` handle from the
-            manager's ``on_connect`` callback.
+            The :class:`~deckui.runtime.deck.Deck` handle.
         """
         caps = deck.capabilities
         log.info(
@@ -1112,25 +1142,26 @@ class StreamDeckApp:
             "yes" if caps.has_touchscreen else "no",
         )
 
-        # Wire deck-aware controllers
-        self.dashboard.bind_deck(deck)
+        # Demonstrate Deck.on_screen_changed: log every screen switch.
+        @deck.on_screen_changed
+        async def _log_screen(name: str) -> None:
+            log.info("Active screen confirmed: %s", name)
+
+        # Hand the deck to controllers that need it.  bind_deck on the
+        # dashboard subscribes to brightness events and replays the
+        # last-known value -- this is what survives reconnect.
+        await self.dashboard.bind_deck(deck)
         self.nav.bind_deck(deck)
 
-        # Build both screens up-front so the navigation controller can
-        # switch between them at any time.
         self._build_main_screen(deck)
         self._build_settings_screen(deck)
 
-        # Resume on the user's last screen (defaults to the first screen
-        # in the cycler -- "main" -- on a cold start).  Also wires every
-        # key/card's request_refresh() to deck.refresh() under the hood.
+        # Resume on the user's last screen (cold start: first screen
+        # in the cycler -- "main").  set_screen wires every key/card's
+        # request_refresh() to deck.refresh() under the hood.
         await deck.set_screen(self.nav.current)
 
-        # Replay hardware brightness so the user's last value survives a
-        # reconnect (Deck.start resets to the manager's startup default).
-        await self.dashboard.apply_brightness_to_deck()
-
-        # Start background tasks AFTER the screen is active so their
+        # Background tasks AFTER the screen is active so their
         # request_refresh() calls go to the right place.
         await self.timer.start_runtime()
         await self.dashboard.start_runtime()
@@ -1142,20 +1173,16 @@ class StreamDeckApp:
 
     async def on_disconnect(self, info: DeviceInfo) -> None:
         """Stop background tasks when the deck goes away."""
-        log.warning("Deck disconnected: %s -- waiting for reconnect...", info.serial)
+        log.warning(
+            "Deck disconnected: %s -- waiting for reconnect...", info.serial
+        )
         await self.timer.stop_runtime()
         await self.dashboard.stop_runtime()
 
     # -- screen construction -------------------------------------------
 
-    def _build_main_screen(self, deck: Any) -> None:
-        """Layout: favourites + scenes on keys, all four cards on the strip.
-
-        Parameters
-        ----------
-        deck
-            Open deck handle.
-        """
+    def _build_main_screen(self, deck: Deck) -> None:
+        """Layout: favourites + scenes on keys, all four cards on the strip."""
         caps = deck.capabilities
         screen = deck.screen("main")
 
@@ -1166,46 +1193,22 @@ class StreamDeckApp:
             screen.set_card(2, self.timer.card)
             screen.set_card(3, self.dashboard.card)
 
-        # Favourites first, then scenes -- using every available key.
-        # Screen cycling is driven by the dashboard encoder, so no
-        # navigation key is needed.
         num_favs = min(len(self.favorites.keys), caps.key_count)
         remaining = max(0, caps.key_count - num_favs)
         num_scenes = min(len(self.scenes.keys), remaining)
 
         self.favorites.install(screen, list(range(num_favs)))
-        self.scenes.install(screen, list(range(num_favs, num_favs + num_scenes)))
+        self.scenes.install(
+            screen, list(range(num_favs, num_favs + num_scenes))
+        )
 
-    def _build_settings_screen(self, deck: Any) -> None:
-        """Layout: a placeholder screen with room for the user to extend.
-
-        Demonstrates the core multi-screen story without committing to a
-        specific second-screen purpose:
-
-        * **Dashboard pinned on slot 3** -- the same controller instance
-          appears on both screens, demonstrating that ``DuiCard`` and
-          ``DuiKey`` instances may be installed on multiple screens at
-          different (or the same) slots.  The screen's slot map -- not
-          the object's ``index`` property -- is the source of truth for
-          rendering.
-        * **All other strip slots blank** -- ready for the reader to
-          drop in their own cards.
-        * **One ``IconKey`` per slot** -- each key gets its own
-          ``DuiKey`` instance with the manifest's default icon and the
-          label ``"Unassigned"`` so the reader has a clear template to
-          replace.
-
-        Parameters
-        ----------
-        deck
-            Open deck handle.
-        """
+    def _build_settings_screen(self, deck: Deck) -> None:
+        """Layout: dashboard pinned, otherwise template ``IconKey``s."""
         screen = deck.screen("settings")
         caps = deck.capabilities
 
         if screen.touch_strip is not None:
             screen.touch_strip.background_color = "#1c1c1c"
-            # Pin the dashboard so the cycling encoder is always available.
             screen.set_card(3, self.dashboard.card)
 
         pkg_dir = self._packages_dir or EXAMPLES_DIR
@@ -1224,10 +1227,8 @@ class StreamDeckApp:
 async def run() -> None:
     """Build the app, attach to :class:`DeckManager`, and run forever.
 
-    This is the canonical DeckUI lifecycle:
-
-    1. Construct your controllers.
-    2. Create a :class:`DeckManager`.
+    1. Construct controllers.
+    2. Create a :class:`DeckManager` with the cold-start brightness.
     3. Register ``on_connect`` / ``on_disconnect`` handlers.
     4. ``async with`` the manager and ``await manager.wait_closed()``.
     """
@@ -1237,7 +1238,7 @@ async def run() -> None:
     )
 
     @manager.on_connect()
-    async def _on_connect(deck: Any) -> None:
+    async def _on_connect(deck: Deck) -> None:
         await app.on_connect(deck)
 
     @manager.on_disconnect

--- a/src/deckui/__init__.py
+++ b/src/deckui/__init__.py
@@ -38,6 +38,8 @@ from .dui import (
 )
 from .render import ImageFetchError, RenderMetrics, clear_image_cache, fetch_image
 from .runtime import (
+    AsyncEvent,
+    Deck,
     DeckError,
     DeckEvent,
     DeckManager,
@@ -61,8 +63,10 @@ from .ui import (
 )
 
 __all__ = [
+    "AsyncEvent",
     "BlankCard",
     "Card",
+    "Deck",
     "DeckError",
     "DeckEvent",
     "DeckManager",

--- a/src/deckui/runtime/__init__.py
+++ b/src/deckui/runtime/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .deck import Deck, DeckError
 from .device_info import DeviceInfo
@@ -19,6 +20,7 @@ from .manager import DeckManager
 from .transport import AsyncTransport
 
 __all__ = [
+    "AsyncEvent",
     "AsyncHandler",
     "AsyncTransport",
     "Deck",

--- a/src/deckui/runtime/async_event.py
+++ b/src/deckui/runtime/async_event.py
@@ -1,0 +1,125 @@
+"""Async event primitive for property-change notifications.
+
+:class:`AsyncEvent` is a tiny multicast hook used throughout DeckUI
+wherever a state change should be observable by zero or more async
+subscribers — for example :attr:`deckui.Deck.on_brightness_changed`.
+
+The shape mirrors what a real-world backend SDK (Spotify, Home Assistant,
+etc.) usually exposes for property-change notifications: a callable that
+acts both as a decorator for registering subscribers and an awaitable
+emitter for the producer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
+
+AsyncHandler = Callable[..., Coroutine[Any, Any, None]]
+"""Async callable accepted by :class:`AsyncEvent` subscribers."""
+
+_H = TypeVar("_H", bound=AsyncHandler)
+
+
+class AsyncEvent:
+    """A multicast async event that can have multiple subscribers.
+
+    Subscribers are async callables registered via :meth:`subscribe`
+    or by using the event itself as a decorator.  :meth:`emit` invokes
+    every registered subscriber sequentially, awaiting each one in
+    registration order.
+
+    The handler list is snapshotted at the start of every :meth:`emit`,
+    so subscribers may safely register or unregister during dispatch
+    without affecting the in-flight emission.
+
+    The signature of an event is part of its documented contract, not
+    its static type — events here are intentionally non-generic so
+    they can carry arbitrary positional/keyword payloads.
+
+    Examples
+    --------
+    ::
+
+        on_volume_changed = AsyncEvent()
+
+        @on_volume_changed
+        async def _log(value: int) -> None:
+            print(f"volume = {value}")
+
+        await on_volume_changed.emit(75)
+    """
+
+    __slots__ = ("_handlers",)
+
+    def __init__(self) -> None:
+        self._handlers: list[AsyncHandler] = []
+
+    def subscribe(self, handler: _H) -> _H:
+        """Register *handler* as a subscriber.
+
+        Parameters
+        ----------
+        handler
+            Async callable to invoke on every :meth:`emit`.
+
+        Returns
+        -------
+        handler
+            The original *handler*, unchanged, so this can be used as
+            a decorator.
+        """
+        self._handlers.append(handler)
+        return handler
+
+    def unsubscribe(self, handler: AsyncHandler) -> None:
+        """Remove *handler* from the subscriber list.
+
+        Parameters
+        ----------
+        handler
+            A previously-registered subscriber.
+
+        Raises
+        ------
+        ValueError
+            If *handler* is not currently subscribed.
+        """
+        self._handlers.remove(handler)
+
+    def __call__(self, handler: _H) -> _H:
+        """Decorator alias for :meth:`subscribe`.
+
+        Parameters
+        ----------
+        handler
+            Async callable to register.
+
+        Returns
+        -------
+        handler
+            The original handler.
+        """
+        return self.subscribe(handler)
+
+    async def emit(self, *args: Any, **kwargs: Any) -> None:
+        """Invoke every subscriber sequentially, awaiting each in turn.
+
+        A snapshot of the handler list is taken first, so handlers may
+        subscribe or unsubscribe during dispatch without affecting the
+        current emission.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments forwarded to every handler.
+        **kwargs
+            Keyword arguments forwarded to every handler.
+        """
+        for handler in list(self._handlers):
+            await handler(*args, **kwargs)
+
+    @property
+    def subscriber_count(self) -> int:
+        """Number of currently-registered subscribers."""
+        return len(self._handlers)

--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -13,6 +13,7 @@ from StreamDeck.DeviceManager import DeviceManager
 from ..render.key_renderer import render_blank_key
 from ..render.metrics import RenderMetrics
 from ..render.touch_renderer import compose_touchstrip
+from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .device_info import DeviceInfo
 from .events import (
@@ -47,6 +48,18 @@ class Deck:
 
     The ``Deck`` object provides the per-device API for screens, keys,
     encoders, touchscreen cards, brightness, and rendering.
+
+    Attributes
+    ----------
+    on_brightness_changed : AsyncEvent
+        Fires after :meth:`set_brightness` confirms a change to a *new*
+        value (the hardware push has returned).  Subscribers receive
+        the new brightness percentage as an ``int`` in ``[0, 100]``.
+        Idempotent calls (same value) do not emit.
+    on_screen_changed : AsyncEvent
+        Fires after :meth:`set_screen` finishes rendering a new active
+        screen.  Subscribers receive the new screen name (``str``).
+        Idempotent calls (same screen) do not emit.
     """
 
     def __init__(
@@ -76,6 +89,9 @@ class Deck:
 
         self._screens: dict[str, Screen] = {}
         self._active_screen: Screen | None = None
+
+        self.on_brightness_changed = AsyncEvent()
+        self.on_screen_changed = AsyncEvent()
 
     async def start(self) -> None:
         """Discover the device by serial, open it, and start the event loop."""
@@ -232,18 +248,28 @@ class Deck:
     async def set_brightness(self, percent: int) -> None:
         """Set screen brightness.
 
+        Pushes the value to the hardware (if connected) and emits
+        :attr:`on_brightness_changed` with the clamped result.  If the
+        clamped value equals the current brightness, no event fires —
+        observers see only confirmed transitions.
+
         Parameters
         ----------
         percent
-            Brightness level (0-100).
+            Brightness level (0-100).  Values outside the range are
+            clamped.
         """
-        self._brightness = max(0, min(100, percent))
-        if self._device:
+        clamped = max(0, min(100, percent))
+        if clamped == self._brightness:
+            return
+        if self._device is not None:
             loop = asyncio.get_running_loop()
             async with self._device_lock:
                 await loop.run_in_executor(
-                    self._executor, self._device.set_brightness, self._brightness
+                    self._executor, self._device.set_brightness, clamped
                 )
+        self._brightness = clamped
+        await self.on_brightness_changed.emit(clamped)
 
     def screen(self, name: str) -> Screen:
         """Get or create a screen by name.
@@ -270,17 +296,28 @@ class Deck:
         Wires up refresh callbacks on every key and card so that any
         handler or background task can call ``request_refresh()`` to
         trigger a re-render without needing a direct reference to the
-        deck.
+        deck.  After the new screen has finished rendering, fires
+        :attr:`on_screen_changed` with the new name.  No event fires
+        if the requested screen is already active.
 
         Parameters
         ----------
         name
             Screen name (must already exist via ``deck.screen(name)``).
+
+        Raises
+        ------
+        DeckError
+            If *name* does not match a previously-created screen.
         """
         if name not in self._screens:
             raise DeckError(f"Screen '{name}' does not exist")
 
-        self._active_screen = self._screens[name]
+        target = self._screens[name]
+        if target is self._active_screen:
+            return
+
+        self._active_screen = target
         logger.info("Switching to screen: %s", name)
 
         self._wire_refresh_callbacks()
@@ -290,6 +327,8 @@ class Deck:
             await self._render_touchscreen()
         if self._active_screen.info_screen is not None:
             await self._render_info_screen()
+
+        await self.on_screen_changed.emit(name)
 
     def _wire_refresh_callbacks(self) -> None:
         """Register ``self.refresh`` on every key and card of the active screen.

--- a/tests/test_async_event.py
+++ b/tests/test_async_event.py
@@ -1,0 +1,147 @@
+"""Tests for :class:`deckui.runtime.async_event.AsyncEvent`."""
+
+from __future__ import annotations
+
+import pytest
+
+from deckui import AsyncEvent
+from deckui.runtime.async_event import AsyncEvent as AsyncEventInternal
+
+
+class TestSubscription:
+    def test_decorator_returns_handler_unchanged(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+
+        async def handler() -> None:  # pragma: no cover - never invoked
+            pass
+
+        assert evt(handler) is handler
+        assert evt.subscribe(handler) is handler  # idempotent return value
+
+    def test_subscriber_count_tracks_subscriptions(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+        assert evt.subscriber_count == 0
+
+        async def a() -> None:  # pragma: no cover - never invoked
+            pass
+
+        async def b() -> None:  # pragma: no cover - never invoked
+            pass
+
+        evt.subscribe(a)
+        evt.subscribe(b)
+        assert evt.subscriber_count == 2
+
+        evt.unsubscribe(a)
+        assert evt.subscriber_count == 1
+
+    def test_unsubscribe_unknown_handler_raises(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+
+        async def handler() -> None:  # pragma: no cover - never invoked
+            pass
+
+        with pytest.raises(ValueError):
+            evt.unsubscribe(handler)
+
+
+class TestEmit:
+    async def test_no_subscribers_is_noop(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+        await evt.emit(1, 2, three=3)  # must not raise
+
+    async def test_invokes_every_subscriber_with_args(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+        seen: list[tuple[int, str]] = []
+
+        @evt
+        async def first(value: int, label: str) -> None:
+            seen.append((value, label))
+
+        @evt
+        async def second(value: int, label: str) -> None:
+            seen.append((value * 2, label.upper()))
+
+        await evt.emit(7, "hi")
+        assert seen == [(7, "hi"), (14, "HI")]
+
+    async def test_dispatch_order_is_registration_order(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+        order: list[str] = []
+
+        @evt
+        async def a() -> None:
+            order.append("a")
+
+        @evt
+        async def b() -> None:
+            order.append("b")
+
+        @evt
+        async def c() -> None:
+            order.append("c")
+
+        await evt.emit()
+        assert order == ["a", "b", "c"]
+
+    async def test_subscribe_during_emit_does_not_fire_in_same_emission(
+        self,
+    ) -> None:
+        """Snapshotting handlers prevents reentrant subscribe storms."""
+        evt: AsyncEvent = AsyncEvent()
+        late_called = False
+
+        async def late() -> None:
+            nonlocal late_called
+            late_called = True
+
+        @evt
+        async def first() -> None:
+            evt.subscribe(late)
+
+        await evt.emit()
+        assert late_called is False
+        # But it does fire on the next emission.
+        await evt.emit()
+        assert late_called is True
+
+    async def test_unsubscribe_during_emit_is_safe(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+        calls: list[str] = []
+
+        async def b() -> None:
+            calls.append("b")
+
+        unsubscribed = False
+
+        @evt
+        async def a() -> None:
+            nonlocal unsubscribed
+            calls.append("a")
+            if not unsubscribed:
+                evt.unsubscribe(b)
+                unsubscribed = True
+
+        evt.subscribe(b)
+        await evt.emit()
+        # Snapshot semantics: b still ran in this emission.
+        assert calls == ["a", "b"]
+        # Next emission only has a.
+        calls.clear()
+        await evt.emit()
+        assert calls == ["a"]
+
+    async def test_handler_exception_propagates(self) -> None:
+        evt: AsyncEvent = AsyncEvent()
+
+        @evt
+        async def boom() -> None:
+            raise RuntimeError("nope")
+
+        with pytest.raises(RuntimeError, match="nope"):
+            await evt.emit()
+
+
+def test_top_level_export_matches_internal() -> None:
+    """Public re-export from ``deckui`` is the same class."""
+    assert AsyncEvent is AsyncEventInternal

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -96,6 +96,46 @@ class TestDeckBrightness:
         await deck.set_brightness(60)
         assert deck.brightness == 60
 
+    async def test_set_brightness_emits_event(self, deck):
+        seen: list[int] = []
+
+        @deck.on_brightness_changed
+        async def _on(value: int) -> None:
+            seen.append(value)
+
+        await deck.set_brightness(42)
+        assert seen == [42]
+
+    async def test_set_brightness_idempotent_no_event(self, deck):
+        """Setting the same value emits no event and skips the hardware push."""
+        seen: list[int] = []
+
+        @deck.on_brightness_changed
+        async def _on(value: int) -> None:  # pragma: no cover - never invoked
+            seen.append(value)
+
+        # initial brightness is 80; setting to 80 should be a no-op.
+        await deck.set_brightness(80)
+        assert seen == []
+
+    async def test_set_brightness_skips_hw_when_unchanged(
+        self, deck, mock_streamdeck_device
+    ):
+        """A no-op call must not touch the hardware."""
+        deck._device = mock_streamdeck_device
+        await deck.set_brightness(80)  # equal to default
+        mock_streamdeck_device.set_brightness.assert_not_called()
+
+    async def test_set_brightness_emits_clamped_value(self, deck):
+        seen: list[int] = []
+
+        @deck.on_brightness_changed
+        async def _on(value: int) -> None:
+            seen.append(value)
+
+        await deck.set_brightness(999)
+        assert seen == [100]
+
 
 class TestDeckSetPage:
     async def test_sets_active_screen(self, deck):
@@ -119,6 +159,60 @@ class TestDeckSetPage:
         await deck.set_screen("main")
         deck._render_all_keys.assert_awaited_once()
         deck._render_touchscreen.assert_awaited_once()
+
+    async def test_emits_event_after_render(self, deck):
+        """on_screen_changed fires after the new screen has rendered."""
+        deck.screen("main")
+        deck._render_all_keys = AsyncMock()
+        deck._render_touchscreen = AsyncMock()
+
+        order: list[str] = []
+        deck._render_all_keys.side_effect = lambda: order.append("rendered")
+
+        @deck.on_screen_changed
+        async def _on(name: str) -> None:
+            order.append(f"event:{name}")
+
+        await deck.set_screen("main")
+        assert order == ["rendered", "event:main"]
+
+    async def test_idempotent_does_not_emit_or_re_render(self, deck):
+        """Re-setting the same screen emits nothing and re-renders nothing."""
+        deck.screen("main")
+        deck._render_all_keys = AsyncMock()
+        deck._render_touchscreen = AsyncMock()
+
+        await deck.set_screen("main")  # initial activation
+        seen: list[str] = []
+
+        @deck.on_screen_changed
+        async def _on(name: str) -> None:  # pragma: no cover - never invoked
+            seen.append(name)
+
+        deck._render_all_keys.reset_mock()
+        deck._render_touchscreen.reset_mock()
+
+        await deck.set_screen("main")
+        assert seen == []
+        deck._render_all_keys.assert_not_awaited()
+        deck._render_touchscreen.assert_not_awaited()
+
+    async def test_emits_event_on_screen_switch(self, deck):
+        deck.screen("main")
+        deck.screen("settings")
+        deck._render_all_keys = AsyncMock()
+        deck._render_touchscreen = AsyncMock()
+
+        seen: list[str] = []
+
+        @deck.on_screen_changed
+        async def _on(name: str) -> None:
+            seen.append(name)
+
+        await deck.set_screen("main")
+        await deck.set_screen("settings")
+        await deck.set_screen("main")
+        assert seen == ["main", "settings", "main"]
 
 
 class TestDeckActivePage:

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -393,7 +394,7 @@ class TestAudioController:
         return AudioController(MEDIA_CATALOG, packages_dir=tmp_path)
 
     def test_initial_state(self, ctrl: AudioController) -> None:
-        assert ctrl.volume_level == 0.5
+        assert ctrl.volume == 50
         assert ctrl.is_muted is False
         assert ctrl.is_playing is False
 
@@ -444,14 +445,22 @@ class TestAudioController:
         assert ctrl.card.get("artist") == MEDIA_CATALOG[-1]["artist"]
 
     async def test_set_volume_clamps(self, ctrl: AudioController) -> None:
-        await ctrl.svc.set_volume(1.5)
-        assert ctrl.volume_level == 1.0
-        await ctrl.svc.set_volume(-0.5)
-        assert ctrl.volume_level == 0.0
+        await ctrl.svc.set_volume(150)
+        assert ctrl.volume == 100
+        await ctrl.svc.set_volume(-50)
+        assert ctrl.volume == 0
 
     async def test_set_volume_updates_card(self, ctrl: AudioController) -> None:
-        await ctrl.svc.set_volume(0.75)
+        await ctrl.svc.set_volume(75)
         assert ctrl.card.get("value_text") == "75%"
+        # Volume slider binding tracks domain value normalised 0..1.
+        assert ctrl.card.get("volume") == pytest.approx(0.75)
+
+    async def test_set_volume_idempotent(self, ctrl: AudioController) -> None:
+        """A same-value set neither emits nor mutates the card."""
+        await ctrl.svc.set_volume(50)  # equal to default
+        # value_text was set during initial render; still shows 50%.
+        assert ctrl.card.get("value_text") == "50%"
 
     async def test_toggle_mute(self, ctrl: AudioController) -> None:
         await ctrl.svc.toggle_mute()
@@ -460,6 +469,22 @@ class TestAudioController:
         await ctrl.svc.toggle_mute()
         assert ctrl.is_muted is False
         assert ctrl.card.get("value_text") == "50%"
+
+    async def test_volume_handler_does_not_pre_mutate_card(
+        self, ctrl: AudioController
+    ) -> None:
+        """volume_up handler routes through the service, not the card.
+
+        The card's volume slider must reflect the *post-service* value,
+        not a pre-emptive UI guess.  We pin the service so it ignores
+        the request -- the card binding must remain unchanged.
+        """
+        before = ctrl.card.get("volume")
+        ctrl.svc.set_volume = AsyncMock()  # type: ignore[method-assign]
+        handler = ctrl.card._events._handlers["volume_up"]
+        await handler(1)
+        assert ctrl.card.get("volume") == before
+        ctrl.svc.set_volume.assert_awaited_once_with(51)
 
 
 # ===================================================================
@@ -593,7 +618,19 @@ class TestTimerController:
 
 
 class TestDashboardController:
-    """Tests for DashboardController state and card bindings."""
+    """Tests for DashboardController.
+
+    Deck brightness is *deck-owned* state -- the controller observes
+    :attr:`Deck.on_brightness_changed` rather than holding its own
+    value.  The tests verify that:
+
+    * Telemetry pushes from the service drive the temperature/humidity
+      bindings.
+    * Brightness handlers route through ``deck.set_brightness``, never
+      the card directly.
+    * ``bind_deck`` replays the controller's last-known brightness onto
+      the freshly-connected deck (the reconnect contract).
+    """
 
     @pytest.fixture
     def ctrl(self, monkeypatch: pytest.MonkeyPatch) -> DashboardController:
@@ -603,13 +640,20 @@ class TestDashboardController:
         )
         return DashboardController()
 
+    def _real_deck(self, brightness: int = 50) -> Any:
+        """Build a real Deck so the AsyncEvents are wired correctly."""
+        from deckui.runtime.deck import Deck
+
+        return Deck(serial_number="TEST_DASH", brightness=brightness)
+
     def test_initial_state(self, ctrl: DashboardController) -> None:
+        # 0.5 default -> 50% in domain units.
         assert ctrl.deck_brightness == 50
-        assert ctrl.temperature == "22C"
-        assert ctrl.humidity == "45%"
+        assert ctrl.temperature_c == pytest.approx(22.0)
+        assert ctrl.humidity_pct == 45
 
     def test_card_initial_bindings(self, ctrl: DashboardController) -> None:
-        assert ctrl.card.get("temperature") == "22C"
+        assert ctrl.card.get("temperature") == "22.0C"
         assert ctrl.card.get("humidity") == "45%"
 
     def test_get_date_format(self, ctrl: DashboardController) -> None:
@@ -620,22 +664,68 @@ class TestDashboardController:
     def test_get_time_format(self, ctrl: DashboardController) -> None:
         assert ":" in ctrl.get_time()
 
-    async def test_set_brightness_clamps(self, ctrl: DashboardController) -> None:
-        await ctrl._set_brightness(200)
-        assert ctrl.deck_brightness == 100
-        await ctrl._set_brightness(-50)
-        assert ctrl.deck_brightness == 0
+    async def test_telemetry_event_updates_card(
+        self, ctrl: DashboardController
+    ) -> None:
+        await ctrl._svc.set_telemetry(18.4, 60)
+        assert ctrl.card.get("temperature") == "18.4C"
+        assert ctrl.card.get("humidity") == "60%"
 
-    async def test_set_brightness_calls_deck(self, ctrl: DashboardController) -> None:
-        mock_deck = MagicMock()
-        mock_deck.set_brightness = AsyncMock()
-        ctrl.bind_deck(mock_deck)
-        await ctrl._set_brightness(75)
-        mock_deck.set_brightness.assert_awaited_once_with(75)
+    async def test_brightness_handler_routes_through_deck(
+        self, ctrl: DashboardController
+    ) -> None:
+        """brightness_up only calls deck.set_brightness; no direct card mutation."""
+        deck = self._real_deck(brightness=50)
+        await ctrl.bind_deck(deck)
+        before = ctrl.card.get("deck_brightness")
 
-    async def test_set_brightness_without_deck(self, ctrl: DashboardController) -> None:
-        await ctrl._set_brightness(50)
-        assert ctrl.deck_brightness == 50
+        # Pin the deck so the event never fires; the card must stay put.
+        deck.set_brightness = AsyncMock()  # type: ignore[method-assign]
+        handler = ctrl.card._events._handlers["brightness_up"]
+        await handler(1)
+        assert ctrl.card.get("deck_brightness") == before
+        deck.set_brightness.assert_awaited_once_with(51)
+
+    async def test_brightness_event_updates_card_and_last_known(
+        self, ctrl: DashboardController
+    ) -> None:
+        """deck.set_brightness fires the event; subscriber updates UI + memory."""
+        deck = self._real_deck(brightness=50)
+        await ctrl.bind_deck(deck)
+
+        await deck.set_brightness(73)
+        assert ctrl.deck_brightness == 73
+        assert ctrl.card.get("deck_brightness") == pytest.approx(0.73)
+
+    async def test_bind_deck_replays_last_known(
+        self, ctrl: DashboardController
+    ) -> None:
+        """Reconnect: a fresh deck gets the user's last value replayed."""
+        first = self._real_deck(brightness=50)
+        await ctrl.bind_deck(first)
+        await first.set_brightness(80)
+        assert ctrl.deck_brightness == 80
+
+        # Simulate disconnect + reconnect: a brand-new Deck instance.
+        second = self._real_deck(brightness=50)
+        await ctrl.bind_deck(second)
+        # The replay must have driven the new deck to 80.
+        assert second.brightness == 80
+
+    async def test_bind_deck_no_replay_when_already_matching(
+        self, ctrl: DashboardController
+    ) -> None:
+        """If the new deck already matches, replay is a silent no-op."""
+        deck = self._real_deck(brightness=50)
+        # 50 matches the manifest default the controller is holding.
+        events: list[int] = []
+
+        @deck.on_brightness_changed
+        async def _on(value: int) -> None:
+            events.append(value)
+
+        await ctrl.bind_deck(deck)
+        assert events == []
 
 
 # ===================================================================
@@ -784,6 +874,25 @@ class TestFavoritesController:
 class TestScreenCycler:
     """Tests for the ScreenCycler controller."""
 
+    def _stub_deck(self) -> Any:
+        """Build a minimal deck stub with a real ``on_screen_changed``.
+
+        The cycler subscribes to the deck's ``on_screen_changed`` event
+        in ``bind_deck``; pure ``MagicMock`` doesn't expose AsyncEvent
+        semantics, so we wire one in by hand and have ``set_screen``
+        emit it.
+        """
+        from deckui import AsyncEvent
+
+        deck = MagicMock()
+        deck.on_screen_changed = AsyncEvent()
+
+        async def _set_screen(name: str) -> None:
+            await deck.on_screen_changed.emit(name)
+
+        deck.set_screen = AsyncMock(side_effect=_set_screen)
+        return deck
+
     def test_rejects_empty_screen_list(self) -> None:
         with pytest.raises(ValueError):
             ScreenCycler([])
@@ -794,8 +903,7 @@ class TestScreenCycler:
 
     async def test_advance_wraps_around(self) -> None:
         cycler = ScreenCycler(["a", "b", "c"])
-        deck = MagicMock()
-        deck.set_screen = AsyncMock()
+        deck = self._stub_deck()
         cycler.bind_deck(deck)
 
         await cycler.advance()
@@ -807,13 +915,25 @@ class TestScreenCycler:
 
         await cycler.advance()
         assert cycler.current == "a"
-        # Three calls in total, in order.
         targets = [c.args[0] for c in deck.set_screen.await_args_list]
         assert targets == ["b", "c", "a"]
 
+    async def test_current_tracks_external_screen_change(self) -> None:
+        """Cycler observes deck.on_screen_changed even from external callers."""
+        cycler = ScreenCycler(["a", "b", "c"])
+        deck = self._stub_deck()
+        cycler.bind_deck(deck)
+
+        # External code (not the cycler) drives the deck to "c".
+        await deck.set_screen("c")
+        assert cycler.current == "c"
+
+        # The cycler then advances from "c" -- next is "a".
+        await cycler.advance()
+        assert cycler.current == "a"
+
     async def test_advance_without_deck_is_noop(self) -> None:
         cycler = ScreenCycler(["a", "b"])
-        # No bind_deck() -- must not raise and must not advance index.
         await cycler.advance()
         assert cycler.current == "a"
 
@@ -821,20 +941,16 @@ class TestScreenCycler:
         spec = _dash_spec()
         card = DuiCard(spec)
         cycler = ScreenCycler(["a", "b"])
-        deck = MagicMock()
-        deck.set_screen = AsyncMock()
+        deck = self._stub_deck()
         cycler.bind_deck(deck)
 
         cycler.attach(card)
-        # The cycler registers a handler against the manifest event;
-        # invoke it the same way the deck would.
         handler = card._events._handlers["next_screen"]
         await handler()
         assert cycler.current == "b"
         deck.set_screen.assert_awaited_with("b")
 
     async def test_attach_custom_event_name(self) -> None:
-        # Build a dashboard-shaped spec but with a differently-named event.
         spec = PackageSpec(
             name="DashboardCard",
             type=PackageType.TOUCH_STRIP_CARD,
@@ -851,8 +967,7 @@ class TestScreenCycler:
         )
         card = DuiCard(spec)
         cycler = ScreenCycler(["x", "y"])
-        deck = MagicMock()
-        deck.set_screen = AsyncMock()
+        deck = self._stub_deck()
         cycler.bind_deck(deck)
 
         cycler.attach(card, event="rotate_screen")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,8 +11,10 @@ class TestPublicAPI:
 
     def test_all_exports(self):
         expected = {
+            "AsyncEvent",
             "BlankCard",
             "Card",
+            "Deck",
             "DeckError",
             "DeckEvent",
             "DeckManager",
@@ -133,3 +135,13 @@ class TestPublicAPI:
         assert DeviceCapabilities is not None
         assert InfoScreen is not None
         assert RenderMetrics is not None
+
+    def test_async_event_importable(self):
+        from deckui import AsyncEvent
+
+        assert AsyncEvent is not None
+
+    def test_deck_importable(self):
+        from deckui import Deck
+
+        assert Deck is not None


### PR DESCRIPTION
## Summary

- Adds `deckui.AsyncEvent`, a small multicast async event primitive, and uses it to expose two property-change hooks on `Deck`: `on_brightness_changed: AsyncEvent[int]` and `on_screen_changed: AsyncEvent[str]`. Both fire only on confirmed transitions; idempotent calls neither re-emit nor re-push to the hardware.
- Rewrites `examples/streamdeck.py` and `examples/mock_backend.py` so every controller follows the same one-way data flow — DUI input → `service.method(...)` → service emits change event → subscriber updates card. No DUI handler mutates a card binding directly. Mock services keep state in *domain units only* (no normalised floats, no formatted strings in event payloads); presentation lives entirely in controllers.
- Brightness in particular is now treated as deck-owned state: `DashboardController` observes `Deck.on_brightness_changed` instead of holding its own value, and only remembers a `_last_known_brightness` to replay across reconnects. New `MockScenesService` gives `SceneController` a real backend to call. `ScreenCycler` observes `Deck.on_screen_changed` instead of duplicating active-screen state.

## Why

The previous example claimed to demonstrate ‟UI reflects *confirmed* state, not *requested* state” but several controllers (notably `AudioController._vol_up` and `DashboardController._set_brightness`) mutated card bindings before their service had been told. The library also had no `AsyncEvent` primitive — `mock_backend.py` reinvented one — and `Deck.set_brightness` / `set_screen` were silent, forcing the example to break its own architecture to wire deck-owned state into the UI. This PR fixes both gaps.

## Public API additions
- `deckui.AsyncEvent`
- `deckui.Deck` (now top-level export)
- `deckui.Deck.on_brightness_changed`
- `deckui.Deck.on_screen_changed`

No removals; no breaking changes for library consumers. Behaviour change in `Deck.set_brightness` / `set_screen`: same-value calls are now silent no-ops (previously brightness still pushed to hardware). Documented and covered by tests.

## Test plan

- [x] `ruff check .`
- [x] `mypy src` (strict)
- [x] `pytest tests/ --cov=deckui --cov-fail-under=95` — **97.80%** coverage, 1165 passed
- [x] New tests: 10 for `AsyncEvent`, 4 for the new `Deck` events, plus no-pre-mutation assertions on `volume_up` and `brightness_up` handlers in the example
- [x] `python -c "import streamdeck"` smoke-imports the rewritten example
- [ ] Manual run of `python examples/streamdeck.py` against a real Stream Deck (not in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)