### PR TITLE
Require caps in Screen; raise in Deck.screen() pre-start

### DIFF
--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -283,8 +283,17 @@ class Deck:
         -------
         Screen
             The Screen instance.
+
+        Raises
+        ------
+        DeckError
+            If the device is not opened — capabilities are required to
+            size the screen, and they are only known after :meth:`start`.
         """
         from ..ui.screen import Screen
+
+        if self._caps is None:
+            raise DeckError("Device not opened")
 
         if name not in self._screens:
             self._screens[name] = Screen(name, self._caps)

--- a/src/deckui/ui/screen.py
+++ b/src/deckui/ui/screen.py
@@ -40,11 +40,9 @@ class Screen:
             await deck.set_screen("settings")
     """
 
-    def __init__(self, name: str, caps: DeviceCapabilities | None = None) -> None:
-        from ..runtime.capabilities import STREAM_DECK_PLUS
-
+    def __init__(self, name: str, caps: DeviceCapabilities) -> None:
         self._name = name
-        self._caps = caps or STREAM_DECK_PLUS
+        self._caps = caps
         self._keys: dict[int, KeySlot] = {}
         self._encoders: dict[int, EncoderSlot] = {}
 
@@ -188,7 +186,7 @@ class Screen:
 
     @property
     def touchstrip_background(self) -> str:
-        """The fill colour for the touchscreen canvas (margins and gaps)."""
+        """The fill colour for the touchscreen canvas behind cards."""
         if self._touch_strip is None:
             return "black"
         return self._touch_strip.background_color

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -32,8 +32,15 @@ class _TestCard(Card):
 
 @pytest.fixture
 def deck(tmp_path):
-    """A Deck instance with required serial_number."""
-    return Deck(serial_number="TEST123")
+    """A Deck instance with required serial_number.
+
+    Capabilities are pre-populated so tests can call ``deck.screen()``
+    without going through the real device-discovery path.
+    """
+    d = Deck(serial_number="TEST123")
+    d._caps = STREAM_DECK_PLUS
+    d._metrics = RenderMetrics(STREAM_DECK_PLUS)
+    return d
 
 
 class TestDeckInit:
@@ -656,21 +663,25 @@ class TestDeckInfo:
 
 
 class TestDeckCapabilities:
-    def test_capabilities_not_opened(self, deck):
+    def test_capabilities_not_opened(self):
+        d = Deck(serial_number="TEST123")
         with pytest.raises(DeckError, match="Device not opened"):
-            _ = deck.capabilities
+            _ = d.capabilities
 
-    def test_metrics_not_opened(self, deck):
+    def test_metrics_not_opened(self):
+        d = Deck(serial_number="TEST123")
         with pytest.raises(DeckError, match="Device not opened"):
-            _ = deck.metrics
+            _ = d.metrics
+
+    def test_screen_not_opened(self):
+        d = Deck(serial_number="TEST123")
+        with pytest.raises(DeckError, match="Device not opened"):
+            d.screen("main")
 
     def test_capabilities_after_set(self, deck):
-        deck._caps = STREAM_DECK_PLUS
         assert deck.capabilities is STREAM_DECK_PLUS
 
     def test_metrics_after_set(self, deck):
-        deck._caps = STREAM_DECK_PLUS
-        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
         assert deck.metrics.key_count == 8
 
 

--- a/tests/test_dui_card.py
+++ b/tests/test_dui_card.py
@@ -17,6 +17,7 @@ from deckui.dui.schema import (
     TextBinding,
     ToggleBinding,
 )
+from deckui.runtime.capabilities import STREAM_DECK_PLUS
 from deckui.runtime.events import EventType, TouchEvent
 from deckui.ui.cards.base import Card
 from deckui.ui.screen import Screen
@@ -58,7 +59,7 @@ class TestDuiCardIsCard:
         list is the authoritative source of truth.
         """
         card = DuiCard(card_package_spec)
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         screen.set_card(2, card)
         assert screen.touch_strip is not None
         assert screen.touch_strip.cards[2] is card

--- a/tests/test_dui_integration.py
+++ b/tests/test_dui_integration.py
@@ -19,6 +19,7 @@ from deckui.dui.schema import (
     PackageType,
     TextBinding,
 )
+from deckui.runtime.capabilities import STREAM_DECK_PLUS
 from deckui.ui.controls.key_slot import KeySlot
 from deckui.ui.screen import Screen
 
@@ -60,13 +61,13 @@ def _card_spec() -> PackageSpec:
 
 class TestScreenSetKey:
     def test_set_key_installs_dui_key(self):
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         key = DuiKey(_key_spec())
         screen.set_key(0, key)
         assert screen.keys[0] is key
 
     def test_set_key_validates_index(self):
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         key = DuiKey(_key_spec())
         with pytest.raises(IndexError):
             screen.set_key(8, key)
@@ -74,12 +75,12 @@ class TestScreenSetKey:
             screen.set_key(-1, key)
 
     def test_set_key_validates_type(self):
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         with pytest.raises(TypeError):
             screen.set_key(0, "not a key")
 
     def test_set_key_replaces_existing(self):
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         old = screen.key(0)
         new = DuiKey(_key_spec())
         screen.set_key(0, new)
@@ -87,7 +88,7 @@ class TestScreenSetKey:
         assert screen.keys[0] is not old
 
     def test_set_key_accepts_regular_key_slot(self):
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         key = KeySlot()
         screen.set_key(0, key)
         assert screen.keys[0] is key
@@ -95,7 +96,7 @@ class TestScreenSetKey:
 
 class TestScreenSetCard:
     def test_set_card_with_dui_card(self):
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         card = DuiCard(_card_spec())
         screen.set_card(0, card)
         assert screen.card(0) is card
@@ -246,7 +247,7 @@ class TestEndToEnd:
         packages = load_all_packages(dui_packages_dir)
         assert len(packages) == 2
 
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         card = DuiCard(packages["TestCard"])
         screen.set_card(0, card)
 

--- a/tests/test_dui_key.py
+++ b/tests/test_dui_key.py
@@ -16,6 +16,7 @@ from deckui.dui.schema import (
     TextBinding,
     ToggleBinding,
 )
+from deckui.runtime.capabilities import STREAM_DECK_PLUS
 from deckui.ui.controls.key_slot import KeySlot
 from deckui.ui.screen import Screen
 
@@ -55,7 +56,7 @@ class TestDuiKeyIsKeySlot:
         """
         spec = _make_key_spec()
         key = DuiKey(spec)
-        screen = Screen("test")
+        screen = Screen("test", STREAM_DECK_PLUS)
         screen.set_key(3, key)
         assert screen.keys[3] is key
 


### PR DESCRIPTION
## Summary

- Removes the last Stream-Deck-Plus default baked into shared library code: `Screen(name, caps=None)` previously imported `STREAM_DECK_PLUS` inside `__init__` and used it as a fallback, silently sizing every fallback-constructed screen to that specific model.
- `caps` is now required on `Screen`. `Deck.screen()` raises `DeckError("Device not opened")` when capabilities aren't yet known — mirroring the existing behaviour of `Deck.capabilities` and `Deck.metrics`.
- Tidies a stale doc comment on `Screen.touchstrip_background` that still referenced margins and gaps (removed in #147).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy src/deckui` — clean
- [x] `pytest tests/ --cov=deckui --cov-fail-under=95` — 1191 passed, 1 skipped, **97.80% coverage**

## Notes

- The `deck` fixture in `tests/test_deck.py` now pre-populates `_caps`/`_metrics` so the bulk of tests can use `deck.screen()` without going through the full `start()` path. The two tests that explicitly cover the unopened-device error path construct their own `Deck` directly.
- Three other test files (`test_dui_card`, `test_dui_key`, `test_dui_integration`) had ~9 callsites of `Screen("test")` updated to pass `STREAM_DECK_PLUS` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
