### PR TITLE
Redesign IconKey DUI layout with gradient, shadows, and halo

### DIFF
--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -954,19 +954,20 @@ class SceneController:
         label : str
             Scene label, passed to the service on click.
         """
-        bg = key.get("background")
-        fg = key.get("foreground")
 
+        """
+        bg = key.get("background")
+        
         @key.on_event("press")
         async def _press() -> None:
-            key.set_many(background=fg, foreground=bg)
+            key.set("background", "success")
             await key.request_refresh()
 
         @key.on_event("release")
         async def _release() -> None:
-            key.set_many(background=bg, foreground=fg)
+            key.set("background", "background-dark")
             await key.request_refresh()
-
+        """
         key.forward("click", lambda: self._svc.activate(label))
 
 class ScreenCycler:

--- a/src/deckui/dui/packages/IconKey.dui/layout.svg
+++ b/src/deckui/dui/packages/IconKey.dui/layout.svg
@@ -1,24 +1,35 @@
-<svg id="IconKey" width="120" height="120" viewBox="0 0 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg" font-family="ArialMT,Arial,sans-serif">
-    <rect id="background" color="#1c1c1c" fill="currentColor" x="0" y="0" width="120" height="120" />
-    <g id="foreground" color="#dedede">
-        <g id="icon" transform="translate(32.5 15)">
-            <svg xmlns="http://www.w3.org/2000/svg" width="55" height="55" viewBox="0 0 256 256"><path fill="currentColor" d="M208 28H48a20 20 0 0 0-20 20v160a20 20 0 0 0 20 20h160a20 20 0 0 0 20-20V48a20 20 0 0 0-20-20m-4 159L69 52h135ZM52 69l135 135H52Z"/></svg>
-        </g>
-        <text id="label" x="60" y="100" font-size="18" text-anchor="middle" fill="currentColor">
-            Icon Key
-        </text>
-        <g transform="translate(32.5 15)">
-            <rect id="spinner_background" color="#1c1c1c" x="0"  y="0" width="55" height="55" rx="4" ry="4" fill="currentColor" fill-opacity="0.8" stroke="none"/>
-            <svg id="spinner" x="3.5" y="3.5" color="#5c5b5b" width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <rect color="#dedede" x="22" width="4" height="12" rx="2" fill="currentColor"/>
-                <rect x="22" y="36" width="4" height="12" rx="2" fill="currentColor"/>
-                <rect y="26" width="4" height="12" rx="2" transform="rotate(-90 0 26)" fill="currentColor"/>
-                <rect x="36" y="26" width="4" height="12" rx="2" transform="rotate(-90 36 26)" fill="currentColor"/>
-                <rect x="5.61523" y="8.4436" width="4" height="12" rx="2" transform="rotate(-45 5.61523 8.4436)" fill="currentColor"/>
-                <rect x="31.071" y="33.8995" width="4" height="12" rx="2" transform="rotate(-45 31.071 33.8995)" fill="currentColor"/>
-                <rect x="8.4436" y="42.3848" width="4" height="12" rx="2" transform="rotate(-135 8.4436 42.3848)" fill="currentColor"/>
-                <rect x="33.8994" y="16.9288" width="4" height="12" rx="2" transform="rotate(-135 33.8994 16.9288)" fill="currentColor"/>
-            </svg>
-        </g>
+<svg xmlns="http://www.w3.org/2000/svg" id="IconKey" width="120" height="120" viewBox="0 0 120 120" version="1.1"  font-family="'Frutiger Linotype'">
+  <defs>
+    <linearGradient id="backgroundGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop class="background-dark" offset="0%" stop-color="currentColor" />
+      <stop class="background-light" offset="100%" stop-color="currentColor" />
+    </linearGradient>
+    <filter id="shadow" x="-100%" y="-100%" width="250%" height="250%">
+      <feDropShadow dx="-1" dy="-1" stdDeviation="3" flood-color="black" flood-opacity=".5" />
+    </filter>
+  </defs>
+  <rect id="background" class="background-dark" fill="currentColor" x="0" y="0" width="120" height="120" />
+  <rect id="surface" stroke="none" fill="url(#backgroundGradient)" stroke-width="10" rx="10" ry="10" x="5" y="5" width="110" height="110" filter="url(#shadow)" />
+  <g id="foreground" color="#dedede">
+    <g id="icon" class="icon" transform="translate(32.5 20)" filter="url(#shadow)">
+        <svg xmlns="http://www.w3.org/2000/svg" width="55" height="55" viewBox="0 0 256 256"><path fill="currentColor" d="M208 28H48a20 20 0 0 0-20 20v160a20 20 0 0 0 20 20h160a20 20 0 0 0 20-20V48a20 20 0 0 0-20-20m-4 159L69 52h135ZM52 69l135 135H52Z"/></svg>
     </g>
+    <text id="label" class="text-primary" x="60" y="100" font-size="18" text-anchor="middle" fill="currentColor" filter="url(#shadow)">
+      Icon Key
+    </text>
+    <g display="none" transform="translate(32.5 20)">
+      <rect id="spinner_background" color="#1c1c1c" x="0" y="0" width="55" height="55" rx="4" ry="4" fill="currentColor" fill-opacity="0.8" stroke="none" />
+      <svg id="spinner" x="3.5" y="3.5" color="#5c5b5b" width="48" height="48" viewBox="0 0 48 48" fill="none">
+        <rect color="#dedede" x="22" width="4" height="12" rx="2" fill="currentColor" />
+        <rect x="22" y="36" width="4" height="12" rx="2" fill="currentColor" />
+        <rect y="26" width="4" height="12" rx="2" transform="rotate(-90 0 26)" fill="currentColor" />
+        <rect x="36" y="26" width="4" height="12" rx="2" transform="rotate(-90 36 26)" fill="currentColor" />
+        <rect x="5.61523" y="8.4436" width="4" height="12" rx="2" transform="rotate(-45 5.61523 8.4436)" fill="currentColor" />
+        <rect x="31.071" y="33.8995" width="4" height="12" rx="2" transform="rotate(-45 31.071 33.8995)" fill="currentColor" />
+        <rect x="8.4436" y="42.3848" width="4" height="12" rx="2" transform="rotate(-135 8.4436 42.3848)" fill="currentColor" />
+        <rect x="33.8994" y="16.9288" width="4" height="12" rx="2" transform="rotate(-135 33.8994 16.9288)" fill="currentColor" />
+      </svg>
+    </g>
+  </g>
+  <rect id="halo" display="none" class="success" stroke="currentColor" fill="none" stroke-width="10" rx="10" ry="10" x="5" y="5" width="110" height="110" />
 </svg>

--- a/src/deckui/dui/packages/IconKey.dui/manifest.yaml
+++ b/src/deckui/dui/packages/IconKey.dui/manifest.yaml
@@ -19,18 +19,6 @@ bindings:
     node: label
     default: "Icon Key"
     max_width: 110
-  
-  background:
-    type: color
-    node: background
-    attribute: color
-    default: "#1c1c1c"
-
-  foreground:
-    type: color
-    node: foreground
-    attribute: color
-    default: "#dedede"
 
 spinner:
   type: rotation

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -858,38 +858,27 @@ class TestSceneController:
         assert screen.set_key.call_count == len(SCENE_DEFS)
 
     def test_initial_colors_are_defaults(self, ctrl: SceneController) -> None:
-        """Each key starts with default background/foreground colors from manifest."""
+        """Each key starts with default background color from manifest."""
         for key in ctrl.keys:
             assert key.get("background") == "#1c1c1c"
-            assert key.get("foreground") == "#dedede"
 
-    async def test_press_swaps_colors(self, ctrl: SceneController) -> None:
-        """key.dispatch(pressed=True) swaps fg/bg via the press handler."""
+    async def test_press_does_not_change_colors(self, ctrl: SceneController) -> None:
+        """Press no longer swaps colors; visual feedback is disabled."""
         key = ctrl.keys[0]
         await key.dispatch(pressed=True)
-        assert key.get("background") == "#dedede"
-        assert key.get("foreground") == "#1c1c1c"
+        assert key.get("background") == "#1c1c1c"
 
-    async def test_release_restores_colors(self, ctrl: SceneController) -> None:
-        """A release after a press restores the original colors."""
+    async def test_release_keeps_colors(self, ctrl: SceneController) -> None:
+        """Release keeps colors unchanged since visual feedback is disabled."""
         key = ctrl.keys[0]
         await key.dispatch(pressed=True)
         await key.dispatch(pressed=False)
         assert key.get("background") == "#1c1c1c"
-        assert key.get("foreground") == "#dedede"
 
-    async def test_press_release_requests_refresh(
+    async def test_press_release_refresh_from_click_forward(
         self, ctrl: SceneController
     ) -> None:
-        """Press and release each call request_refresh on the key.
-
-        The stub mimics ``Deck.refresh`` by clearing the dirty flag,
-        which is what makes the auto-refresh wrapper idempotent in
-        production: when a handler explicitly calls ``request_refresh``,
-        the card is rendered and marked clean, so the wrapper's
-        post-handler ``if is_dirty: refresh()`` check finds nothing to
-        do.
-        """
+        """Only the click forward on release triggers a refresh; press does not."""
         key = ctrl.keys[0]
         refreshes = 0
 
@@ -901,16 +890,15 @@ class TestSceneController:
         key.set_refresh_callback(_refresh)
         await key.dispatch(pressed=True)
         await key.dispatch(pressed=False)
-        assert refreshes == 2
+        assert refreshes == 1
 
-    async def test_each_key_has_independent_handlers(
+    async def test_keys_remain_independent(
         self, ctrl: SceneController
     ) -> None:
-        """Closure capture is per-key: pressing one key only affects that key."""
+        """Pressing one key does not affect another key's state."""
         first, second = ctrl.keys[0], ctrl.keys[1]
         await first.dispatch(pressed=True)
-        # First is inverted, second is untouched.
-        assert first.get("background") == "#dedede"
+        assert first.get("background") == "#1c1c1c"
         assert second.get("background") == "#1c1c1c"
 
 


### PR DESCRIPTION
## Summary

- Redesigned `IconKey.dui/layout.svg` with linear gradient background, drop shadow filters, rounded surface rect, and a toggleable halo overlay element
- Removed `background` and `foreground` color bindings from manifest (layout now uses CSS classes for theming)
- Disabled press/release visual feedback in `SceneController` (commented out); click forwarding remains active
- Updated `TestSceneController` tests to match the simplified behavior