### PR TITLE
feat: pluggable SVG backend registry with pyvips support

### DIFF
--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -94,6 +94,7 @@ from deckui import (
     DuiCard,
     DuiKey,
     load_package,
+    set_svg_backend
 )
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -103,6 +104,10 @@ log = logging.getLogger(__name__)
 # below.  Adjust if you move them elsewhere.
 EXAMPLES_DIR = Path(__file__).resolve().parent
 
+try:
+    set_svg_backend("pyvips")
+except Exception:
+    log.info("pyvips backend unavailable, using default (auto)")
 
 # ===========================================================================
 # Time helpers (used by TimerController)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ ignore = ["B008"]
 "tests/*" = ["B011"]
 
 [project.optional-dependencies]
+pyvips = [
+    "pyvips>=2.2.0",
+]
+
 test = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24",
@@ -98,5 +102,6 @@ strict = true
 module = [
     "StreamDeck.*",
     "cairosvg",
+    "pyvips",
 ]
 ignore_missing_imports = true

--- a/src/deckui/__init__.py
+++ b/src/deckui/__init__.py
@@ -36,7 +36,17 @@ from .dui import (
     load_all_packages,
     load_package,
 )
-from .render import ImageFetchError, RenderMetrics, clear_image_cache, fetch_image
+from .render import (
+    ImageFetchError,
+    RenderMetrics,
+    SvgRasterizer,
+    clear_image_cache,
+    fetch_image,
+    get_svg_backend,
+    list_svg_backends,
+    register_svg_backend,
+    set_svg_backend,
+)
 from .runtime import (
     AsyncEvent,
     Deck,
@@ -90,13 +100,18 @@ __all__ = [
     "PackageSpec",
     "RenderMetrics",
     "Screen",
+    "SvgRasterizer",
     "TouchEvent",
     "TouchStrip",
     "clear_image_cache",
     "fetch_image",
+    "get_svg_backend",
     "list_devices",
+    "list_svg_backends",
     "load_all_packages",
     "load_package",
+    "register_svg_backend",
+    "set_svg_backend",
 ]
 
 from deckui._version import __version__

--- a/src/deckui/render/__init__.py
+++ b/src/deckui/render/__init__.py
@@ -7,7 +7,14 @@ from .image_fetch import clear_cache as clear_image_cache
 from .key_renderer import render_blank_key, render_key_image
 from .metrics import RenderMetrics
 from .screen_renderer import render_info_screen
-from .svg_rasterize import RasterizeError
+from .svg_rasterize import (
+    RasterizeError,
+    SvgRasterizer,
+    get_svg_backend,
+    list_svg_backends,
+    register_svg_backend,
+    set_svg_backend,
+)
 from .touch_renderer import (
     compose_touchstrip,
     render_blank_touchscreen,
@@ -17,11 +24,16 @@ __all__ = [
     "ImageFetchError",
     "RasterizeError",
     "RenderMetrics",
+    "SvgRasterizer",
     "clear_image_cache",
     "compose_touchstrip",
     "fetch_image",
+    "get_svg_backend",
+    "list_svg_backends",
+    "register_svg_backend",
     "render_blank_key",
     "render_blank_touchscreen",
     "render_info_screen",
     "render_key_image",
+    "set_svg_backend",
 ]

--- a/src/deckui/render/svg_rasterize.py
+++ b/src/deckui/render/svg_rasterize.py
@@ -83,7 +83,7 @@ class SvgRasterizer(Protocol):
         RasterizeError
             If rasterisation fails.
         """
-        ...  # pragma: no cover
+        pass  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------

--- a/src/deckui/render/svg_rasterize.py
+++ b/src/deckui/render/svg_rasterize.py
@@ -171,6 +171,10 @@ class PyvipsRasterizer:
             _ensure_macos_lib_path()
             import pyvips
 
+            # Suppress noisy libvips GLib messages (e.g. "threadpool completed")
+            # by raising the pyvips logger threshold to WARNING.
+            logging.getLogger("pyvips").setLevel(logging.WARNING)
+
             image = pyvips.Image.svgload_buffer(svg_data)
             # Scale to fit the requested dimensions.
             h_scale = width / image.width

--- a/src/deckui/render/svg_rasterize.py
+++ b/src/deckui/render/svg_rasterize.py
@@ -35,6 +35,20 @@ from typing import Protocol, runtime_checkable
 logger = logging.getLogger(__name__)
 
 
+def _ensure_macos_lib_path() -> None:
+    """Set ``DYLD_FALLBACK_LIBRARY_PATH`` on macOS if Homebrew libs exist.
+
+    macOS SIP strips ``DYLD_*`` variables from child processes, so
+    Homebrew-installed C libraries (libcairo, libvips, etc.) are not
+    found by default.  This sets the fallback path once so that
+    ``cffi``/``ctypes`` can locate them.
+    """
+    if platform.system() == "Darwin":
+        brew_lib = Path("/opt/homebrew/lib")
+        if brew_lib.exists():
+            os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
+
+
 class RasterizeError(Exception):
     """Raised when SVG rasterisation fails."""
 
@@ -108,10 +122,7 @@ class CairoRasterizer:
             cannot be loaded.
         """
         try:
-            if platform.system() == "Darwin":
-                brew_lib = Path("/opt/homebrew/lib")
-                if brew_lib.exists():
-                    os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
+            _ensure_macos_lib_path()
 
             import cairosvg
 
@@ -157,6 +168,7 @@ class PyvipsRasterizer:
             If pyvips is not installed or SVG loading fails.
         """
         try:
+            _ensure_macos_lib_path()
             import pyvips
 
             image = pyvips.Image.svgload_buffer(svg_data)

--- a/src/deckui/render/svg_rasterize.py
+++ b/src/deckui/render/svg_rasterize.py
@@ -249,19 +249,27 @@ def register_svg_backend(name: str, backend: SvgRasterizer) -> None:
     logger.debug("Registered SVG backend %r", name)
 
 
-def set_svg_backend(name: str) -> None:
+def set_svg_backend(name: str, *, verify: bool = True) -> None:
     """Select the active SVG rasterisation backend by name.
+
+    By default, performs a smoke test to verify the backend can
+    rasterise a trivial SVG.  Pass ``verify=False`` to skip.
 
     Parameters
     ----------
     name : str
         Name of a previously registered backend, or ``"auto"`` to use
         automatic fallback ordering.
+    verify : bool, default=True
+        When *True*, render a tiny SVG to confirm the backend works.
+        Raises :class:`RasterizeError` immediately if it does not.
 
     Raises
     ------
     ValueError
         If *name* is not ``"auto"`` and has not been registered.
+    RasterizeError
+        If *verify* is True and the backend cannot rasterise.
     """
     global _active_backend  # noqa: PLW0603
     if name != "auto" and name not in _registry:
@@ -269,6 +277,12 @@ def set_svg_backend(name: str) -> None:
             f"Unknown SVG backend {name!r}. "
             f"Registered backends: {', '.join(sorted(_registry)) or '(none)'}"
         )
+    if verify and name != "auto":
+        _test_svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+            b'<rect width="1" height="1"/></svg>'
+        )
+        _registry[name].rasterize(_test_svg, 1, 1)
     _active_backend = name
     logger.debug("Active SVG backend set to %r", name)
 

--- a/src/deckui/render/svg_rasterize.py
+++ b/src/deckui/render/svg_rasterize.py
@@ -123,6 +123,8 @@ class CairoRasterizer:
             return result
         except (OSError, ImportError) as exc:
             raise RasterizeError(f"cairosvg unavailable: {exc}") from exc
+        except Exception as exc:
+            raise RasterizeError(f"cairosvg rasterisation failed: {exc}") from exc
 
 
 class PyvipsRasterizer:

--- a/src/deckui/render/svg_rasterize.py
+++ b/src/deckui/render/svg_rasterize.py
@@ -1,4 +1,27 @@
-"""SVG-to-PNG rasterisation via CairoSVG or rsvg-convert fallback."""
+"""SVG-to-PNG rasterisation with a pluggable backend registry.
+
+Built-in backends: ``cairo`` (CairoSVG), ``pyvips``, and ``rsvg-cli``
+(subprocess).  Third-party backends can be registered at runtime via
+:func:`register_svg_backend`.
+
+Examples
+--------
+Select a specific backend::
+
+    from deckui import set_svg_backend
+    set_svg_backend("pyvips")
+
+Register a custom backend::
+
+    from deckui import SvgRasterizer, register_svg_backend, set_svg_backend
+
+    class MyRasterizer:
+        def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+            ...
+
+    register_svg_backend("custom", MyRasterizer())
+    set_svg_backend("custom")
+"""
 
 from __future__ import annotations
 
@@ -7,7 +30,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
-from typing import cast
+from typing import Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -16,10 +39,273 @@ class RasterizeError(Exception):
     """Raised when SVG rasterisation fails."""
 
 
-def _svg_to_png(svg_data: bytes, width: int, height: int) -> bytes:
-    """Convert SVG bytes to PNG bytes.
+@runtime_checkable
+class SvgRasterizer(Protocol):
+    """Protocol for SVG-to-PNG rasterisation backends.
 
-    Attempts CairoSVG first, then falls back to ``rsvg-convert``.
+    Any object that implements :meth:`rasterize` with the correct
+    signature can be used as a backend.
+    """
+
+    def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+        """Convert raw SVG bytes to PNG bytes.
+
+        Parameters
+        ----------
+        svg_data : bytes
+            Raw SVG content.
+        width : int
+            Desired output width in pixels.
+        height : int
+            Desired output height in pixels.
+
+        Returns
+        -------
+        bytes
+            Rasterised PNG image bytes.
+
+        Raises
+        ------
+        RasterizeError
+            If rasterisation fails.
+        """
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Built-in backend implementations
+# ---------------------------------------------------------------------------
+
+
+class CairoRasterizer:
+    """SVG rasteriser using CairoSVG.
+
+    The ``cairosvg`` package is imported lazily on first call so that the
+    module can be imported even when CairoSVG is not installed.
+    """
+
+    def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+        """Rasterise *svg_data* to PNG via ``cairosvg.svg2png``.
+
+        Parameters
+        ----------
+        svg_data : bytes
+            Raw SVG content.
+        width : int
+            Desired output width in pixels.
+        height : int
+            Desired output height in pixels.
+
+        Returns
+        -------
+        bytes
+            PNG image bytes.
+
+        Raises
+        ------
+        RasterizeError
+            If CairoSVG is not installed or the underlying C library
+            cannot be loaded.
+        """
+        try:
+            if platform.system() == "Darwin":
+                brew_lib = Path("/opt/homebrew/lib")
+                if brew_lib.exists():
+                    os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
+
+            import cairosvg
+
+            result: bytes = cairosvg.svg2png(
+                bytestring=svg_data,
+                output_width=width,
+                output_height=height,
+            )
+            return result
+        except (OSError, ImportError) as exc:
+            raise RasterizeError(f"cairosvg unavailable: {exc}") from exc
+
+
+class PyvipsRasterizer:
+    """SVG rasteriser using pyvips.
+
+    The ``pyvips`` package is imported lazily on first call so that the
+    module can be imported even when pyvips is not installed.
+    """
+
+    def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+        """Rasterise *svg_data* to PNG via ``pyvips``.
+
+        Parameters
+        ----------
+        svg_data : bytes
+            Raw SVG content.
+        width : int
+            Desired output width in pixels.
+        height : int
+            Desired output height in pixels.
+
+        Returns
+        -------
+        bytes
+            PNG image bytes.
+
+        Raises
+        ------
+        RasterizeError
+            If pyvips is not installed or SVG loading fails.
+        """
+        try:
+            import pyvips
+
+            image = pyvips.Image.svgload_buffer(svg_data)
+            # Scale to fit the requested dimensions.
+            h_scale = width / image.width
+            v_scale = height / image.height
+            image = image.resize(h_scale, vscale=v_scale)
+            png_bytes: bytes = image.write_to_buffer(".png")
+            return png_bytes
+        except (OSError, ImportError) as exc:
+            raise RasterizeError(f"pyvips unavailable: {exc}") from exc
+        except Exception as exc:
+            raise RasterizeError(f"pyvips rasterisation failed: {exc}") from exc
+
+
+class RsvgCliRasterizer:
+    """SVG rasteriser using the ``rsvg-convert`` CLI tool."""
+
+    def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+        """Rasterise *svg_data* to PNG via the ``rsvg-convert`` subprocess.
+
+        Parameters
+        ----------
+        svg_data : bytes
+            Raw SVG content.
+        width : int
+            Desired output width in pixels.
+        height : int
+            Desired output height in pixels.
+
+        Returns
+        -------
+        bytes
+            PNG image bytes.
+
+        Raises
+        ------
+        RasterizeError
+            If ``rsvg-convert`` is not found or the subprocess fails.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "rsvg-convert",
+                    "--width",
+                    str(width),
+                    "--height",
+                    str(height),
+                    "--format",
+                    "png",
+                ],
+                input=svg_data,
+                capture_output=True,
+                check=True,
+                timeout=10,
+            )
+            return result.stdout
+        except (FileNotFoundError, subprocess.SubprocessError) as exc:
+            raise RasterizeError(f"rsvg-convert unavailable: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Backend registry
+# ---------------------------------------------------------------------------
+
+_registry: dict[str, SvgRasterizer] = {}
+_active_backend: str | None = None
+
+
+def register_svg_backend(name: str, backend: SvgRasterizer) -> None:
+    """Register an SVG rasterisation backend.
+
+    Parameters
+    ----------
+    name : str
+        Unique name for the backend (e.g. ``"cairo"``, ``"pyvips"``).
+    backend : SvgRasterizer
+        An object implementing the :class:`SvgRasterizer` protocol.
+
+    Raises
+    ------
+    TypeError
+        If *backend* does not implement :class:`SvgRasterizer`.
+    """
+    if not isinstance(backend, SvgRasterizer):
+        raise TypeError(
+            f"backend must implement SvgRasterizer protocol, got {type(backend).__name__}"
+        )
+    _registry[name] = backend
+    logger.debug("Registered SVG backend %r", name)
+
+
+def set_svg_backend(name: str) -> None:
+    """Select the active SVG rasterisation backend by name.
+
+    Parameters
+    ----------
+    name : str
+        Name of a previously registered backend, or ``"auto"`` to use
+        automatic fallback ordering.
+
+    Raises
+    ------
+    ValueError
+        If *name* is not ``"auto"`` and has not been registered.
+    """
+    global _active_backend  # noqa: PLW0603
+    if name != "auto" and name not in _registry:
+        raise ValueError(
+            f"Unknown SVG backend {name!r}. "
+            f"Registered backends: {', '.join(sorted(_registry)) or '(none)'}"
+        )
+    _active_backend = name
+    logger.debug("Active SVG backend set to %r", name)
+
+
+def get_svg_backend() -> str:
+    """Return the name of the currently active SVG backend.
+
+    Returns
+    -------
+    str
+        ``"auto"`` when no explicit backend has been chosen, otherwise
+        the name passed to :func:`set_svg_backend`.
+    """
+    return _active_backend or "auto"
+
+
+def list_svg_backends() -> list[str]:
+    """Return the names of all registered SVG backends.
+
+    Returns
+    -------
+    list[str]
+        Sorted list of registered backend names.
+    """
+    return sorted(_registry)
+
+
+# ---------------------------------------------------------------------------
+# Auto-fallback ordering
+# ---------------------------------------------------------------------------
+
+_AUTO_ORDER: tuple[str, ...] = ("cairo", "pyvips", "rsvg-cli")
+
+
+def _svg_to_png(svg_data: bytes, width: int, height: int) -> bytes:
+    """Convert SVG bytes to PNG bytes using the active backend.
+
+    When the backend is ``"auto"`` (the default), tries each registered
+    backend in order: cairo -> pyvips -> rsvg-cli.
 
     Parameters
     ----------
@@ -38,51 +324,42 @@ def _svg_to_png(svg_data: bytes, width: int, height: int) -> bytes:
     Raises
     ------
     RasterizeError
-        If no SVG renderer backend is available.
+        If no SVG renderer backend is available or the selected backend
+        fails.
     """
-    try:
-        if platform.system() == "Darwin":
-            brew_lib = Path("/opt/homebrew/lib")
-            if brew_lib.exists():
-                os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
+    backend_name = _active_backend or "auto"
 
-        import cairosvg
+    if backend_name != "auto":
+        return _registry[backend_name].rasterize(svg_data, width, height)
 
-        return cast(
-            "bytes",
-            cairosvg.svg2png(
-            bytestring=svg_data,
-            output_width=width,
-            output_height=height,
-        )
-        )
-    except (OSError, ImportError) as exc:
-        logger.debug("cairosvg unavailable (%s), trying fallback", exc)
+    # Auto mode: try backends in order, collecting errors.
+    errors: list[str] = []
+    for name in _AUTO_ORDER:
+        backend = _registry.get(name)
+        if backend is None:
+            continue
+        try:
+            return backend.rasterize(svg_data, width, height)
+        except RasterizeError as exc:
+            logger.debug("Backend %r failed: %s", name, exc)
+            errors.append(f"  - {name}: {exc}")
 
-    try:
-        result = subprocess.run(
-            [
-                "rsvg-convert",
-                "--width",
-                str(width),
-                "--height",
-                str(height),
-                "--format",
-                "png",
-            ],
-            input=svg_data,
-            capture_output=True,
-            check=True,
-            timeout=10,
-        )
-        return result.stdout
-    except (FileNotFoundError, subprocess.SubprocessError) as exc:
-        logger.debug("rsvg-convert unavailable (%s), trying Pillow", exc)
-
+    error_detail = "\n".join(errors) if errors else "  (no backends registered)"
     raise RasterizeError(
         "No SVG renderer available. Install one of:\n"
         "  - System library: brew install cairo  (macOS) or apt install libcairo2 "
         "(Linux)\n"
         "  - CLI tool: apt install librsvg2-bin\n"
-        "  - Python package: pip install cairosvg"
+        "  - Python package: pip install cairosvg\n"
+        "  - Python package: pip install pyvips\n"
+        "\nBackend errors:\n" + error_detail
     )
+
+
+# ---------------------------------------------------------------------------
+# Register built-in backends at import time
+# ---------------------------------------------------------------------------
+
+register_svg_backend("cairo", CairoRasterizer())
+register_svg_backend("pyvips", PyvipsRasterizer())
+register_svg_backend("rsvg-cli", RsvgCliRasterizer())

--- a/src/deckui/tools/preview.py
+++ b/src/deckui/tools/preview.py
@@ -139,7 +139,11 @@ def _svg_to_png_fit(svg_data: bytes, max_width: int, max_height: int) -> bytes:
                 out_h = max(1, int(svg_h * scale))
                 return _svg_to_png(svg_data, out_w, out_h)
     except ET.ParseError:
-        pass
+        logger.debug(
+            "Failed to parse SVG intrinsic dimensions; using fallback raster size %dx%d.",
+            max_width,
+            max_height,
+        )
 
     # Fallback: force exact dimensions.
     return _svg_to_png(svg_data, max_width, max_height)

--- a/src/deckui/tools/preview.py
+++ b/src/deckui/tools/preview.py
@@ -31,11 +31,8 @@ import argparse
 import asyncio
 import io
 import logging
-import os
-import platform
 import re
 import signal
-import subprocess
 import sys
 from pathlib import Path
 from typing import Protocol, cast
@@ -43,7 +40,7 @@ from typing import Protocol, cast
 from PIL import Image
 
 from deckui.render.key_renderer import _encode_image
-from deckui.render.svg_rasterize import RasterizeError
+from deckui.render.svg_rasterize import _svg_to_png
 from deckui.runtime.capabilities import DeviceCapabilities
 
 logger = logging.getLogger(__name__)
@@ -98,67 +95,54 @@ def parse_hex_color(value: str) -> str:
 def _svg_to_png_fit(svg_data: bytes, max_width: int, max_height: int) -> bytes:
     """Rasterise SVG bytes to PNG, fitting within a bounding box.
 
-    Unlike ``icons._svg_to_png`` (which forces exact dimensions), this
-    function preserves the SVG's intrinsic aspect ratio by only
-    constraining the output width, then scaling down if the height
-    exceeds *max_height*.
+    Parses the SVG's intrinsic ``width`` and ``height`` attributes to
+    compute the correct output size that preserves aspect ratio within
+    the *max_width* x *max_height* bounding box, then delegates to
+    the active SVG backend.
+
+    Parameters
+    ----------
+    svg_data : bytes
+        Raw SVG content.
+    max_width : int
+        Maximum output width in pixels.
+    max_height : int
+        Maximum output height in pixels.
+
+    Returns
+    -------
+    bytes
+        PNG image bytes fitting within the bounding box.
+
+    Raises
+    ------
+    RasterizeError
+        If no SVG renderer backend is available.
     """
+    import re as _re
+    import xml.etree.ElementTree as ET
+
+    # Try to extract intrinsic dimensions to preserve aspect ratio.
     try:
-        if platform.system() == "Darwin":
-            brew_lib = Path("/opt/homebrew/lib")
-            if brew_lib.exists():
-                os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
+        root = ET.fromstring(svg_data)
+        w_attr = root.get("width", "")
+        h_attr = root.get("height", "")
+        # Strip unit suffixes like "px", "pt", etc.
+        w_match = _re.match(r"([\d.]+)", w_attr)
+        h_match = _re.match(r"([\d.]+)", h_attr)
+        if w_match and h_match:
+            svg_w = float(w_match.group(1))
+            svg_h = float(h_match.group(1))
+            if svg_w > 0 and svg_h > 0:
+                scale = min(max_width / svg_w, max_height / svg_h)
+                out_w = max(1, int(svg_w * scale))
+                out_h = max(1, int(svg_h * scale))
+                return _svg_to_png(svg_data, out_w, out_h)
+    except ET.ParseError:
+        pass
 
-        import cairosvg
-
-        png_bytes = cast(
-            "bytes",
-            cairosvg.svg2png(
-                bytestring=svg_data,
-                output_width=max_width,
-            ),
-        )
-        img = Image.open(io.BytesIO(png_bytes))
-        if img.height > max_height:
-            png_bytes = cast(
-                "bytes",
-                cairosvg.svg2png(
-                    bytestring=svg_data,
-                    output_height=max_height,
-                ),
-            )
-        return png_bytes
-    except (OSError, ImportError) as exc:
-        logger.debug("cairosvg unavailable (%s), trying rsvg-convert", exc)
-
-    try:
-        result = subprocess.run(
-            [
-                "rsvg-convert",
-                "--keep-aspect-ratio",
-                "--width",
-                str(max_width),
-                "--height",
-                str(max_height),
-                "--format",
-                "png",
-            ],
-            input=svg_data,
-            capture_output=True,
-            check=True,
-            timeout=10,
-        )
-        return result.stdout
-    except (FileNotFoundError, subprocess.SubprocessError) as exc:
-        logger.debug("rsvg-convert unavailable (%s)", exc)
-
-    raise RasterizeError(
-        "No SVG renderer available. Install one of:\n"
-        "  - System library: brew install cairo  (macOS) or apt install libcairo2 "
-        "(Linux)\n"
-        "  - CLI tool: apt install librsvg2-bin\n"
-        "  - Python package: pip install cairosvg"
-    )
+    # Fallback: force exact dimensions.
+    return _svg_to_png(svg_data, max_width, max_height)
 
 
 def load_svg(path: Path, max_width: int, max_height: int) -> Image.Image:

--- a/src/deckui/tools/preview.py
+++ b/src/deckui/tools/preview.py
@@ -40,7 +40,7 @@ from typing import Protocol, cast
 from PIL import Image
 
 from deckui.render.key_renderer import _encode_image
-from deckui.render.svg_rasterize import _svg_to_png
+from deckui.render.svg_rasterize import _svg_to_png, list_svg_backends, set_svg_backend
 from deckui.runtime.capabilities import DeviceCapabilities
 
 logger = logging.getLogger(__name__)
@@ -304,6 +304,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=0.5,
         metavar="SECS",
         help="File poll interval in seconds when --watch is active (default: 0.5)",
+    )
+    parser.add_argument(
+        "-r",
+        "--renderer",
+        type=str,
+        default="auto",
+        metavar="NAME",
+        help=(
+            "SVG renderer backend to use "
+            f"(choices: {', '.join(['auto', *list_svg_backends()])}; default: auto)"
+        ),
     )
     parser.add_argument(
         "-v",
@@ -621,6 +632,9 @@ def main(argv: list[str] | None = None) -> None:
 
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+    if args.renderer != "auto":
+        set_svg_backend(args.renderer)
 
     asyncio.run(push_to_device(args, poll_interval=args.poll_interval))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from PIL import Image
 
+import deckui.render.svg_rasterize as _svg_mod
 from deckui.render.metrics import RenderMetrics
 from deckui.runtime.capabilities import (
     STREAM_DECK_PLUS,
@@ -18,8 +19,28 @@ from deckui.ui.controls.key_slot import KeySlot
 from deckui.ui.screen import Screen
 from deckui.ui.touch_strip import TouchStrip
 
+# Capture pristine state BEFORE any test modules are imported
+# (some examples set the backend at module level during collection).
+_PRISTINE_ACTIVE_BACKEND: str | None = _svg_mod._active_backend
+_PRISTINE_REGISTRY: dict[str, object] = _svg_mod._registry.copy()
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _reset_svg_backend():
+    """Reset SVG backend state before and after every test.
+
+    Restores the pristine state captured at conftest import time
+    (before any test module imports that may call ``set_svg_backend``
+    at module level).
+    """
+    _svg_mod._active_backend = _PRISTINE_ACTIVE_BACKEND
+    _svg_mod._registry = _PRISTINE_REGISTRY.copy()
+    yield
+    _svg_mod._active_backend = _PRISTINE_ACTIVE_BACKEND
+    _svg_mod._registry = _PRISTINE_REGISTRY.copy()
 
 
 _PLUS_METRICS = RenderMetrics(STREAM_DECK_PLUS)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,13 +38,18 @@ class TestPublicAPI:
             "PackageSpec",
             "RenderMetrics",
             "Screen",
+            "SvgRasterizer",
             "TouchEvent",
             "TouchStrip",
             "clear_image_cache",
             "fetch_image",
+            "get_svg_backend",
             "list_devices",
+            "list_svg_backends",
             "load_all_packages",
             "load_package",
+            "register_svg_backend",
+            "set_svg_backend",
         }
         assert set(deckui.__all__) == expected
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -328,6 +328,18 @@ class TestParser:
         args = parse_args(["--verbose"])
         assert args.verbose is True
 
+    def test_renderer_default_auto(self):
+        args = parse_args([])
+        assert args.renderer == "auto"
+
+    def test_renderer_short_flag(self):
+        args = parse_args(["-r", "cairo"])
+        assert args.renderer == "cairo"
+
+    def test_renderer_long_flag(self):
+        args = parse_args(["--renderer", "pyvips"])
+        assert args.renderer == "pyvips"
+
     def test_build_parser_returns_parser(self):
         parser = build_parser()
         assert isinstance(parser, argparse.ArgumentParser)
@@ -822,3 +834,25 @@ class TestPushToDeviceWatch:
             await push_to_device(args, poll_interval=0.5)
 
         mock_watch.assert_awaited_once()
+
+
+class TestMainRendererFlag:
+    """Tests that ``main()`` applies the ``--renderer`` flag."""
+
+    def test_main_sets_renderer(self):
+        """``--renderer`` flag calls ``set_svg_backend`` before running."""
+        with (
+            patch("deckui.tools.preview.set_svg_backend") as mock_set,
+            patch("deckui.tools.preview.push_to_device", new_callable=AsyncMock),
+        ):
+            main(["--renderer", "cairo"])
+            mock_set.assert_called_once_with("cairo")
+
+    def test_main_auto_skips_set(self):
+        """``--renderer auto`` (default) does not call ``set_svg_backend``."""
+        with (
+            patch("deckui.tools.preview.set_svg_backend") as mock_set,
+            patch("deckui.tools.preview.push_to_device", new_callable=AsyncMock),
+        ):
+            main([])
+            mock_set.assert_not_called()

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -562,6 +562,7 @@ class TestSvgToPngFit:
         assert img.height <= 80
 
     def test_cairosvg_fallback_to_rsvg(self):
+        """When the first backend fails, auto mode falls through to the next."""
         svg = (
             b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
             b'<rect width="10" height="10" fill="red"/>'
@@ -572,22 +573,49 @@ class TestSvgToPngFit:
         fake_png.save(buf, format="PNG")
         fake_png_bytes = buf.getvalue()
 
-        with (
-            patch.dict("sys.modules", {"cairosvg": None}),
-            patch("subprocess.run") as mock_run,
-        ):
-            mock_run.return_value = MagicMock(stdout=fake_png_bytes)
+        import deckui.render.svg_rasterize as svg_mod
+
+        class FailBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                raise RasterizeError("fail")
+
+        class SuccessBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                return fake_png_bytes
+
+        old_registry = svg_mod._registry.copy()
+        old_active = svg_mod._active_backend
+        try:
+            svg_mod._registry["cairo"] = FailBackend()  # type: ignore[assignment]
+            svg_mod._registry["pyvips"] = SuccessBackend()  # type: ignore[assignment]
+            svg_mod._active_backend = None  # auto mode
             result = _svg_to_png_fit(svg, 80, 80)
             assert result == fake_png_bytes
-            mock_run.assert_called_once()
+        finally:
+            svg_mod._registry = old_registry
+            svg_mod._active_backend = old_active
 
     def test_no_renderer_raises(self):
+        """When all backends fail in auto mode, RasterizeError is raised."""
         svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
-        with patch.dict("sys.modules", {"cairosvg": None}), patch(
-            "subprocess.run",
-            side_effect=FileNotFoundError("no rsvg"),
-        ), pytest.raises(RasterizeError, match="No SVG renderer"):
-            _svg_to_png_fit(svg, 80, 80)
+
+        import deckui.render.svg_rasterize as svg_mod
+
+        class FailBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                raise RasterizeError("fail")
+
+        old_registry = svg_mod._registry.copy()
+        old_active = svg_mod._active_backend
+        try:
+            for name in list(svg_mod._registry):
+                svg_mod._registry[name] = FailBackend()  # type: ignore[assignment]
+            svg_mod._active_backend = None  # auto mode
+            with pytest.raises(RasterizeError):
+                _svg_to_png_fit(svg, 80, 80)
+        finally:
+            svg_mod._registry = old_registry
+            svg_mod._active_backend = old_active
 
 
 class TestFindAndOpenDevice:

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -1,0 +1,269 @@
+"""Tests for the pluggable SVG backend registry."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+import deckui.render.svg_rasterize as svg_mod
+from deckui.render.svg_rasterize import (
+    CairoRasterizer,
+    PyvipsRasterizer,
+    RasterizeError,
+    RsvgCliRasterizer,
+    SvgRasterizer,
+    _svg_to_png,
+    get_svg_backend,
+    list_svg_backends,
+    register_svg_backend,
+    set_svg_backend,
+)
+
+
+def _fake_png(width: int = 10, height: int = 10) -> bytes:
+    """Create a minimal valid PNG image."""
+    img = Image.new("RGB", (width, height), "red")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    """Reset backend state before/after each test."""
+    original_active = svg_mod._active_backend
+    original_registry = svg_mod._registry.copy()
+    yield
+    svg_mod._active_backend = original_active
+    svg_mod._registry = original_registry
+
+
+class TestRegistry:
+    """Tests for register/set/get/list backend functions."""
+
+    def test_builtin_backends_registered(self):
+        """Built-in backends are registered at import time."""
+        names = list_svg_backends()
+        assert "cairo" in names
+        assert "pyvips" in names
+        assert "rsvg-cli" in names
+
+    def test_default_backend_is_auto(self):
+        """Default backend is 'auto' when nothing is explicitly set."""
+        svg_mod._active_backend = None
+        assert get_svg_backend() == "auto"
+
+    def test_set_and_get_backend(self):
+        """set_svg_backend changes the active backend."""
+        set_svg_backend("cairo")
+        assert get_svg_backend() == "cairo"
+
+    def test_set_auto_backend(self):
+        """'auto' is always valid for set_svg_backend."""
+        set_svg_backend("auto")
+        assert get_svg_backend() == "auto"
+
+    def test_set_unknown_backend_raises(self):
+        """Setting an unregistered backend raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown SVG backend"):
+            set_svg_backend("nonexistent")
+
+    def test_register_custom_backend(self):
+        """A custom backend implementing the protocol can be registered."""
+
+        class CustomRasterizer:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                return _fake_png(width, height)
+
+        register_svg_backend("custom", CustomRasterizer())
+        assert "custom" in list_svg_backends()
+
+        set_svg_backend("custom")
+        result = _svg_to_png(b"<svg/>", 10, 10)
+        img = Image.open(io.BytesIO(result))
+        assert img.size == (10, 10)
+
+    def test_register_invalid_backend_raises(self):
+        """Registering a non-protocol object raises TypeError."""
+        with pytest.raises(TypeError, match="SvgRasterizer protocol"):
+            register_svg_backend("bad", "not a rasterizer")  # type: ignore[arg-type]
+
+    def test_protocol_check(self):
+        """SvgRasterizer protocol runtime check works."""
+
+        class Good:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                return b""
+
+        assert isinstance(Good(), SvgRasterizer)
+        assert not isinstance("string", SvgRasterizer)
+
+
+class TestCairoRasterizer:
+    """Tests for the CairoSVG backend."""
+
+    def test_cairo_success(self):
+        """CairoRasterizer delegates to cairosvg.svg2png."""
+        fake = _fake_png(20, 20)
+        with patch.dict("sys.modules", {"cairosvg": MagicMock()}):
+            import sys
+
+            sys.modules["cairosvg"].svg2png.return_value = fake
+            rasterizer = CairoRasterizer()
+            result = rasterizer.rasterize(b"<svg/>", 20, 20)
+            assert result == fake
+
+    def test_cairo_import_error(self):
+        """CairoRasterizer raises RasterizeError when cairosvg is missing."""
+        rasterizer = CairoRasterizer()
+        with patch.dict("sys.modules", {"cairosvg": None}), \
+             pytest.raises(RasterizeError, match="cairosvg unavailable"):
+            rasterizer.rasterize(b"<svg/>", 10, 10)
+
+
+class TestPyvipsRasterizer:
+    """Tests for the pyvips backend."""
+
+    def test_pyvips_success(self):
+        """PyvipsRasterizer delegates to pyvips.Image.svgload_buffer."""
+        fake = _fake_png(20, 20)
+        mock_pyvips = MagicMock()
+        mock_image = MagicMock()
+        mock_image.width = 100
+        mock_image.height = 100
+        mock_image.resize.return_value = mock_image
+        mock_image.write_to_buffer.return_value = fake
+        mock_pyvips.Image.svgload_buffer.return_value = mock_image
+
+        with patch.dict("sys.modules", {"pyvips": mock_pyvips}):
+            rasterizer = PyvipsRasterizer()
+            result = rasterizer.rasterize(b"<svg/>", 20, 20)
+            assert result == fake
+            mock_image.resize.assert_called_once_with(0.2, vscale=0.2)
+
+    def test_pyvips_import_error(self):
+        """PyvipsRasterizer raises RasterizeError when pyvips is missing."""
+        rasterizer = PyvipsRasterizer()
+        with patch.dict("sys.modules", {"pyvips": None}), \
+             pytest.raises(RasterizeError, match="pyvips unavailable"):
+            rasterizer.rasterize(b"<svg/>", 10, 10)
+
+
+class TestRsvgCliRasterizer:
+    """Tests for the rsvg-convert CLI backend."""
+
+    def test_rsvg_success(self):
+        """RsvgCliRasterizer calls rsvg-convert subprocess."""
+        fake = _fake_png()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=fake)
+            rasterizer = RsvgCliRasterizer()
+            result = rasterizer.rasterize(b"<svg/>", 10, 10)
+            assert result == fake
+
+    def test_rsvg_not_found(self):
+        """RsvgCliRasterizer raises RasterizeError when rsvg-convert missing."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            rasterizer = RsvgCliRasterizer()
+            with pytest.raises(RasterizeError, match="rsvg-convert unavailable"):
+                rasterizer.rasterize(b"<svg/>", 10, 10)
+
+
+class TestSvgToPngDispatch:
+    """Tests for the _svg_to_png dispatch function."""
+
+    def test_explicit_backend(self):
+        """Explicit backend selection dispatches correctly."""
+        fake = _fake_png()
+
+        class FakeBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                return fake
+
+        register_svg_backend("fake", FakeBackend())
+        set_svg_backend("fake")
+        assert _svg_to_png(b"<svg/>", 10, 10) == fake
+
+    def test_auto_fallback_order(self):
+        """Auto mode falls back through backends in order."""
+        fake = _fake_png()
+        calls: list[str] = []
+
+        class FailBackend:
+            def __init__(self, name: str):
+                self._name = name
+
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                calls.append(self._name)
+                raise RasterizeError(f"{self._name} failed")
+
+        class SuccessBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                calls.append("pyvips")
+                return fake
+
+        svg_mod._registry["cairo"] = FailBackend("cairo")  # type: ignore[assignment]
+        svg_mod._registry["pyvips"] = SuccessBackend()  # type: ignore[assignment]
+        set_svg_backend("auto")
+
+        result = _svg_to_png(b"<svg/>", 10, 10)
+        assert result == fake
+        assert calls == ["cairo", "pyvips"]
+
+    def test_auto_all_fail_raises(self):
+        """Auto mode raises RasterizeError when all backends fail."""
+
+        class FailBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                raise RasterizeError("fail")
+
+        svg_mod._registry = {
+            "cairo": FailBackend(),  # type: ignore[assignment]
+            "pyvips": FailBackend(),  # type: ignore[assignment]
+            "rsvg-cli": FailBackend(),  # type: ignore[assignment]
+        }
+        set_svg_backend("auto")
+
+        with pytest.raises(RasterizeError, match="No SVG renderer available"):
+            _svg_to_png(b"<svg/>", 10, 10)
+
+    def test_auto_empty_registry_raises(self):
+        """Auto mode raises RasterizeError when no backends registered."""
+        svg_mod._registry = {}
+        set_svg_backend("auto")
+
+        with pytest.raises(RasterizeError, match="No SVG renderer available"):
+            _svg_to_png(b"<svg/>", 10, 10)
+
+
+class TestPublicExports:
+    """Tests for public API re-exports."""
+
+    def test_render_exports(self):
+        """render.__init__ exports backend API."""
+        from deckui.render import (
+            SvgRasterizer,
+            get_svg_backend,
+            list_svg_backends,
+            register_svg_backend,
+            set_svg_backend,
+        )
+
+        assert callable(register_svg_backend)
+        assert callable(set_svg_backend)
+        assert callable(get_svg_backend)
+        assert callable(list_svg_backends)
+        assert SvgRasterizer is not None
+
+    def test_toplevel_exports(self):
+        """deckui.__init__ exports backend API."""
+        import deckui
+
+        assert callable(deckui.register_svg_backend)
+        assert callable(deckui.set_svg_backend)
+        assert callable(deckui.get_svg_backend)
+        assert callable(deckui.list_svg_backends)
+        assert deckui.SvgRasterizer is not None

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -33,7 +33,11 @@ def _fake_png(width: int = 10, height: int = 10) -> bytes:
 
 @pytest.fixture(autouse=True)
 def _reset_backend():
-    """Reset backend state before/after each test."""
+    """Reset backend state before/after each test.
+
+    Overrides the global conftest fixture so that tests in this module
+    that modify the registry see a clean slate.
+    """
     original_active = svg_mod._active_backend
     original_registry = svg_mod._registry.copy()
     yield

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -62,7 +62,7 @@ class TestRegistry:
 
     def test_set_and_get_backend(self):
         """set_svg_backend changes the active backend."""
-        set_svg_backend("cairo")
+        set_svg_backend("cairo", verify=False)
         assert get_svg_backend() == "cairo"
 
     def test_set_auto_backend(self):
@@ -104,6 +104,28 @@ class TestRegistry:
 
         assert isinstance(Good(), SvgRasterizer)
         assert not isinstance("string", SvgRasterizer)
+
+    def test_set_backend_verify_catches_broken(self):
+        """set_svg_backend raises RasterizeError when verify detects a broken backend."""
+
+        class BrokenBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                raise RasterizeError("broken")
+
+        register_svg_backend("broken", BrokenBackend())
+        with pytest.raises(RasterizeError, match="broken"):
+            set_svg_backend("broken")
+
+    def test_set_backend_verify_false_skips_check(self):
+        """set_svg_backend with verify=False skips the smoke test."""
+
+        class BrokenBackend:
+            def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes:
+                raise RasterizeError("broken")
+
+        register_svg_backend("broken", BrokenBackend())
+        set_svg_backend("broken", verify=False)
+        assert get_svg_backend() == "broken"
 
 
 class TestCairoRasterizer:

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -9,6 +9,18 @@ import pytest
 from PIL import Image
 
 import deckui.render.svg_rasterize as svg_mod
+from deckui.render.svg_rasterize import (
+    CairoRasterizer,
+    PyvipsRasterizer,
+    RasterizeError,
+    RsvgCliRasterizer,
+    SvgRasterizer,
+    _svg_to_png,
+    get_svg_backend,
+    list_svg_backends,
+    register_svg_backend,
+    set_svg_backend,
+)
 
 
 def _fake_png(width: int = 10, height: int = 10) -> bytes:
@@ -38,7 +50,7 @@ class TestRegistry:
 
     def test_builtin_backends_registered(self):
         """Built-in backends are registered at import time."""
-        names = svg_mod.list_svg_backends()
+        names = list_svg_backends()
         assert "cairo" in names
         assert "pyvips" in names
         assert "rsvg-cli" in names

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -9,18 +9,6 @@ import pytest
 from PIL import Image
 
 import deckui.render.svg_rasterize as svg_mod
-from deckui.render.svg_rasterize import (
-    CairoRasterizer,
-    PyvipsRasterizer,
-    RasterizeError,
-    RsvgCliRasterizer,
-    SvgRasterizer,
-    _svg_to_png,
-    get_svg_backend,
-    list_svg_backends,
-    register_svg_backend,
-    set_svg_backend,
-)
 
 
 def _fake_png(width: int = 10, height: int = 10) -> bytes:
@@ -50,7 +38,7 @@ class TestRegistry:
 
     def test_builtin_backends_registered(self):
         """Built-in backends are registered at import time."""
-        names = list_svg_backends()
+        names = svg_mod.list_svg_backends()
         assert "cairo" in names
         assert "pyvips" in names
         assert "rsvg-cli" in names

--- a/uv.lock
+++ b/uv.lock
@@ -391,6 +391,9 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pylint" },
 ]
+pyvips = [
+    { name = "pyvips" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -411,11 +414,12 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0" },
+    { name = "pyvips", marker = "extra == 'pyvips'", specifier = ">=2.2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "streamdeck", specifier = ">=0.9.8" },
     { name = "types-pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
 ]
-provides-extras = ["docs", "test"]
+provides-extras = ["docs", "pyvips", "test"]
 
 [[package]]
 name = "defusedxml"
@@ -999,6 +1003,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
+
+[[package]]
+name = "pyvips"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/282936de9faac6addf6bc8792c18e006489d0023ffd8856b8643f54d0558/pyvips-3.1.1.tar.gz", hash = "sha256:84fe744d023b1084ac2516bb17064cacd41c7f8aabf8e524dd383534941b9301", size = 56951, upload-time = "2025-12-09T18:38:06.355Z" }
 
 [[package]]
 name = "pyyaml"


### PR DESCRIPTION
## Summary

- Adds a `SvgRasterizer` Protocol and a runtime registry so users can choose or add SVG rendering backends without modifying DeckUI source.
- Ships three built-in backends: `cairo` (CairoSVG), `pyvips`, and `rsvg-cli` (subprocess).
- Default "auto" mode tries cairo → pyvips → rsvg-cli, preserving existing behavior.
- Removes duplicated cairosvg fallback logic from the preview tool (`tools/preview.py`), which now delegates to the centralized `_svg_to_png`.
- Adds `pyvips` optional dependency extra (`pip install deckui[pyvips]`).

## Public API

```python
from deckui import (
    SvgRasterizer,          # Protocol
    register_svg_backend,   # register custom backend
    set_svg_backend,        # select active backend by name
    get_svg_backend,        # query active backend
    list_svg_backends,      # list registered backends
)

# Use pyvips
set_svg_backend("pyvips")

# Register a third-party backend (e.g. Chromium)
class ChromiumRasterizer:
    def rasterize(self, svg_data: bytes, width: int, height: int) -> bytes: ...

register_svg_backend("chromium", ChromiumRasterizer())
set_svg_backend("chromium")
```

## Testing

- 20 new tests covering registry operations, each built-in backend (mocked), auto-fallback ordering, custom backends, and public exports.
- All 1237 tests pass, 97.74% coverage (>95% gate).
- Lint and mypy clean.