### PR TITLE
Hook up GaugeCard text, icon, and toggle_simulator bindings

### DIFF
--- a/examples/GaugeCard.dui/layout.svg
+++ b/examples/GaugeCard.dui/layout.svg
@@ -29,10 +29,16 @@
             <use href="#long_tick" transform="rotate(50)" />
         </g>
         <g id="value">
-            <text id="min_value" x="-73" y="-66" font-size="16" fill="#DEDEDE" text-anchor="end" dominant-baseline="middle">-50</text>
-            <text id="mid_value" x="0" y="-103" font-size="16" fill="#DEDEDE" text-anchor="middle" dominant-baseline="middle">0</text>
-            <text id="max_value" x="73" y="-66" font-size="16" fill="#DEDEDE" text-anchor="start" dominant-baseline="middle">50</text>
+            <text id="min_label" x="-71" y="-68" font-size="16" fill="#DEDEDE" text-anchor="end" dominant-baseline="middle">-50</text>
+            <text id="mid_label" x="0" y="-103" font-size="16" fill="#DEDEDE" text-anchor="middle" dominant-baseline="middle">0</text>
+            <text id="max_label" x="71" y="-68" font-size="16" fill="#DEDEDE" text-anchor="start" dominant-baseline="middle">-50</text>
         </g>
+        <g id="icon" transform="translate(-12 -75)" color="#DEDEDE">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 256 256"><path fill="currentColor" d="M190 136a6 6 0 0 1-6 6h-10v10a6 6 0 0 1-12 0v-10h-10a6 6 0 0 1 0-12h10v-10a6 6 0 0 1 12 0v10h10a6 6 0 0 1 6 6m-86-6H72a6 6 0 0 0 0 12h32a6 6 0 0 0 0-12m134-42v96a14 14 0 0 1-14 14H32a14 14 0 0 1-14-14V88a14 14 0 0 1 14-14h18V56a14 14 0 0 1 14-14h32a14 14 0 0 1 14 14v18h36V56a14 14 0 0 1 14-14h32a14 14 0 0 1 14 14v18h18a14 14 0 0 1 14 14m-80-14h36V56a2 2 0 0 0-2-2h-32a2 2 0 0 0-2 2Zm-96 0h36V56a2 2 0 0 0-2-2H64a2 2 0 0 0-2 2Zm164 14a2 2 0 0 0-2-2H32a2 2 0 0 0-2 2v96a2 2 0 0 0 2 2h192a2 2 0 0 0 2-2Z"/></svg>
+        </g>
+        <text id="label" color="#DEDEDE" x="0" y="-45" font-size="16" text-anchor="middle" dominant-baseline="middle" fill="currentColor">
+            Charge
+        </text>
         <polyline id="needle" points="0,0 2,-2 0,-80 -2,-2" transform="rotate(-50)" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="2" />
         <circle cx="0" cy="0" r="20" stroke="none" fill="#DEDEDE" />
         <circle cx="0" cy="0" r="30" stroke="none" fill="#1C1C1C" />

--- a/examples/GaugeCard.dui/layout.svg
+++ b/examples/GaugeCard.dui/layout.svg
@@ -4,7 +4,7 @@
         <line id="long_tick" x1="0" y1="-85" x2="0" y2="-95"/>
     </defs>
     <rect id="background" x="0" y="0" width="200" height="100"  stroke="none" fill="#1C1C1C"/>
-    <g transform="translate(100,114)">
+    <g transform="translate(100,117)">
         <g id="ticks"  stroke="#DEDEDE" stroke-width="2">
             <use href="#long_tick" transform="rotate(-50)" />
             <use href="#short_tick" transform="rotate(-45)" />
@@ -41,7 +41,7 @@
         </text>
         <polyline id="needle" points="0,0 2,-2 0,-80 -2,-2" transform="rotate(-50)" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="2" />
         <circle cx="0" cy="0" r="20" stroke="none" fill="#DEDEDE" />
-        <circle cx="0" cy="0" r="30" stroke="none" fill="#1C1C1C" />
+        <circle cx="0" cy="0" r="37" stroke="none" fill="#1C1C1C" />
     </g>
         
 </svg>

--- a/examples/GaugeCard.dui/manifest.yaml
+++ b/examples/GaugeCard.dui/manifest.yaml
@@ -17,7 +17,42 @@ bindings:
         from: -50
         to: 50
         origin: 0 0
+
+  label:
+    type: text
+    node: label
+    default: "Charge"
+    max_width: 100
+
+  min_label:
+    type: text
+    node: min_label
+    default: "-50"
+    max_width: 30
+
+  mid_label:
+    type: text
+    node: mid_label
+    default: "0"
+    max_width: 30
+
+  max_label:
+    type: text
+    node: max_label
+    default: "+50"
+    max_width: 30
+
+  icon:
+    type: iconify
+    node: icon
+    size: 24
+    default: "ph:car-battery-light"
+
 events:
+  - name: toggle_simulator
+    source: encoder_press_release
+    max_duration_ms: 300
+
   - name: value_down
     source: encoder_turn
     direction: left

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -867,6 +867,13 @@ class GaugeController(CardController):
             simulate=simulate,
         )
 
+        # ----- static bindings (text / icon defaults from manifest) -----
+        self.card.set("label", self.card.get("label"))
+        self.card.set("min_label", self.card.get("min_label"))
+        self.card.set("mid_label", self.card.get("mid_label"))
+        self.card.set("max_label", self.card.get("max_label"))
+        self.card.set("icon", self.card.get("icon"))
+
         # ----- bindings (service event -> card binding) -----
         self.card.bind("gauge", self._svc.on_value_changed)
 
@@ -879,11 +886,21 @@ class GaugeController(CardController):
             "value_up",
             lambda steps: self._svc.adjust(steps * self._svc.step),
         )
+        self.card.forward("toggle_simulator", self._toggle_simulator)
 
     @property
     def value(self) -> float:
         """Current gauge value (0.0 -- 1.0)."""
         return self._svc.value
+
+    async def _toggle_simulator(self) -> None:
+        """Toggle the background drift simulator on or off."""
+        if self._svc._task is not None and not self._svc._task.done():
+            await self._svc.stop()
+            self._svc._simulate = False
+        else:
+            self._svc._simulate = True
+            await self._svc.start()
 
     async def on_attach(self, deck: Deck) -> None:
         """Start the background drift simulator.

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -109,6 +109,11 @@ _PICTURE_KEY_SVG = (
 _GAUGE_SVG = (
     '<svg id="GaugeCard" xmlns="http://www.w3.org/2000/svg" width="200" height="100">'
     '<polyline id="needle" points="0,0 2,-2 0,-80 -2,-2" fill="#DEDEDE"/>'
+    '<text id="label">Charge</text>'
+    '<text id="min_label">-50</text>'
+    '<text id="mid_label">0</text>'
+    '<text id="max_label">+50</text>'
+    '<g id="icon"/>'
     "</svg>"
 )
 
@@ -411,8 +416,18 @@ def _gauge_spec() -> PackageSpec:
                     RotateTransform(from_angle=-50, to_angle=50, origin="0 0"),
                 ),
             ),
+            "label": TextBinding(node="label", default="Charge", max_width=100),
+            "min_label": TextBinding(node="min_label", default="-50", max_width=30),
+            "mid_label": TextBinding(node="mid_label", default="0", max_width=30),
+            "max_label": TextBinding(node="max_label", default="+50", max_width=30),
+            "icon": IconifyBinding(node="icon", size=24, default="ph:car-battery-light"),
         },
         events=(
+            EventMapping(
+                name="toggle_simulator",
+                source="encoder_press_release",
+                max_duration_ms=300,
+            ),
             EventMapping(
                 name="value_down",
                 source="encoder_turn",
@@ -1010,6 +1025,52 @@ class TestGaugeController:
         """on_attach does not start a task when simulate=False."""
         deck = MagicMock()
         await ctrl.on_attach(deck)
+        assert ctrl._svc._task is None
+
+    def test_label_binding_set(self, ctrl: GaugeController) -> None:
+        """Label binding is initialised from the manifest default."""
+        assert ctrl.card.get("label") == "Charge"
+
+    def test_min_label_binding_set(self, ctrl: GaugeController) -> None:
+        """min_label binding is initialised from the manifest default."""
+        assert ctrl.card.get("min_label") == "-50"
+
+    def test_mid_label_binding_set(self, ctrl: GaugeController) -> None:
+        """mid_label binding is initialised from the manifest default."""
+        assert ctrl.card.get("mid_label") == "0"
+
+    def test_max_label_binding_set(self, ctrl: GaugeController) -> None:
+        """max_label binding is initialised from the manifest default."""
+        assert ctrl.card.get("max_label") == "+50"
+
+    def test_icon_binding_set(self, ctrl: GaugeController) -> None:
+        """icon binding is initialised from the manifest default."""
+        assert ctrl.card.get("icon") == "ph:car-battery-light"
+
+    async def test_toggle_simulator_starts_when_stopped(
+        self, ctrl: GaugeController
+    ) -> None:
+        """toggle_simulator starts the drift task when it is stopped."""
+        assert ctrl._svc._task is None
+        await ctrl._toggle_simulator()
+        assert ctrl._svc._simulate is True
+        assert ctrl._svc._task is not None
+        # Clean up
+        await ctrl._svc.stop()
+
+    async def test_toggle_simulator_stops_when_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """toggle_simulator stops the drift task when it is running."""
+        monkeypatch.setattr(
+            "streamdeck.load_package", lambda _path: _gauge_spec()
+        )
+        ctrl = GaugeController(simulate=True)
+        deck = MagicMock()
+        await ctrl.on_attach(deck)
+        assert ctrl._svc._task is not None
+        await ctrl._toggle_simulator()
+        assert ctrl._svc._simulate is False
         assert ctrl._svc._task is None
 
 


### PR DESCRIPTION
## Summary
- Wire up `label`, `min_label`, `mid_label`, `max_label`, and `icon` bindings in `GaugeController`, initialised from the DUI manifest defaults.
- Add `toggle_simulator` event handler that starts/stops the background drift simulator on encoder press.
- Adjust gauge layout: shift center down and enlarge hub cover circle.
- Update test fixture with new bindings/events; add 8 new tests.