### PR TITLE
Add optional background_node to spinner configuration

### DIFF
--- a/examples/IconKey.dui/manifest.yaml
+++ b/examples/IconKey.dui/manifest.yaml
@@ -32,16 +32,12 @@ bindings:
     attribute: color
     default: "#dedede"
 
-  enable_spinner_background:
-    type: visibility
-    node: spinner_background
-    default: false    
-
 spinner:
   type: rotation
   node: spinner
   frames: 8
   interval_ms: 100
+  background_node: spinner_background
 
 events:
   - name: click

--- a/examples/PictureKey.dui/manifest.yaml
+++ b/examples/PictureKey.dui/manifest.yaml
@@ -37,16 +37,12 @@ bindings:
     node: foreground
     default: false
 
-  show_spinner_background:
-    type: visibility
-    node: spinner_background
-    default: false
-
 spinner:
   type: rotation
   node: spinner
   frames: 8
   interval_ms: 100
+  background_node: spinner_background
 
 events:
   - name: click

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -818,7 +818,6 @@ class FavoritesController:
             #key.forward("click", lambda m=media, k=key: self.start_busy(m, k))
             @key.on_event("click")
             async def _click( k=key, m=media):
-                k.set("show_spinner_background", True)
                 await k.start_busy()
                 await self._audio_svc.play(m)
  
@@ -833,7 +832,6 @@ class FavoritesController:
     async def finish_busy(self, *args, **kwargs) -> None:
         log.info(f"Finish busy on all keys")
         for k in self._keys:
-            k.set("show_spinner_background", False)
             await k.finish_busy()
 
     def install(self, screen: Any, positions: list[int]) -> None:

--- a/src/deckui/dui/loader.py
+++ b/src/deckui/dui/loader.py
@@ -446,11 +446,16 @@ def _parse_spinner(raw: dict[str, Any]) -> SpinnerSpec:
     if not isinstance(interval_ms, int) or isinstance(interval_ms, bool) or interval_ms < 10:
         raise PackageError("Spinner 'interval_ms' must be an integer >= 10")
 
+    background_node = raw.get("background_node")
+    if background_node is not None and not isinstance(background_node, str):
+        raise PackageError("Spinner 'background_node' must be a string if provided")
+
     return SpinnerSpec(
         type=spinner_type,
         node=node,
         frames=frames,
         interval_ms=interval_ms,
+        background_node=background_node,
     )
 
 
@@ -711,6 +716,14 @@ def load_package(path: str | Path) -> PackageSpec:
         if spinner.node is not None and spinner.node not in svg_ids:
             raise PackageError(
                 f"Spinner references node '{spinner.node}' "
+                f"which does not exist in the SVG. "
+                f"Available ids: {sorted(svg_ids)}"
+            )
+
+        # Validate background_node exists in SVG if specified
+        if spinner.background_node is not None and spinner.background_node not in svg_ids:
+            raise PackageError(
+                f"Spinner references background_node '{spinner.background_node}' "
                 f"which does not exist in the SVG. "
                 f"Available ids: {sorted(svg_ids)}"
             )

--- a/src/deckui/dui/schema.py
+++ b/src/deckui/dui/schema.py
@@ -277,12 +277,19 @@ class SpinnerSpec:
         Number of frames per animation cycle.
     interval_ms
         Milliseconds between frames.
+    background_node
+        Optional SVG element ID shown behind the spinner during busy
+        state.  The node is made visible when the spinner is active and
+        hidden at rest, but it is **not** animated (no rotation, pulse,
+        or opacity changes are applied to it).  Ignored for ``custom``
+        type spinners.
     """
 
     type: SpinnerType
     node: str | None = None
     frames: int = DEFAULT_SPINNER_FRAMES
     interval_ms: int = DEFAULT_SPINNER_INTERVAL_MS
+    background_node: str | None = None
 
 
 VALID_CATEGORIES = frozenset(

--- a/src/deckui/dui/spinner.py
+++ b/src/deckui/dui/spinner.py
@@ -118,6 +118,7 @@ class SpinnerFrames:
                 rotation = f"rotate({angle:.1f},{cx:.1f},{cy:.1f})"
                 el.set("transform", f"{existing} {rotation}".strip())
 
+            self._show_background_node(root)
             frames.append(self._rasterise(root))
         return frames
 
@@ -147,8 +148,28 @@ class SpinnerFrames:
                 opacity = max(0.2, min(1.0, 0.2 + 0.8 * opacity))
                 el.set("opacity", f"{opacity:.2f}")
 
+            self._show_background_node(root)
             frames.append(self._rasterise(root))
         return frames
+
+    def _show_background_node(self, root: ET.Element) -> None:
+        """Make the background node visible in the given SVG tree.
+
+        If ``background_node`` is configured on the spinner spec, this
+        removes ``display="none"`` from it so the background appears
+        behind the animated spinner.  No transform or opacity changes
+        are applied — the node is shown as-is.
+
+        Parameters
+        ----------
+        root
+            The parsed SVG element tree (will be mutated in place).
+        """
+        bg_id = self._spinner.background_node
+        if bg_id is not None:
+            bg_el = _find_element_by_id(root, bg_id)
+            if bg_el is not None:
+                bg_el.attrib.pop("display", None)
 
     def _generate_custom(self) -> list[bytes]:
         """Load custom frames from package assets.

--- a/src/deckui/dui/svg_renderer.py
+++ b/src/deckui/dui/svg_renderer.py
@@ -455,12 +455,13 @@ class SvgRenderer:
         return ET.tostring(root, encoding="unicode", xml_declaration=True)
 
     def _hide_spinner_node(self, root: ET.Element) -> None:
-        """Hide the spinner SVG node so it is invisible at rest.
+        """Hide the spinner and its background node so they are invisible at rest.
 
         DUI package authors may not set ``display="none"`` on the spinner
-        element, which would make it visible in every non-busy render.
-        This method forces the node hidden; the spinner frame generators
-        remove ``display="none"`` when producing animation frames.
+        element or its background, which would make them visible in every
+        non-busy render.  This method forces both nodes hidden; the spinner
+        frame generators remove ``display="none"`` when producing animation
+        frames.
 
         Parameters
         ----------
@@ -472,6 +473,10 @@ class SvgRenderer:
             elem = _find_element_by_id(root, spinner.node)
             if elem is not None:
                 elem.set("display", "none")
+        if spinner is not None and spinner.background_node is not None:
+            bg_elem = _find_element_by_id(root, spinner.background_node)
+            if bg_elem is not None:
+                bg_elem.set("display", "none")
 
     def _apply_binding(
         self,

--- a/tests/test_busy_guard.py
+++ b/tests/test_busy_guard.py
@@ -344,3 +344,41 @@ class TestSpinnerManifestValidation:
 
         with pytest.raises(PackageError, match="does not exist in the SVG"):
             load_package(pkg_dir)
+
+    def test_background_node_not_string_raises(self):
+        """background_node must be a string if provided."""
+        with pytest.raises(PackageError, match="background_node.*must be a string"):
+            _parse_spinner({
+                "type": "rotation",
+                "node": "spinner",
+                "background_node": 123,
+            })
+
+    def test_background_node_valid_string(self):
+        """background_node as a valid string should parse without error."""
+        spec = _parse_spinner({
+            "type": "rotation",
+            "node": "spinner",
+            "background_node": "spinner_bg",
+        })
+        assert spec.background_node == "spinner_bg"
+
+    def test_background_node_none_by_default(self):
+        """background_node defaults to None when not specified."""
+        spec = _parse_spinner({"type": "rotation", "node": "spinner"})
+        assert spec.background_node is None
+
+    def test_background_node_not_in_svg_raises(self, tmp_path):
+        """Spinner referencing a background_node not present in SVG should fail."""
+        pkg_dir = tmp_path / "Test.dui"
+        pkg_dir.mkdir()
+        (pkg_dir / "layout.svg").write_text(_CARD_SVG, encoding="utf-8")
+        manifest = (
+            "name: Test\ntype: TouchStripCard\nversion: 1\nlayout: layout.svg\n"
+            "spinner:\n  type: rotation\n  node: spinner\n"
+            "  background_node: nonexistent_bg\n"
+        )
+        (pkg_dir / "manifest.yaml").write_text(manifest, encoding="utf-8")
+
+        with pytest.raises(PackageError, match="background_node.*does not exist in the SVG"):
+            load_package(pkg_dir)

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -1788,6 +1788,7 @@ _SPINNER_VISIBLE_SVG = (
     '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="50">'
     '<rect id="bg" width="100" height="50" fill="#000000"/>'
     '<text id="label" x="10" y="30" font-size="12" fill="#ffffff">Hello</text>'
+    '<rect id="spinner_bg" x="65" y="5" width="30" height="30" fill="#333333"/>'
     '<rect id="spinner" x="70" y="10" width="20" height="20" fill="#ff0000"/>'
     "</svg>"
 )
@@ -1870,5 +1871,66 @@ class TestSpinnerNodeHidden:
         )
         renderer = SvgRenderer(spec)
         # Should not raise
+        svg = renderer.render_svg()
+        assert svg
+
+
+class TestSpinnerBackgroundNodeHidden:
+    """Spinner background_node must be hidden in non-busy renders."""
+
+    def test_render_hides_visible_background_node(self):
+        """render_svg() sets display='none' on the background_node."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION,
+                node="spinner",
+                frames=8,
+                background_node="spinner_bg",
+            ),
+        )
+        renderer = SvgRenderer(spec)
+        svg = renderer.render_svg()
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(svg)  # noqa: S314
+        ns = {"svg": "http://www.w3.org/2000/svg"}
+        bg = root.find('.//svg:rect[@id="spinner_bg"]', ns)
+        if bg is None:
+            bg = root.find('.//rect[@id="spinner_bg"]')
+        assert bg is not None
+        assert bg.get("display") == "none"
+
+    def test_no_background_node_no_error(self):
+        """Without background_node, render proceeds normally."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+            spinner=SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=8),
+        )
+        renderer = SvgRenderer(spec)
+        svg = renderer.render_svg()
+        assert svg
+
+    def test_missing_background_node_no_error(self):
+        """If background_node references a missing element, no crash."""
+        spec = PackageSpec(
+            name="Test",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=_SPINNER_VISIBLE_SVG,
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION,
+                node="spinner",
+                frames=8,
+                background_node="nonexistent_bg",
+            ),
+        )
+        renderer = SvgRenderer(spec)
         svg = renderer.render_svg()
         assert svg

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -21,6 +21,8 @@ _SPINNER_SVG = (
     '<svg id="TestCard" xmlns="http://www.w3.org/2000/svg" '
     'width="120" height="120">'
     '<rect id="bg" width="120" height="120" fill="#1c1c1c"/>'
+    '<rect id="spinner_background" x="0" y="0" width="55" height="55" '
+    'display="none" fill="#333"/>'
     '<rect id="spinner" x="80" y="30" width="30" height="30" '
     'display="none" fill="#fff"/>'
     '<circle id="spinner_circle" cx="60" cy="60" r="20" '
@@ -215,3 +217,104 @@ class TestErrors:
         assert len(frames) == 4
         # All frames should be identical (blank)
         assert all(f == frames[0] for f in frames)
+
+
+class TestBackgroundNode:
+    """Background node is shown (not animated) during spinner frames."""
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_rotation_shows_background_node(self, mock_raster):
+        """Rotation frames should unhide the background_node."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION,
+                node="spinner",
+                frames=2,
+                background_node="spinner_background",
+            )
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 2
+
+        # Inspect the SVG passed to rasteriser — background should be visible
+        first_svg: bytes = mock_raster.call_args_list[0][0][0]
+        assert b'id="spinner_background"' in first_svg
+        # display="none" should have been removed from the background node
+        root = ET.fromstring(first_svg)  # noqa: S314
+        bg = root.find('.//{http://www.w3.org/2000/svg}rect[@id="spinner_background"]')
+        if bg is None:
+            bg = root.find('.//rect[@id="spinner_background"]')
+        assert bg is not None
+        assert bg.get("display") is None
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_rotation_background_node_not_rotated(self, mock_raster):
+        """Background node must not receive a rotation transform."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION,
+                node="spinner",
+                frames=4,
+                background_node="spinner_background",
+            )
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 4
+
+        # Check last frame (non-zero rotation) — background should have no transform
+        last_svg: bytes = mock_raster.call_args_list[3][0][0]
+        root = ET.fromstring(last_svg)  # noqa: S314
+        bg = root.find('.//{http://www.w3.org/2000/svg}rect[@id="spinner_background"]')
+        if bg is None:
+            bg = root.find('.//rect[@id="spinner_background"]')
+        assert bg is not None
+        assert "rotate" not in (bg.get("transform") or "")
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_pulse_shows_background_node(self, mock_raster):
+        """Pulse frames should unhide the background_node."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(
+                type=SpinnerType.PULSE,
+                node="spinner",
+                frames=2,
+                background_node="spinner_background",
+            )
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 2
+
+        first_svg: bytes = mock_raster.call_args_list[0][0][0]
+        root = ET.fromstring(first_svg)  # noqa: S314
+        bg = root.find('.//{http://www.w3.org/2000/svg}rect[@id="spinner_background"]')
+        if bg is None:
+            bg = root.find('.//rect[@id="spinner_background"]')
+        assert bg is not None
+        assert bg.get("display") is None
+        # Background should not have opacity set
+        assert bg.get("opacity") is None
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_missing_background_node_no_error(self, mock_raster):
+        """If background_node references a missing element, no crash occurs."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION,
+                node="spinner",
+                frames=2,
+                background_node="nonexistent_bg",
+            )
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 2
+
+    @patch("deckui.render.svg_rasterize._svg_to_png", side_effect=lambda b, w, h: _fake_png(w, h))
+    def test_no_background_node_works(self, mock_raster):
+        """Spinner without background_node still works normally."""
+        spec = _make_spec(
+            spinner=SpinnerSpec(
+                type=SpinnerType.ROTATION, node="spinner", frames=2
+            )
+        )
+        sf = SpinnerFrames(spec, width=120, height=120)
+        assert len(sf.frames) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -378,6 +378,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cairosvg" },
     { name = "pillow" },
+    { name = "platformdirs" },
     { name = "pyyaml" },
     { name = "streamdeck" },
 ]
@@ -405,6 +406,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25" },
     { name = "pillow", specifier = ">=12.0.0" },
+    { name = "platformdirs", specifier = ">=4.0" },
     { name = "pylint", marker = "extra == 'docs'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },


### PR DESCRIPTION
## Summary

- Adds an optional `background_node` field to `SpinnerSpec` that references an SVG element shown behind the spinner during busy state for better visibility
- The background node is hidden at startup (even if the DUI author left it visible), shown during spinner frames without any animation applied, and ignored for `custom` type spinners
- Includes full validation: type checking in `_parse_spinner`, SVG element existence check in `load_package`

## Example usage

```yaml
spinner:
  type: rotation
  node: spinner
  frames: 8
  interval_ms: 100
  background_node: spinner_background
```

## Changes

- `schema.py` — added `background_node: str | None` field to `SpinnerSpec`
- `loader.py` — parse and validate `background_node` in `_parse_spinner` and `load_package`
- `svg_renderer.py` — hide `background_node` alongside spinner node in `_hide_spinner_node`
- `spinner.py` — unhide `background_node` (without animating it) in rotation and pulse frame generators via new `_show_background_node` helper
- Tests added across `test_spinner.py`, `test_dui_svg_renderer.py`, and `test_busy_guard.py`