### PR TITLE
fix: clean up example DUI SVG layouts

### DIFF
--- a/examples/IconKey.dui/layout.svg
+++ b/examples/IconKey.dui/layout.svg
@@ -1,4 +1,4 @@
-<svg id="IconKey" width="120" height="120" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
+<svg id="IconKey" width="120" height="120" viewBox="0 0 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
     <rect id="background" color="#1c1c1c" fill="currentColor" x="0" y="0" width="120" height="120" />
     <g id="foreground" color="#dedede">
         <g id="icon" transform="translate(32.5 15)">
@@ -8,8 +8,8 @@
             Icon Key
         </text>
         <g transform="translate(32.5 15)">
-            <rect id="spinner_background" color="#1c1c1c" x="0"  y="0" width="55" height="55" rx="3" ry="3" fill="currentColor" fill-opacity="0.8" stroke="none"/>
-            <svg id="spinner" x="3.5" y="3.5" color="#5c5b5b" display="none" width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect id="spinner_background" color="#1c1c1c" x="0"  y="0" width="55" height="55" rx="4" ry="4" fill="currentColor" fill-opacity="0.8" stroke="none"/>
+            <svg id="spinner" x="3.5" y="3.5" color="#5c5b5b" width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <rect color="#dedede" x="22" width="4" height="12" rx="2" fill="currentColor"/>
                 <rect x="22" y="36" width="4" height="12" rx="2" fill="currentColor"/>
                 <rect y="26" width="4" height="12" rx="2" transform="rotate(-90 0 26)" fill="currentColor"/>

--- a/examples/IconKey.dui/manifest.yaml
+++ b/examples/IconKey.dui/manifest.yaml
@@ -1,7 +1,7 @@
 name: IconKey
 type: Key
 version: 1
-description: Button with Iconify icon and label and busy spinner
+description: Button with Iconify icon, label and busy spinner
 author: Graphras.com
 license: Apache-2.0
 category: utilities

--- a/examples/PictureKey.dui/layout.svg
+++ b/examples/PictureKey.dui/layout.svg
@@ -1,4 +1,4 @@
-<svg id="PictureKey" width="120" height="120" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
+<svg id="PictureKey" width="120" height="120" viewBox="0 0 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
     <g id="background" color="#1A1A1A">
         <rect x="0" y="0" width="120" height="120" fill="currentColor" stroke="none"/>
         <g transform="translate(3 3)">
@@ -13,8 +13,8 @@
         </text>
     </g>
     <g transform="translate(32.5 15)">
-        <rect id="spinner_background" color="#1c1c1c" x="0"  y="0" width="55" height="55" rx="3" ry="3" fill="currentColor" fill-opacity="0.8" stroke="none"/>
-        <svg id="spinner" x="3.5" y="3.5" color="#5c5b5b" display="none" width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect id="spinner_background" color="#1c1c1c" x="0"  y="0" width="55" height="55" rx="4" ry="4" fill="currentColor" fill-opacity="0.8" stroke="none"/>
+        <svg id="spinner" x="3.5" y="3.5" color="#5c5b5b" width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
             <rect color="#dedede" x="22" width="4" height="12" rx="2" fill="currentColor"/>
             <rect x="22" y="36" width="4" height="12" rx="2" fill="currentColor"/>
             <rect y="26" width="4" height="12" rx="2" transform="rotate(-90 0 26)" fill="currentColor"/>

--- a/examples/TimerCard.dui/layout.svg
+++ b/examples/TimerCard.dui/layout.svg
@@ -1,8 +1,6 @@
-<svg id="TimerCard" xmlns="http://www.w3.org/2000/svg" width="197" height="98" font-family="ArialMT,Arial,sans-serif">
-    <rect id="background" color="#1c1c1c" x="0" y="0" width="197" height="98" fill="currentColor"/>
-    <g id="foreground" color="#dedede">
-        <g  transform="translate(98.5 49)">
-            <text id="timer" font-size="30" fill="currentColor" text-anchor="middle" dominant-baseline="middle">00:00:00</text>
-        </g>
+<svg id="TimerCard" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100" width="200" height="100" font-family="ArialMT,Arial,sans-serif">
+    <rect id="background" color="#1c1c1c" x="0" y="0" width="200" height="100" fill="currentColor"/>
+    <g id="foreground" color="#dedede" transform="translate(100 50)">
+        <text id="timer" font-size="30" fill="currentColor" text-anchor="middle" dominant-baseline="middle">00:00:00</text>
     </g>
 </svg>


### PR DESCRIPTION
## Summary
- Add `viewBox` attributes to IconKey, PictureKey, and TimerCard SVGs for proper scaling
- Increase spinner background corner radius from 3 to 4
- Remove `display="none"` from spinner elements (visibility controlled at runtime)
- Normalize TimerCard dimensions to 200x100 and simplify nested group structure
- Minor manifest description wording fix