### PR TITLE
feat: add --touchstrip flag to preview tool

### DIFF
--- a/src/deckui/tools/preview.py
+++ b/src/deckui/tools/preview.py
@@ -17,6 +17,10 @@ left blank (black unless ``--background`` is given).  SVGs are scaled
 edge-to-edge to the connected device's native key/panel size — the tool
 does not impose any margins, padding, or gaps.
 
+Use ``--touchstrip`` to push a single full-width SVG across the entire
+touchstrip instead of specifying individual ``--cardN`` panels.  The
+``--touchstrip`` flag is mutually exclusive with ``--cardN`` flags.
+
 The tool auto-detects the first connected visual Stream Deck device and
 adapts key/card counts and dimensions to the hardware.
 
@@ -252,6 +256,39 @@ def compose_touchstrip(
     return _encode_image(img)
 
 
+def compose_full_touchstrip(
+    svg_img: Image.Image,
+    touchscreen_size: tuple[int, int],
+    background: str = "black",
+) -> bytes:
+    """Place *svg_img* edge-to-edge on a full touchstrip canvas.
+
+    Unlike :func:`compose_touchstrip`, which tiles individual card
+    images, this function composites a single SVG image covering the
+    entire touchstrip area.
+
+    Parameters
+    ----------
+    svg_img : Image.Image
+        Pre-rasterised SVG image to composite onto the touchstrip canvas.
+    touchscreen_size : tuple[int, int]
+        ``(width, height)`` of the target touchstrip canvas.
+    background : str, default="black"
+        Canvas fill colour (any PIL-compatible colour string).
+
+    Returns
+    -------
+    bytes
+        JPEG-encoded image bytes ready for ``set_touchscreen_image``.
+    """
+    canvas = Image.new("RGB", touchscreen_size, background)
+    x = (touchscreen_size[0] - svg_img.width) // 2
+    y = (touchscreen_size[1] - svg_img.height) // 2
+    if svg_img.mode == "RGBA":
+        canvas.paste(svg_img, (x, y), svg_img)
+    else:
+        canvas.paste(svg_img, (x, y))
+    return _encode_image(canvas)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -281,6 +318,13 @@ def build_parser() -> argparse.ArgumentParser:
             metavar="SVG",
             help=argparse.SUPPRESS if i >= 4 else f"SVG file for card slot {i}",
         )
+    parser.add_argument(
+        "--touchstrip",
+        type=Path,
+        default=None,
+        metavar="SVG",
+        help="SVG file for the full touchstrip (mutually exclusive with --cardN)",
+    )
     parser.add_argument(
         "-b",
         "--brightness",
@@ -342,7 +386,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     argparse.Namespace
         Parsed arguments with key/card paths, brightness, background, etc.
     """
-    return build_parser().parse_args(argv)
+    args = build_parser().parse_args(argv)
+
+    # --touchstrip is mutually exclusive with --cardN flags.
+    if args.touchstrip is not None:
+        card_flags = [
+            f"card{i}"
+            for i in range(_MAX_CARD_SLOTS)
+            if getattr(args, f"card{i}") is not None
+        ]
+        if card_flags:
+            build_parser().error(
+                f"--touchstrip cannot be used together with --{card_flags[0]}"
+            )
+
+    return args
 
 
 
@@ -470,6 +528,9 @@ def collect_svg_paths(args: argparse.Namespace) -> list[Path]:
         p = getattr(args, f"card{i}", None)
         if p is not None:
             paths.append(p)
+    ts: Path | None = getattr(args, "touchstrip", None)
+    if ts is not None:
+        paths.append(ts)
     return paths
 
 
@@ -596,6 +657,22 @@ def render_preview(
 
     if not caps.has_touchscreen or caps.panel_count == 0:
         return key_images, b""
+
+    touchstrip_svg: Path | None = getattr(args, "touchstrip", None)
+    if touchstrip_svg is not None:
+        if not touchstrip_svg.exists():
+            print(f"ERROR: Touchstrip SVG not found: {touchstrip_svg}", file=sys.stderr)  # noqa: T201
+            sys.exit(1)
+        ts_size = (caps.touchscreen_width, caps.touchscreen_height)
+        img = load_svg(touchstrip_svg, *ts_size)
+        touchstrip_bytes = compose_full_touchstrip(img, ts_size, background=background)
+        logger.info(
+            "Rendered full touchstrip from %s (%dx%d)",
+            touchstrip_svg,
+            img.width,
+            img.height,
+        )
+        return key_images, touchstrip_bytes
 
     panel_width = caps.touchscreen_width // caps.panel_count
     panel_size = (panel_width, caps.touchscreen_height)

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -26,6 +26,7 @@ from deckui.tools.preview import (
     build_parser,
     collect_svg_paths,
     compose_card_image,
+    compose_full_touchstrip,
     compose_key_image,
     compose_touchstrip,
     get_mtimes,
@@ -79,6 +80,19 @@ def wide_svg(tmp_path: Path) -> Path:
         b"</svg>"
     )
     p = tmp_path / "wide.svg"
+    p.write_bytes(svg)
+    return p
+
+
+@pytest.fixture
+def touchstrip_svg(tmp_path: Path) -> Path:
+    """Write an 800x100 SVG for full touchstrip tests."""
+    svg = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="800" height="100">'
+        b'<rect width="800" height="100" fill="cyan"/>'
+        b"</svg>"
+    )
+    p = tmp_path / "touchstrip.svg"
     p.write_bytes(svg)
     return p
 
@@ -856,3 +870,126 @@ class TestMainRendererFlag:
         ):
             main([])
             mock_set.assert_not_called()
+
+
+class TestComposeFullTouchstrip:
+    """Tests for ``compose_full_touchstrip``."""
+
+    def test_returns_jpeg_bytes(self):
+        svg_img = Image.new("RGBA", TOUCHSCREEN_SIZE, (0, 255, 255, 255))
+        result = compose_full_touchstrip(svg_img, TOUCHSCREEN_SIZE)
+        assert isinstance(result, bytes)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.format == "JPEG"
+        assert decoded.size == TOUCHSCREEN_SIZE
+
+    def test_centres_smaller_image(self):
+        """A smaller image is centred on the touchstrip canvas."""
+        svg_img = Image.new("RGBA", (400, 50), (255, 0, 0, 255))
+        result = compose_full_touchstrip(svg_img, TOUCHSCREEN_SIZE)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        cx, cy = TOUCHSCREEN_SIZE[0] // 2, TOUCHSCREEN_SIZE[1] // 2
+        r, _, _ = decoded.getpixel((cx, cy))
+        assert r > 200
+
+    def test_full_size_fills_edge_to_edge(self):
+        svg_img = Image.new("RGBA", TOUCHSCREEN_SIZE, (0, 255, 0, 255))
+        result = compose_full_touchstrip(svg_img, TOUCHSCREEN_SIZE)
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        _, g, _ = decoded.getpixel((0, 0))
+        assert g > 200
+
+    def test_rgb_image_no_alpha(self):
+        svg_img = Image.new("RGB", TOUCHSCREEN_SIZE, (0, 0, 255))
+        result = compose_full_touchstrip(svg_img, TOUCHSCREEN_SIZE)
+        decoded = Image.open(io.BytesIO(result))
+        assert decoded.size == TOUCHSCREEN_SIZE
+
+    def test_custom_background(self):
+        svg_img = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+        result = compose_full_touchstrip(svg_img, TOUCHSCREEN_SIZE, background="#ff0000")
+        decoded = Image.open(io.BytesIO(result)).convert("RGB")
+        r, _, _ = decoded.getpixel((0, 0))
+        assert r > 200
+
+
+class TestParserTouchstrip:
+    """Tests for the ``--touchstrip`` CLI flag."""
+
+    def test_touchstrip_default_none(self):
+        args = parse_args([])
+        assert args.touchstrip is None
+
+    def test_touchstrip_accepts_path(self, tmp_path: Path):
+        p = tmp_path / "ts.svg"
+        args = parse_args(["--touchstrip", str(p)])
+        assert args.touchstrip == p
+
+    def test_touchstrip_conflicts_with_card(self, tmp_path: Path):
+        ts = tmp_path / "ts.svg"
+        card = tmp_path / "c.svg"
+        with pytest.raises(SystemExit):
+            parse_args(["--touchstrip", str(ts), "--card0", str(card)])
+
+    def test_touchstrip_conflicts_with_any_card(self, tmp_path: Path):
+        ts = tmp_path / "ts.svg"
+        card = tmp_path / "c.svg"
+        with pytest.raises(SystemExit):
+            parse_args(["--touchstrip", str(ts), "--card3", str(card)])
+
+
+class TestRenderPreviewTouchstrip:
+    """Tests for render_preview with --touchstrip."""
+
+    def test_touchstrip_flag_renders_full(self, touchstrip_svg: Path):
+        args = parse_args(["--touchstrip", str(touchstrip_svg)])
+        key_images, touchstrip = render_preview(args, STREAM_DECK_PLUS)
+        assert key_images == {}
+        decoded = Image.open(io.BytesIO(touchstrip))
+        assert decoded.size == TOUCHSCREEN_SIZE
+
+    def test_touchstrip_with_keys(self, touchstrip_svg: Path, square_svg: Path):
+        args = parse_args([
+            "--touchstrip", str(touchstrip_svg),
+            "--key0", str(square_svg),
+        ])
+        key_images, touchstrip = render_preview(args, STREAM_DECK_PLUS)
+        assert 0 in key_images
+        decoded = Image.open(io.BytesIO(touchstrip))
+        assert decoded.size == TOUCHSCREEN_SIZE
+
+    def test_touchstrip_missing_svg_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        args = parse_args(["--touchstrip", str(tmp_path / "nonexistent.svg")])
+        with pytest.raises(SystemExit):
+            render_preview(args, STREAM_DECK_PLUS)
+        assert "Touchstrip SVG not found" in capsys.readouterr().err
+
+    def test_touchstrip_background(self, touchstrip_svg: Path):
+        args = parse_args([
+            "--touchstrip", str(touchstrip_svg),
+            "--background", "#ff0000",
+        ])
+        _, touchstrip = render_preview(args, STREAM_DECK_PLUS)
+        assert isinstance(touchstrip, bytes)
+        decoded = Image.open(io.BytesIO(touchstrip))
+        assert decoded.size == TOUCHSCREEN_SIZE
+
+
+class TestCollectSvgPathsTouchstrip:
+    """Tests for collect_svg_paths with --touchstrip."""
+
+    def test_includes_touchstrip_path(self, tmp_path: Path):
+        ts = tmp_path / "ts.svg"
+        args = parse_args(["--touchstrip", str(ts)])
+        paths = collect_svg_paths(args)
+        assert ts in paths
+
+    def test_touchstrip_after_keys(self, tmp_path: Path):
+        k = tmp_path / "k.svg"
+        ts = tmp_path / "ts.svg"
+        args = parse_args(["--touchstrip", str(ts), "--key0", str(k)])
+        paths = collect_svg_paths(args)
+        assert paths[0] == k
+        assert paths[-1] == ts


### PR DESCRIPTION
## Summary

- Add `--touchstrip <svg>` flag to push a single full-width SVG across the entire touchstrip, as an alternative to specifying individual `--cardN` panels
- `--touchstrip` is mutually exclusive with `--cardN` flags (exits with error if both are used)
- Works with `--watch` for live reloading and `--background` for custom fill colour
- Adds `compose_full_touchstrip()` function that centres and composites an SVG onto the full touchstrip canvas

## Usage

```bash
python -m deckui.tools.preview --touchstrip my_touchstrip.svg --key0 my_key.svg
```

## Testing

- 17 new tests covering parser flags, mutual exclusivity, rendering, missing files, background colour, and `collect_svg_paths` integration
- All 1385 tests pass, 97.76% coverage (100% on preview.py)