### PR TITLE
fix: prevent encoder release from cancelling hold handler & disable gauge auto-simulation

### DIFF
--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -861,7 +861,7 @@ class GaugeController(CardController):
             await self._svc.start()
 
     async def on_attach(self, deck: Deck) -> None:
-        """Start the background drift simulator.
+        """Start the background drift simulator if enabled.
 
         Parameters
         ----------
@@ -870,7 +870,8 @@ class GaugeController(CardController):
             independent of deck state).
         """
         del deck
-        await self._svc.start()
+        if self._svc._simulate:
+            await self._svc.start()
 
     async def on_detach(self) -> None:
         """Stop the background drift simulator."""
@@ -1050,7 +1051,7 @@ class StreamDeckApp:
         self.audio = AudioController(catalog)
         self.lights = LightsController()
         self.timer = TimerController()
-        self.gauge = GaugeController()
+        self.gauge = GaugeController(simulate=False)
         self.dashboard = DashboardController()
         self.favorites = FavoritesController(catalog, self.audio)
         self.scenes = SceneController(scene_defs)

--- a/src/deckui/dui/event_map.py
+++ b/src/deckui/dui/event_map.py
@@ -143,10 +143,16 @@ class EventMap:
             return
 
     async def _hold_delay(self, seconds: float, handler: AsyncHandler) -> None:
-        """Sleep then fire the hold handler if still pressed."""
+        """Sleep then fire the hold handler if still pressed.
+
+        Detaches ``_hold_task`` before invoking the handler so that a
+        subsequent encoder release does not cancel the in-flight handler
+        via :meth:`_cancel_hold_timer`.
+        """
         await asyncio.sleep(seconds)
         if self._pressed:
             self._hold_fired = True
+            self._hold_task = None
             await handler()
 
     def _cancel_hold_timer(self) -> None:


### PR DESCRIPTION
## Summary
- **EventMap hold cancellation bug**: Detach `_hold_task` before invoking the handler in `_hold_delay` so that encoder release does not cancel an in-flight hold handler via `CancelledError`. This fixes AudioCard `toggle_play_pause` not updating the UI to "Playing".
- **Gauge auto-simulation**: Pass `simulate=False` to `GaugeController` and gate `on_attach` start on `_simulate` flag, so the gauge simulator only runs when the user explicitly toggles it.