### PR TITLE
Switch to hatch-vcs for dynamic versioning from git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Generated version file
+src/deckui/_version.py
+
 # C extensions
 *.so
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "deckui"
-version = "1.2.1"
+dynamic = ["version"]
 description = "A high-level, asyncio-native Python library for Elgato Stream Deck devices."
 readme = "README.md"
 license = "Apache-2.0"
@@ -38,6 +38,12 @@ dependencies = [
 Homepage = "https://github.com/Graphras-com/DeckUI"
 Repository = "https://github.com/Graphras-com/DeckUI"
 Issues = "https://github.com/Graphras-com/DeckUI/issues"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/deckui/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/deckui"]

--- a/src/deckui/__init__.py
+++ b/src/deckui/__init__.py
@@ -95,4 +95,6 @@ __all__ = [
     "load_package",
 ]
 
-__version__ = "0.1.0"
+from deckui._version import __version__
+
+__all__ += ["__version__"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,10 +7,12 @@ import deckui
 
 class TestPublicAPI:
     def test_version(self):
-        assert deckui.__version__ == "0.1.0"
+        assert isinstance(deckui.__version__, str)
+        assert len(deckui.__version__) > 0
 
     def test_all_exports(self):
         expected = {
+            "__version__",
             "AsyncEvent",
             "BlankCard",
             "Card",


### PR DESCRIPTION
## Summary

- Replace hardcoded version in pyproject.toml with hatch-vcs dynamic versioning derived from git tags
- Add hatch-vcs build hook to generate src/deckui/_version.py automatically
- Update __init__.py to import __version__ from the generated _version.py
- Add _version.py to .gitignore (generated at build time)
- Update tests to validate version is a non-empty string rather than a hardcoded value

## Why

Eliminates version drift between git tags and the package. The tag becomes the single source of truth for the version.

## Release workflow

```bash
git tag -a v1.3.0 -m "v1.3.0"
git push origin v1.3.0
gh release create v1.3.0 --generate-notes
```