### PR TITLE
Pass screens dict to on_screen_changed handlers

### DIFF
--- a/examples/DashboardCard.dui/layout.svg
+++ b/examples/DashboardCard.dui/layout.svg
@@ -1,24 +1,37 @@
-<svg id="DashboardCard" xmlns="http://www.w3.org/2000/svg" width="197" height="98" font-family="ArialMT,Arial,sans-serif">
-    <rect id="background" color="#1c1c1c" x="0" y="0" width="197" height="98" fill="currentColor"/>
-    <g id="foreground">
-        <g color="#8f8f8f" transform="translate(98.5 7)">
-            <text id="date" font-size="16" fill="currentColor" text-anchor="middle" dominant-baseline="hanging">Friday, 24 April</text>
+<svg id="DashboardCard" xmlns="http://www.w3.org/2000/svg" width="200" height="100" font-family="ArialMT,Arial,sans-serif">
+    <style>
+        .background { color: #1C1C1C; }
+        .foreground_primary { color: #DEDEDE; }
+        .foreground_secondary { color: #8F8F8F; }
+    </style>
+    <g id="background" class="background">
+        <rect id="background_rect"  x="0" y="0" width="200" height="100" fill="currentColor"/>
+    </g>
+    <g id="foreground_secondary" class="foreground_secondary" transform="translate(0 2)">
+        <g transform="translate(98.5 15)">
+            <text id="date" font-size="18" fill="currentColor" text-anchor="middle" dominant-baseline="middle">Friday, 24 April</text>
         </g>
-        <g color="#dedede" transform="translate(98.5 31)">
-            <text id="time" font-size="30" fill="currentColor" text-anchor="middle" dominant-baseline="hanging">20:41</text>
+        <g transform="translate(150 38)">
+            <rect stroke="currentColor" fill="currentColor" width="35" height="22" rx="3" ry="3"/>
+            <text id="screens" class="background" x="17.5" y="11" font-size="20" fill="currentColor" text-anchor="middle" dominant-baseline="middle">1/3</text>
         </g>
-        <g color="#8f8f8f" transform="translate(18, 65)">
+        <g transform="translate(30, 68)">
             <g transform="translate(0 0)">
                 <svg xmlns="http://www.w3.org/2000/svg" width="23" height="23" viewBox="0 0 24 24"><path fill="currentColor" d="M12 21q-2.075 0-3.537-1.463T7 16q0-1.2.525-2.238T9 12V6q0-1.25.875-2.125T12 3t2.125.875T15 6v6q.95.725 1.475 1.763T17 16q0 2.075-1.463 3.538T12 21m0-2q1.25 0 2.125-.875T15 16q0-.725-.312-1.35T13.8 13.6L13 13V6q0-.425-.288-.712T12 5t-.712.288T11 6v7l-.8.6q-.575.425-.888 1.05T9 16q0 1.25.875 2.125T12 19m0-3"/></svg>
-                <text id="temperature" x="20" y="5" font-size="16" fill="currentColor" dominant-baseline="hanging">22.5C</text>
+                <text id="temperature" x="20" y="14" font-size="16" fill="currentColor" dominant-baseline="middle">22.5C</text>
             </g>
-            <g transform="translate(95 0)">            
-                <svg xmlns="http://www.w3.org/2000/svg" y="2" width="19" height="19" viewBox="0 0 24 24"><path fill="currentColor" d="M15.563 17.563Q16 17.125 16 16.5t-.437-1.062T14.5 15t-1.062.438T13 16.5t.438 1.063T14.5 18t1.063-.437m-6.113.387l6.5-6.5l-1.4-1.4l-6.5 6.5zm1.113-5.387Q11 12.125 11 11.5t-.437-1.062T9.5 10t-1.062.438T8 11.5t.438 1.063T9.5 13t1.063-.437M6.288 19.65Q4 17.3 4 13.8q0-2.5 1.988-5.437T12 2q4.025 3.425 6.013 6.363T20 13.8q0 3.5-2.287 5.85T12 22t-5.712-2.35M16.3 18.238Q18 16.475 18 13.8q0-1.825-1.513-4.125T12 4.65Q9.025 7.375 7.513 9.675T6 13.8q0 2.675 1.7 4.438T12 20t4.3-1.763M12 12"/></svg>
-                <text id="humidity" x="21" y="5" font-size="16" fill="currentColor" dominant-baseline="hanging">36.7%</text>
+            <g transform="translate(80 0)">            
+                <svg xmlns="http://www.w3.org/2000/svg" y="3" width="19" height="19" viewBox="0 0 24 24"><path fill="currentColor" d="M15.563 17.563Q16 17.125 16 16.5t-.437-1.062T14.5 15t-1.062.438T13 16.5t.438 1.063T14.5 18t1.063-.437m-6.113.387l6.5-6.5l-1.4-1.4l-6.5 6.5zm1.113-5.387Q11 12.125 11 11.5t-.437-1.062T9.5 10t-1.062.438T8 11.5t.438 1.063T9.5 13t1.063-.437M6.288 19.65Q4 17.3 4 13.8q0-2.5 1.988-5.437T12 2q4.025 3.425 6.013 6.363T20 13.8q0 3.5-2.287 5.85T12 22t-5.712-2.35M16.3 18.238Q18 16.475 18 13.8q0-1.825-1.513-4.125T12 4.65Q9.025 7.375 7.513 9.675T6 13.8q0 2.675 1.7 4.438T12 20t4.3-1.763M12 12"/></svg>
+                <text id="humidity" x="20" y="14" font-size="16" fill="currentColor" dominant-baseline="middle">36.7%</text>
             </g>
         </g>
-        <g color="#dedede" transform="translate(0 90)">
-            <rect id="deck_brightness" x="0" y="5" width="197" height="5" stroke="none" fill="currentColor" rx="0" ry="0"/>
+    </g>
+    <g id="foreground" class="foreground_primary">
+        <g transform="translate(98.5 52)">
+            <text id="time" font-size="30" fill="currentColor" text-anchor="middle" dominant-baseline="middle">20:41</text>
+        </g>
+        <g transform="translate(0 90)">
+            <rect id="deck_brightness" x="0" y="5" width="200" height="5" stroke="none" fill="currentColor" rx="0" ry="0"/>
         </g>
     </g>
 </svg>

--- a/examples/DashboardCard.dui/manifest.yaml
+++ b/examples/DashboardCard.dui/manifest.yaml
@@ -1,10 +1,10 @@
 name: DashboardCard
 type: TouchStripCard
 version: 1
-description: Displays date and time, temperature and humidity and brightness control for the Deck
+description: Deck brightness control, Screen cycler and displays date, time, temperature and humidity
 author: Graphras.com
 license: Apache-2.0
-category: media
+category: utilities
 layout: layout.svg
 
 bindings:
@@ -13,7 +13,7 @@ bindings:
     node: date
     default: ""
     max_width: 190
-    overflow: ellipsis
+    overflow: clip
 
   time:
     type: text
@@ -36,24 +36,39 @@ bindings:
     max_width: 50
     overflow: clip
 
+  screens:
+    type: text
+    node: screens
+    default: "1/1"
+    max_width: 35
+    overflow: clip
+
   deck_brightness:
     type: range
     node: deck_brightness
     default: 0.8
     direction: horizontal
 
+  background:
+    type: color
+    node: background
+    default: "#1C1C1C"
+
+  foreground:
+    type: color
+    node: foreground
+    default: "#DEDEDE"
+
 events:
   - name: brightness_down
     source: encoder_turn
     direction: left
-    accumulate: true
-    accumulate_delay: 0.05
+    accumulate: false
 
   - name: brightness_up
     source: encoder_turn
     direction: right
-    accumulate: true
-    accumulate_delay: 0.05
+    accumulate: false
 
   - name: next_screen
     source: encoder_press_release

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -705,6 +705,12 @@ class DashboardController(CardController):
         async def _track_last_known(value: int) -> None:
             self._last_known_brightness = value
 
+        @deck.on_screen_changed
+        async def _screen_changed(name: str, screens:dict) -> None:
+            _screens = list(screens)
+            self.card.set("screens", f"{_screens.index(name)+1}/{len(_screens)}")
+            await self.card.request_refresh()
+
         # Replay onto the freshly-connected deck.  Idempotent: if the
         # values match, ``set_brightness`` silently no-ops.
         await deck.set_brightness(self._last_known_brightness)
@@ -967,7 +973,7 @@ class ScreenCycler:
         self._deck = deck
 
         @deck.on_screen_changed
-        async def _on_screen(name: str) -> None:
+        async def _on_screen(name: str, screens:dict) -> None:
             self._last_known = name
 
     def attach(self, card: DuiCard, event: str = "next_screen") -> None:
@@ -1068,7 +1074,7 @@ class StreamDeckApp:
 
         # Demonstrate Deck.on_screen_changed: log every screen switch.
         @deck.on_screen_changed
-        async def _log_screen(name: str) -> None:
+        async def _log_screen(name: str, screens:dict) -> None:
             log.info("Active screen confirmed: %s", name)
 
         # Drive the uniform lifecycle on every controller.

--- a/src/deckui/runtime/deck.py
+++ b/src/deckui/runtime/deck.py
@@ -337,7 +337,7 @@ class Deck:
         if self._active_screen.info_screen is not None:
             await self._render_info_screen()
 
-        await self.on_screen_changed.emit(name)
+        await self.on_screen_changed.emit(name, self._screens)
 
     def _wire_refresh_callbacks(self) -> None:
         """Register ``self.refresh`` on every key and card of the active screen.

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -178,7 +178,7 @@ class TestDeckSetPage:
         deck._render_all_keys.side_effect = lambda: order.append("rendered")
 
         @deck.on_screen_changed
-        async def _on(name: str) -> None:
+        async def _on(name: str, screens: dict) -> None:
             order.append(f"event:{name}")
 
         await deck.set_screen("main")
@@ -194,7 +194,7 @@ class TestDeckSetPage:
         seen: list[str] = []
 
         @deck.on_screen_changed
-        async def _on(name: str) -> None:  # pragma: no cover - never invoked
+        async def _on(name: str, screens: dict) -> None:  # pragma: no cover - never invoked
             seen.append(name)
 
         deck._render_all_keys.reset_mock()
@@ -214,7 +214,7 @@ class TestDeckSetPage:
         seen: list[str] = []
 
         @deck.on_screen_changed
-        async def _on(name: str) -> None:
+        async def _on(name: str, screens: dict) -> None:
             seen.append(name)
 
         await deck.set_screen("main")

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -888,7 +888,7 @@ class TestScreenCycler:
         deck.on_screen_changed = AsyncEvent()
 
         async def _set_screen(name: str) -> None:
-            await deck.on_screen_changed.emit(name)
+            await deck.on_screen_changed.emit(name, {})
 
         deck.set_screen = AsyncMock(side_effect=_set_screen)
         return deck


### PR DESCRIPTION
## Summary
- Extends `on_screen_changed` event to emit the screens dictionary alongside the screen name, enabling handlers to access screen metadata (e.g. screen index/count)
- Adds screen info display (`1/3`) to the Dashboard DUI card via the new screens parameter
- Updates DashboardCard SVG layout and manifest with screen info binding
- Fixes test handler signatures to match the new `(name, screens)` event signature