### PR TITLE
fix: hide spinner SVG node in non-busy renders

### DIFF
--- a/src/deckui/dui/svg_renderer.py
+++ b/src/deckui/dui/svg_renderer.py
@@ -427,6 +427,7 @@ class SvgRenderer:
             self._apply_binding(root, name, binding, value)
 
         self._inline_assets(root)
+        self._hide_spinner_node(root)
 
         svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
         return self._rasterise(svg_bytes.encode("utf-8"))
@@ -449,8 +450,28 @@ class SvgRenderer:
             self._apply_binding(root, name, binding, value)
 
         self._inline_assets(root)
+        self._hide_spinner_node(root)
 
         return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+    def _hide_spinner_node(self, root: ET.Element) -> None:
+        """Hide the spinner SVG node so it is invisible at rest.
+
+        DUI package authors may not set ``display="none"`` on the spinner
+        element, which would make it visible in every non-busy render.
+        This method forces the node hidden; the spinner frame generators
+        remove ``display="none"`` when producing animation frames.
+
+        Parameters
+        ----------
+        root
+            The parsed SVG element tree (will be mutated in place).
+        """
+        spinner = self._spec.spinner
+        if spinner is not None and spinner.node is not None:
+            elem = _find_element_by_id(root, spinner.node)
+            if elem is not None:
+                elem.set("display", "none")
 
     def _apply_binding(
         self,

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -18,6 +18,8 @@ from deckui.dui.schema import (
     RangeBinding,
     RangeDirection,
     SliderBinding,
+    SpinnerSpec,
+    SpinnerType,
     TextBinding,
     ToggleBinding,
     VisibilityBinding,
@@ -1780,3 +1782,93 @@ class TestIconifyBindingRendering:
         renderer = SvgRenderer(spec)
         assert renderer.set("icon", "line-md:home") is False
         assert renderer.set("icon", "line-md:settings") is True
+
+
+_SPINNER_VISIBLE_SVG = (
+    '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="50">'
+    '<rect id="bg" width="100" height="50" fill="#000000"/>'
+    '<text id="label" x="10" y="30" font-size="12" fill="#ffffff">Hello</text>'
+    '<rect id="spinner" x="70" y="10" width="20" height="20" fill="#ff0000"/>'
+    "</svg>"
+)
+
+_SPINNER_HIDDEN_SVG = (
+    '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="50">'
+    '<rect id="bg" width="100" height="50" fill="#000000"/>'
+    '<text id="label" x="10" y="30" font-size="12" fill="#ffffff">Hello</text>'
+    '<rect id="spinner" x="70" y="10" width="20" height="20" '
+    'display="none" fill="#ff0000"/>'
+    "</svg>"
+)
+
+
+class TestSpinnerNodeHidden:
+    """Spinner SVG node must be hidden in non-busy renders."""
+
+    def test_render_hides_visible_spinner_node(self):
+        """render() sets display='none' even if the author omitted it."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=8),
+        )
+        renderer = SvgRenderer(spec)
+        svg = renderer.render_svg()
+        assert 'display="none"' in svg
+
+    def test_render_keeps_already_hidden_spinner(self):
+        """render() still works when author already set display='none'."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_HIDDEN_SVG,
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=8),
+        )
+        renderer = SvgRenderer(spec)
+        svg = renderer.render_svg()
+        assert 'display="none"' in svg
+
+    def test_render_svg_hides_visible_spinner_node(self):
+        """render_svg() also hides the spinner node."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+            spinner=SpinnerSpec(type=SpinnerType.PULSE, node="spinner", frames=6),
+        )
+        renderer = SvgRenderer(spec)
+        svg = renderer.render_svg()
+        assert 'display="none"' in svg
+
+    def test_no_spinner_spec_no_error(self):
+        """Without a spinner spec, render proceeds normally."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+        )
+        renderer = SvgRenderer(spec)
+        svg = renderer.render_svg()
+        # No display="none" should be forced on the rect
+        assert 'display="none"' not in svg
+
+    def test_spinner_node_not_in_svg_no_error(self):
+        """If spinner.node references a missing element, no crash occurs."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION, node="nonexistent", frames=8
+            ),
+        )
+        renderer = SvgRenderer(spec)
+        # Should not raise
+        svg = renderer.render_svg()
+        assert svg


### PR DESCRIPTION
## Summary

- Forces `display="none"` on spinner SVG nodes during normal (non-busy) renders in `SvgRenderer`, preventing spinners from being visible at startup when DUI package authors omit the attribute
- Adds `_hide_spinner_node()` method called by both `render()` and `render_svg()`
- Spinner animation frames already remove `display="none"` during busy state, so animations are unaffected

## Problem

If a DUI manifest defines a spinner with a `node` reference but the SVG element lacks `display="none"`, the spinner is visible in every non-busy render — including at startup.

## Solution

`SvgRenderer` now hides the spinner node after applying bindings and before rasterising, ensuring consistent hidden state regardless of the source SVG.