### PR TITLE
feat: add GaugeController example with MockGaugeService

### DIFF
--- a/examples/GaugeCard.dui/layout.svg
+++ b/examples/GaugeCard.dui/layout.svg
@@ -1,91 +1,41 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="GaugeCard" width="400" height="200" viewBox="0 0 400 200" font-family="ArialMT,Arial,sans-serif">
-    <rect id="background" x="0" y="0" width="400" height="200"  stroke="none" stroke-width="0" fill="#1C1C1C"/>
-    <g id="layer" transform="translate(3.5 0)">
-        <g id="ticks" stroke="#DEDEDE" stroke-width="2" fill="#DEDEDE">
-            <path id="tick00" d="m32.269 112.179 13.545 12.907"/>
-            <path id="tick02" d="m43.569 112.463 6.498 6.818"/>
-            <path id="tick04" d="m48.472 106.56 6.219 7.161"/>
-            <path id="tick06" d="m53.51 100.909 5.931 7.483"/>
-            <path id="tick08" d="m58.822 95.527 5.638 7.785"/>
-            <path id="tick10" d="m58.958 82.348 10.68 16.125"/>
-            <path id="tick12" d="m69.989 85.599 5.034 8.32"/>
-            <path id="tick14" d="m75.846 81.054 4.728 8.554"/>
-            <path id="tick16" d="m81.839 76.794 4.427 8.769"/>
-            <path id="tick18" d="m87.966 72.816 4.128 8.964"/>
-            <path id="tick20" d="m90.281 59.967 7.667 18.279"/>
-            <path id="tick22" d="m100.63 65.68 3.543 9.299"/>
-            <path id="tick24" d="m107.031 62.524 3.254 9.438"/>
-            <path id="tick26" d="m113.567 59.636 2.973 9.559"/>
-            <path id="tick28" d="m120.241 57 2.697 9.662"/>
-            <path id="tick30" d="m124.599 44.863 4.854 19.512"/>
-            <path id="tick32" d="m133.72 52.487 2.161 9.841"/>
-            <path id="tick34" d="m140.666 50.593 1.898 9.915"/>
-            <path id="tick36" d="m147.474 48.952 1.639 9.979"/>
-            <path id="tick38" d="m154.419 47.548 1.383 10.036"/>
-            <path id="tick40" d="m160.274 36.295 2.265 20.167"/>
-            <path id="tick42" d="m168.444 45.433 0.886 10.116"/>
-            <path id="tick44" d="m175.39 44.723 0.643 10.144"/>
-            <path id="tick46" d="m182.47 44.249 0.403 10.16"/>
-            <path id="tick48" d="m189.415 43.981 0.168 10.168"/>
-            <path id="tick50" d="m196.632 33.769 -0.129 20.34"/>
-            <path id="tick52" d="m203.578 44.092 -0.293 10.157"/>
-            <path id="tick45" d="m210.523 44.471 -0.519 10.149"/>
-            <path id="tick56" d="m217.603 45.07 -0.748 10.132"/>
-            <path id="tick58" d="m224.548 45.859 -0.981 10.107"/>
-            <path id="tick60" d="m232.855 36.815 -2.427 20.148"/>
-            <path id="tick62" d="m238.574 48.131 -1.452 10.027"/>
-            <path id="tick64" d="m245.519 49.583 -1.692 9.975"/>
-            <path id="tick66" d="m252.328 51.271 -1.935 9.912"/>
-            <path id="tick68" d="m259.138 53.181 -2.181 9.839"/>
-            <path id="tick70" d="m268.396 45.576 -4.86 19.518"/>
-            <path id="tick72" d="m272.753 57.712 -2.682 9.669"/>
-            <path id="tick74" d="m279.291 60.316 -2.937 9.569"/>
-            <path id="tick76" d="m285.963 63.172 -3.194 9.46"/>
-            <path id="tick78" d="m292.5 66.265 -3.458 9.34"/>
-            <path id="tick80" d="m302.574 60.41 -7.469 18.397"/>
-            <path id="tick82" d="m305.161 73.211 -4.018 9.037"/>
-            <path id="tick84" d="m311.425 77.077 -4.31 8.848"/>
-            <path id="tick86" d="m317.416 81.229 -4.613 8.638"/>
-            <path id="tick88" d="m323.272 85.663 -4.924 8.407"/>
-            <path id="tick90" d="m334.303 82.237 -10.49 16.298"/>
-            <path id="tick92" d="m334.575 95.415 -5.573 7.854"/>
-            <path id="tick94" d="m339.887 100.752 -5.903 7.515"/>
-            <path id="tick96" d="m344.925 106.402 -6.238 7.135"/>
-            <path id="tick98" d="m349.828 112.368 -6.576 6.71"/>
-            <path id="tick100" d="m361.128 112.399 -13.835 12.486"/>
+<svg xmlns="http://www.w3.org/2000/svg" id="GaugeCard" width="200" height="100" viewBox="0 0 200 100" font-family="ArialMT,Arial,sans-serif">
+    <defs>
+        <line id="short_tick" x1="0" y1="-85" x2="0" y2="-90"/>
+        <line id="long_tick" x1="0" y1="-85" x2="0" y2="-95"/>
+    </defs>
+    <rect id="background" x="0" y="0" width="200" height="100"  stroke="none" fill="#1C1C1C"/>
+    <g transform="translate(100,114)">
+        <g id="ticks"  stroke="#DEDEDE" stroke-width="2">
+            <use href="#long_tick" transform="rotate(-50)" />
+            <use href="#short_tick" transform="rotate(-45)" />
+            <use href="#long_tick" transform="rotate(-40)" />
+            <use href="#short_tick" transform="rotate(-35)" />
+            <use href="#long_tick" transform="rotate(-30)" />
+            <use href="#short_tick" transform="rotate(-25)" />
+            <use href="#long_tick" transform="rotate(-20)" />
+            <use href="#short_tick" transform="rotate(-15)" />
+            <use href="#long_tick" transform="rotate(-10)" />
+            <use href="#short_tick" transform="rotate(-5)" />
+            <use href="#long_tick" transform="rotate(0)" />
+            <use href="#short_tick" transform="rotate(5)" />
+            <use href="#long_tick" transform="rotate(10)" />
+            <use href="#short_tick" transform="rotate(15)" />
+            <use href="#long_tick" transform="rotate(20)" />
+            <use href="#short_tick" transform="rotate(25)" />
+            <use href="#long_tick" transform="rotate(30)" />
+            <use href="#short_tick" transform="rotate(35)" />
+            <use href="#long_tick" transform="rotate(40)" />
+            <use href="#short_tick" transform="rotate(45)" />
+            <use href="#long_tick" transform="rotate(50)" />
         </g>
-        <g id="numbers" fill="#DEDEDE" font-size="25" text-anchor="middle" dominant-baseline="central">
-            <text id="number0" x="23.4" y="100.8">0</text>
-            <!--
-            <text id="number10" x="57.1" y="71.2">10</text>
-
-            <text id="number20" x="88.4" y="48.8">20</text>
-            <text id="number30" x="123.7" y="34.8">30</text>
-            <text id="number40" x="159.3" y="25.8">40</text>
-            -->
-            <text id="number50" x="197.7" y="23.7">50</text>
-            <!--
-            <text id="number60" x="233.6" y="25.8">60</text>
-            <text id="number70" x="270.2" y="34.8">70</text>
-            <text id="number80" x="303.6" y="50.5">80</text>
-            <text id="number90" x="336.6" y="70.7">90</text>
-            -->
-            <text id="number100" x="369" y="99.3">100</text>
+        <g id="value">
+            <text id="min_value" x="-73" y="-66" font-size="16" fill="#DEDEDE" text-anchor="end" dominant-baseline="middle">-50</text>
+            <text id="mid_value" x="0" y="-103" font-size="16" fill="#DEDEDE" text-anchor="middle" dominant-baseline="middle">0</text>
+            <text id="max_value" x="73" y="-66" font-size="16" fill="#DEDEDE" text-anchor="start" dominant-baseline="middle">50</text>
         </g>
+        <polyline id="needle" points="0,0 2,-2 0,-80 -2,-2" transform="rotate(-50)" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="2" />
+        <circle cx="0" cy="0" r="20" stroke="none" fill="#DEDEDE" />
+        <circle cx="0" cy="0" r="30" stroke="none" fill="#1C1C1C" />
     </g>
-    <!--
-    <line x1="200" y1="0" x2="200" y2="200" stroke="white"/>
-    <line x1="360" y1="0" x2="360" y2="200" stroke="white"/>
-    <line x1="40" y1="0" x2="40" y2="200" stroke="white"/>
-    
-    <circle cx="200" cy="250" r="195" stroke="white" fill="none"/>
-    -->
-    <g transform="translate(200,250)rotate(-50)">
-        <!--
-            max 50
-            min -50
-        -->
-        <polyline id="needle" points="0,0 2,-2 0,-185 -2,-2" transform="rotate(85)" fill="#DEDEDE" stroke="#DEDEDE" />
-    </g>
-    <circle cx="200" cy="250" r="100" stroke="none" fill="#1C1C1C"/>
+        
 </svg>

--- a/examples/GaugeCard.dui/manifest.yaml
+++ b/examples/GaugeCard.dui/manifest.yaml
@@ -11,9 +11,19 @@ bindings:
   gauge:
     type: transform
     node: needle
-    default: 0.4
+    default: 0.8
     transforms:
       - kind: rotate
         from: -50
         to: 50
-        origin: center
+        origin: 0 0
+events:
+  - name: value_down
+    source: encoder_turn
+    direction: left
+    accumulate: false
+
+  - name: value_up
+    source: encoder_turn
+    direction: right
+    accumulate: false

--- a/examples/mock_backend.py
+++ b/examples/mock_backend.py
@@ -492,6 +492,103 @@ class MockDashboardService:
             pass
 
 
+class MockGaugeService:
+    """Simulated gauge backend -- a single normalised value in ``[0.0, 1.0]``.
+
+    Represents a generic metric (CPU load, fuel level, signal strength,
+    etc.) that can be adjusted up or down in small increments.  A
+    background task nudges the value randomly to simulate live sensor
+    data; manual adjustments via :meth:`adjust` are additive.
+
+    Events
+    ------
+    on_value_changed : AsyncEvent
+        Emitted whenever ``value`` changes.
+        Signature: ``(value: float) -> None`` -- normalised ``[0.0, 1.0]``.
+
+    Parameters
+    ----------
+    initial_value : float, default=0.5
+        Starting gauge value (clamped to ``[0.0, 1.0]``).
+    step : float, default=0.01
+        Default adjustment per encoder step.
+    simulate : bool, default=True
+        When ``True``, a background task drifts the value randomly.
+    """
+
+    UPDATE_INTERVAL_S = 2.0
+    DRIFT_RANGE = 0.02
+
+    def __init__(
+        self,
+        initial_value: float = 0.5,
+        step: float = 0.01,
+        simulate: bool = True,
+    ) -> None:
+        self.value: float = max(0.0, min(1.0, initial_value))
+        self.step: float = step
+        self._simulate: bool = simulate
+
+        self.on_value_changed: AsyncEvent = AsyncEvent()
+        self._task: asyncio.Task[None] | None = None
+
+    async def adjust(self, delta: float) -> None:
+        """Add *delta* to the current value (clamped to ``[0.0, 1.0]``).
+
+        Idempotent: emits nothing if the clamped result equals the
+        current value.
+
+        Parameters
+        ----------
+        delta : float
+            Amount to add (positive) or subtract (negative).
+        """
+        clamped = max(0.0, min(1.0, self.value + delta))
+        if clamped == self.value:
+            return
+        self.value = clamped
+        log.info("Gauge: %.2f", self.value)
+        await self.on_value_changed.emit(self.value)
+
+    async def set_value(self, value: float) -> None:
+        """Set the gauge to an absolute value (clamped to ``[0.0, 1.0]``).
+
+        Parameters
+        ----------
+        value : float
+            Target gauge value.
+        """
+        await self.adjust(value - self.value)
+
+    async def start(self) -> None:
+        """Start the background drift simulator (idempotent)."""
+        if not self._simulate:
+            return
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(
+                self._drift_loop(), name="gauge-drift"
+            )
+
+    async def stop(self) -> None:
+        """Cancel the drift simulator and wait for it to exit."""
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def _drift_loop(self) -> None:
+        """Nudge the gauge value periodically to simulate sensor data."""
+        try:
+            while True:
+                await asyncio.sleep(self.UPDATE_INTERVAL_S)
+                drift = random.uniform(-self.DRIFT_RANGE, self.DRIFT_RANGE)
+                await self.adjust(drift)
+        except asyncio.CancelledError:
+            pass
+
+
 class MockScenesService:
     """Simulated scene activator -- "set the room to Cinema mode".
 

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -827,13 +827,6 @@ class FavoritesController:
 
 
 class GaugeController(CardController):
-
-
-
-
-
-
-class GaugeController(CardController):
     """Gauge card -- a needle indicator driven by a simulated sensor.
 
     Loads ``GaugeCard.dui`` and binds a single normalised value

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -80,6 +80,7 @@ from mock_backend import (
     SCENE_DEFS,
     MockAudioService,
     MockDashboardService,
+    MockGaugeService,
     MockLightsService,
     MockScenesService,
     MockTimerService,
@@ -825,6 +826,89 @@ class FavoritesController:
             screen.set_key(pos, key)
 
 
+class GaugeController(CardController):
+
+
+
+
+
+
+class GaugeController(CardController):
+    """Gauge card -- a needle indicator driven by a simulated sensor.
+
+    Loads ``GaugeCard.dui`` and binds a single normalised value
+    (``0.0`` -- ``1.0``) to a rotating needle transform.  The
+    underlying :class:`MockGaugeService` simulates a drifting sensor
+    reading; manual encoder turns adjust the value through the service.
+
+    Encoder bindings
+    ~~~~~~~~~~~~~~~~
+    * **encoder turn left**  -- decrease gauge value by one step.
+    * **encoder turn right** -- increase gauge value by one step.
+
+    The controller follows the same event-driven pattern as the other
+    controllers: encoder input is forwarded to the service, the service
+    clamps and emits ``on_value_changed``, and a reactive binding
+    pushes the confirmed value back to the card.
+
+    Parameters
+    ----------
+    packages_dir : Path | None
+        Directory containing ``GaugeCard.dui``.  Defaults to ``examples/``.
+    simulate : bool, default=True
+        When ``True``, the service drifts the gauge value randomly in
+        the background.
+    """
+
+    def __init__(
+        self,
+        packages_dir: Path | None = None,
+        simulate: bool = True,
+    ) -> None:
+        pkg_dir = packages_dir or EXAMPLES_DIR
+        self.card = DuiCard(load_package(pkg_dir / "GaugeCard.dui"))
+
+        initial_value: float = self.card.get("gauge")
+        self._svc = MockGaugeService(
+            initial_value=initial_value,
+            simulate=simulate,
+        )
+
+        # ----- bindings (service event -> card binding) -----
+        self.card.bind("gauge", self._svc.on_value_changed)
+
+        # ----- forwards (DUI event -> service method) -----
+        self.card.forward(
+            "value_down",
+            lambda steps: self._svc.adjust(-abs(steps) * self._svc.step),
+        )
+        self.card.forward(
+            "value_up",
+            lambda steps: self._svc.adjust(steps * self._svc.step),
+        )
+
+    @property
+    def value(self) -> float:
+        """Current gauge value (0.0 -- 1.0)."""
+        return self._svc.value
+
+    async def on_attach(self, deck: Deck) -> None:
+        """Start the background drift simulator.
+
+        Parameters
+        ----------
+        deck
+            The :class:`~deckui.Deck` instance (unused -- the gauge is
+            independent of deck state).
+        """
+        del deck
+        await self._svc.start()
+
+    async def on_detach(self) -> None:
+        """Stop the background drift simulator."""
+        await self._svc.stop()
+
+
 class SceneController:
     """Scene-activation keys -- one :class:`DuiKey` per scene definition.
 
@@ -1014,6 +1098,7 @@ class StreamDeckApp:
         self.audio = AudioController(catalog, packages_dir=self._packages_dir)
         self.lights = LightsController(packages_dir=self._packages_dir)
         self.timer = TimerController(packages_dir=self._packages_dir)
+        self.gauge = GaugeController(packages_dir=self._packages_dir)
         self.dashboard = DashboardController(packages_dir=self._packages_dir)
         self.favorites = FavoritesController(
             catalog, self.audio, packages_dir=self._packages_dir
@@ -1032,6 +1117,7 @@ class StreamDeckApp:
             self.audio,
             self.lights,
             self.timer,
+            self.gauge,
             self.dashboard,
         ]
 
@@ -1116,6 +1202,7 @@ class StreamDeckApp:
 
         if screen.touch_strip is not None:
             screen.touch_strip.background_color = "#1c1c1c"
+            screen.set_card(2, self.gauge.card)
             screen.set_card(3, self.dashboard.card)
 
         pkg_dir = self._packages_dir or EXAMPLES_DIR

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -20,9 +20,11 @@ from deckui.dui.schema import (
     PackageSpec,
     PackageType,
     RangeBinding,
+    RotateTransform,
     SliderBinding,
     TextBinding,
     ToggleBinding,
+    TransformBinding,
 )
 
 # Make examples importable
@@ -34,6 +36,7 @@ from streamdeck import (
     AudioController,
     DashboardController,
     FavoritesController,
+    GaugeController,
     LightsController,
     SceneController,
     ScreenCycler,
@@ -100,6 +103,12 @@ _KEY_SVG = (
 _PICTURE_KEY_SVG = (
     '<svg id="PictureKey" xmlns="http://www.w3.org/2000/svg" width="120" height="120">'
     '<image id="picture" x="0" y="0" width="120" height="120" href=""/>'
+    "</svg>"
+)
+
+_GAUGE_SVG = (
+    '<svg id="GaugeCard" xmlns="http://www.w3.org/2000/svg" width="200" height="100">'
+    '<polyline id="needle" points="0,0 2,-2 0,-80 -2,-2" fill="#DEDEDE"/>'
     "</svg>"
 )
 
@@ -376,6 +385,46 @@ def _picturekey_spec() -> PackageSpec:
         },
         events=(
             EventMapping(name="click", source="key_press_release", max_duration_ms=300),
+        ),
+    )
+
+
+def _gauge_spec() -> PackageSpec:
+    """Build a minimal GaugeCard PackageSpec for testing.
+
+    Returns
+    -------
+    PackageSpec
+        Spec with a transform binding and encoder turn events matching
+        GaugeController.
+    """
+    return PackageSpec(
+        name="GaugeCard",
+        type=PackageType.TOUCH_STRIP_CARD,
+        version=1,
+        svg_source=_GAUGE_SVG,
+        bindings={
+            "gauge": TransformBinding(
+                node="needle",
+                default=0.8,
+                transforms=(
+                    RotateTransform(from_angle=-50, to_angle=50, origin="0 0"),
+                ),
+            ),
+        },
+        events=(
+            EventMapping(
+                name="value_down",
+                source="encoder_turn",
+                direction="left",
+                accumulate=False,
+            ),
+            EventMapping(
+                name="value_up",
+                source="encoder_turn",
+                direction="right",
+                accumulate=False,
+            ),
         ),
     )
 
@@ -864,6 +913,104 @@ class TestFavoritesController:
         screen = MagicMock()
         ctrl.install(screen, [0, 1])
         assert screen.set_key.call_count == 2
+
+
+# ===================================================================
+# GaugeController tests
+# ===================================================================
+
+
+class TestGaugeController:
+    """Tests for GaugeController state and card bindings."""
+
+    @pytest.fixture
+    def ctrl(self, monkeypatch: pytest.MonkeyPatch) -> GaugeController:
+        """A GaugeController with a mocked load_package."""
+        monkeypatch.setattr(
+            "streamdeck.load_package", lambda _path: _gauge_spec()
+        )
+        return GaugeController(simulate=False)
+
+    def test_initial_value(self, ctrl: GaugeController) -> None:
+        """Gauge starts at the manifest default (0.8)."""
+        assert ctrl.value == pytest.approx(0.8)
+
+    def test_card_is_dui_card(self, ctrl: GaugeController) -> None:
+        assert isinstance(ctrl.card, DuiCard)
+
+    def test_card_initial_binding(self, ctrl: GaugeController) -> None:
+        """Card gauge binding matches the initial service value."""
+        assert ctrl.card.get("gauge") == pytest.approx(0.8)
+
+    async def test_adjust_up(self, ctrl: GaugeController) -> None:
+        """Adjusting up increases the value and updates the card."""
+        await ctrl._svc.adjust(0.05)
+        assert ctrl.value == pytest.approx(0.85)
+        assert ctrl.card.get("gauge") == pytest.approx(0.85)
+
+    async def test_adjust_down(self, ctrl: GaugeController) -> None:
+        """Adjusting down decreases the value and updates the card."""
+        await ctrl._svc.adjust(-0.1)
+        assert ctrl.value == pytest.approx(0.7)
+        assert ctrl.card.get("gauge") == pytest.approx(0.7)
+
+    async def test_clamps_to_max(self, ctrl: GaugeController) -> None:
+        """Value is clamped to 1.0."""
+        await ctrl._svc.adjust(1.0)
+        assert ctrl.value == pytest.approx(1.0)
+
+    async def test_clamps_to_min(self, ctrl: GaugeController) -> None:
+        """Value is clamped to 0.0."""
+        await ctrl._svc.adjust(-2.0)
+        assert ctrl.value == pytest.approx(0.0)
+
+    async def test_idempotent_at_boundary(self, ctrl: GaugeController) -> None:
+        """Adjusting past a boundary emits nothing on repeated calls."""
+        await ctrl._svc.adjust(1.0)  # clamp to 1.0
+        events: list[float] = []
+        ctrl._svc.on_value_changed.subscribe(lambda v: events.append(v))
+        await ctrl._svc.adjust(0.1)  # already at max
+        assert events == []
+
+    async def test_set_value(self, ctrl: GaugeController) -> None:
+        """set_value sets an absolute value."""
+        await ctrl._svc.set_value(0.5)
+        assert ctrl.value == pytest.approx(0.5)
+        assert ctrl.card.get("gauge") == pytest.approx(0.5)
+
+    async def test_forward_value_up(self, ctrl: GaugeController) -> None:
+        """value_up event handler routes through the service."""
+        handler = ctrl.card._events._handlers["value_up"]
+        await handler(1)
+        assert ctrl.value == pytest.approx(0.81)
+
+    async def test_forward_value_down(self, ctrl: GaugeController) -> None:
+        """value_down event handler routes through the service."""
+        handler = ctrl.card._events._handlers["value_down"]
+        await handler(1)
+        assert ctrl.value == pytest.approx(0.79)
+
+    async def test_on_attach_starts_simulator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """on_attach starts the drift task when simulate=True."""
+        monkeypatch.setattr(
+            "streamdeck.load_package", lambda _path: _gauge_spec()
+        )
+        ctrl = GaugeController(simulate=True)
+        deck = MagicMock()
+        await ctrl.on_attach(deck)
+        assert ctrl._svc._task is not None
+        await ctrl.on_detach()
+        assert ctrl._svc._task is None
+
+    async def test_on_attach_no_task_when_disabled(
+        self, ctrl: GaugeController
+    ) -> None:
+        """on_attach does not start a task when simulate=False."""
+        deck = MagicMock()
+        await ctrl.on_attach(deck)
+        assert ctrl._svc._task is None
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

- Add MockGaugeService in mock_backend.py -- a simulated sensor backend with a normalised [0.0, 1.0] value, background drift simulator, and on_value_changed async event.
- Refactor GaugeController in streamdeck.py to follow the event-driven architecture: encoder input forwarded to service, service clamps/emits, reactive bind() pushes confirmed values back to card.
- Wire gauge into Settings screen and controller lifecycle (on_attach/on_detach start/stop drift task).
- Add NumPy-style docstrings per AGENTS.md convention.
- Updated GaugeCard.dui layout SVG and manifest (added encoder turn events).

All tests pass (1305 passed, 97.68% coverage).