### PR TITLE
Swap gauge and timer screen positions

### DIFF
--- a/examples/GaugeCard.dui/layout.svg
+++ b/examples/GaugeCard.dui/layout.svg
@@ -33,15 +33,15 @@
             <text id="mid_label" x="0" y="-103" font-size="16" fill="#DEDEDE" text-anchor="middle" dominant-baseline="middle">0</text>
             <text id="max_label" x="71" y="-68" font-size="16" fill="#DEDEDE" text-anchor="start" dominant-baseline="middle">-50</text>
         </g>
-        <g id="icon" transform="translate(-12 -75)" color="#DEDEDE">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 256 256"><path fill="currentColor" d="M190 136a6 6 0 0 1-6 6h-10v10a6 6 0 0 1-12 0v-10h-10a6 6 0 0 1 0-12h10v-10a6 6 0 0 1 12 0v10h10a6 6 0 0 1 6 6m-86-6H72a6 6 0 0 0 0 12h32a6 6 0 0 0 0-12m134-42v96a14 14 0 0 1-14 14H32a14 14 0 0 1-14-14V88a14 14 0 0 1 14-14h18V56a14 14 0 0 1 14-14h32a14 14 0 0 1 14 14v18h36V56a14 14 0 0 1 14-14h32a14 14 0 0 1 14 14v18h18a14 14 0 0 1 14 14m-80-14h36V56a2 2 0 0 0-2-2h-32a2 2 0 0 0-2 2Zm-96 0h36V56a2 2 0 0 0-2-2H64a2 2 0 0 0-2 2Zm164 14a2 2 0 0 0-2-2H32a2 2 0 0 0-2 2v96a2 2 0 0 0 2 2h192a2 2 0 0 0 2-2Z"/></svg>
+        <g id="icon" transform="translate(-16 -79)" color="#DEDEDE">
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 256 256"><path fill="currentColor" d="M190 136a6 6 0 0 1-6 6h-10v10a6 6 0 0 1-12 0v-10h-10a6 6 0 0 1 0-12h10v-10a6 6 0 0 1 12 0v10h10a6 6 0 0 1 6 6m-86-6H72a6 6 0 0 0 0 12h32a6 6 0 0 0 0-12m134-42v96a14 14 0 0 1-14 14H32a14 14 0 0 1-14-14V88a14 14 0 0 1 14-14h18V56a14 14 0 0 1 14-14h32a14 14 0 0 1 14 14v18h36V56a14 14 0 0 1 14-14h32a14 14 0 0 1 14 14v18h18a14 14 0 0 1 14 14m-80-14h36V56a2 2 0 0 0-2-2h-32a2 2 0 0 0-2 2Zm-96 0h36V56a2 2 0 0 0-2-2H64a2 2 0 0 0-2 2Zm164 14a2 2 0 0 0-2-2H32a2 2 0 0 0-2 2v96a2 2 0 0 0 2 2h192a2 2 0 0 0 2-2Z"/></svg>
         </g>
-        <text id="label" color="#DEDEDE" x="0" y="-45" font-size="16" text-anchor="middle" dominant-baseline="middle" fill="currentColor">
+        <text id="label" color="#DEDEDE" x="0" y="-44" font-size="14" text-anchor="middle" dominant-baseline="middle" fill="currentColor">
             Charge
         </text>
-        <polyline id="needle" points="0,0 2,-2 0,-80 -2,-2" transform="rotate(-50)" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="2" />
-        <circle cx="0" cy="0" r="20" stroke="none" fill="#DEDEDE" />
-        <circle cx="0" cy="0" r="37" stroke="none" fill="#1C1C1C" />
+        <polyline id="needle" points="0,0 2,-2 1,-78 0,-81 -1,-78 -2,-2" transform="rotate(0)" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="1" />
+
+        <circle id="hub_cover" cx="0" cy="0" r="37" stroke="none" fill="#1C1C1C" />
     </g>
         
 </svg>

--- a/examples/GaugeCard.dui/manifest.yaml
+++ b/examples/GaugeCard.dui/manifest.yaml
@@ -45,7 +45,7 @@ bindings:
   icon:
     type: iconify
     node: icon
-    size: 24
+    size: 32
     default: "ph:car-battery-light"
 
 events:

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -867,12 +867,12 @@ class GaugeController(CardController):
             simulate=simulate,
         )
 
-        # ----- static bindings (text / icon defaults from manifest) -----
-        self.card.set("label", self.card.get("label"))
-        self.card.set("min_label", self.card.get("min_label"))
-        self.card.set("mid_label", self.card.get("mid_label"))
-        self.card.set("max_label", self.card.get("max_label"))
-        self.card.set("icon", self.card.get("icon"))
+        # ----- static bindings (text / icon ) -----
+        self.card.set("label", "Charge")
+        self.card.set("min_label", "-50")
+        self.card.set("mid_label", "0")
+        self.card.set("max_label", "+50")
+        self.card.set("icon", "ph:car-battery-light")
 
         # ----- bindings (service event -> card binding) -----
         self.card.bind("gauge", self._svc.on_value_changed)
@@ -1193,7 +1193,7 @@ class StreamDeckApp:
             screen.touch_strip.background_color = "#1c1c1c"
             screen.set_card(0, self.audio.card)
             screen.set_card(1, self.lights.card)
-            screen.set_card(2, self.timer.card)
+            screen.set_card(2, self.gauge.card)
             screen.set_card(3, self.dashboard.card)
 
         num_favs = min(len(self.favorites.keys), caps.key_count)
@@ -1212,7 +1212,7 @@ class StreamDeckApp:
 
         if screen.touch_strip is not None:
             screen.touch_strip.background_color = "#1c1c1c"
-            screen.set_card(2, self.gauge.card)
+            screen.set_card(2, self.timer.card)
             screen.set_card(3, self.dashboard.card)
 
         pkg_dir = self._packages_dir or EXAMPLES_DIR


### PR DESCRIPTION
## Summary
- Move GaugeCard from Settings screen (slot 2) to Main screen (slot 2)
- Move TimerCard from Main screen (slot 2) to Settings screen (slot 2)
- Gauge is now visible on the main screen; timer is accessible via Settings