### PR TITLE
refactor: SVG-native render pipeline with vector scaling and per-panel rendering

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any
 
 from ..ui.cards.base import Card
@@ -79,6 +80,8 @@ class DuiCard(Card):
         self._push_fn: PushFn | None = None
         self._panel_size: tuple[int, int] | None = None
         self._bg_tile: Image.Image | None = None
+        self._bg_svg_root: ET.Element | None = None
+        self._card_index: int | None = None
 
     @property
     def spec(self) -> PackageSpec:
@@ -125,6 +128,84 @@ class DuiCard(Card):
             The RGB background tile, or ``None`` to clear.
         """
         self._bg_tile = tile
+
+    def set_background_layer(
+        self,
+        bg_root: ET.Element,
+        card_index: int,
+        panel_width: int,
+        panel_height: int,
+    ) -> None:
+        """Set a background SVG layer underneath the card content.
+
+        The background SVG's ``viewBox`` is sliced to the region for
+        *card_index* and composed as a layer beneath the card's own
+        SVG.  The composed tree is cached so subsequent renders only
+        need to apply bindings and rasterise.
+
+        Parameters
+        ----------
+        bg_root : ET.Element
+            The full-width background ``<svg>`` root element.
+        card_index : int
+            Zero-based panel index.
+        panel_width : int
+            Width of a single panel in pixels.
+        panel_height : int
+            Height of a single panel in pixels.
+        """
+        self._bg_svg_root = bg_root
+        self._card_index = card_index
+        self._renderer.set_base_layer(bg_root, card_index, panel_width, panel_height)
+        self._renderer.set_target_size(panel_width, panel_height)
+
+    def clear_background_layer(self) -> None:
+        """Remove the background layer and revert to the card's own SVG."""
+        self._bg_svg_root = None
+        self._card_index = None
+        self._renderer.clear_base_layer()
+
+    def render_bytes(
+        self,
+        *,
+        panel_width: int,
+        panel_height: int,
+        image_format: str = "JPEG",
+        background: str = "black",
+    ) -> bytes:
+        """Render the card directly to encoded image bytes.
+
+        Uses the SVG-native pipeline: background compositing happens
+        at the SVG level (if a background layer is set), dimensions are
+        set for vector scaling, and the output is rasterised directly
+        to the requested format.
+
+        Parameters
+        ----------
+        panel_width : int
+            Target panel width in pixels.
+        panel_height : int
+            Target panel height in pixels.
+        image_format : str, default="JPEG"
+            Image encoding format (``"JPEG"`` or ``"BMP"``).
+        background : str, default="black"
+            Fallback background colour (used when no background SVG
+            layer is set).
+
+        Returns
+        -------
+        bytes
+            Encoded image bytes ready to send to the device.
+        """
+        self._renderer.set_target_size(panel_width, panel_height)
+        fmt = image_format.upper()
+        out_fmt = "jpeg" if fmt == "JPEG" else "bmp"
+        # Only inject a solid background if no SVG background layer is set.
+        bg = background if self._bg_svg_root is None else None
+        return self._renderer.render_bytes(
+            output_format=out_fmt,
+            background=bg,
+        )
 
     def set(self, name: str, value: Any) -> DuiCard:
         """Set a binding value.  Marks the card dirty if changed.

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from PIL import Image
-
-from ..render.key_renderer import _encode_image
 from ..ui.controls.key_slot import KeySlot
 from .animator import PushFn, SpinnerAnimator
 from .event_map import EventMap
@@ -496,8 +493,13 @@ class DuiKey(KeySlot):
     ) -> bytes:
         """Render the SVG layout to image bytes for the key.
 
-        The SVG is rasterised and scaled edge-to-edge to *key_size*
-        (no margins or padding) and encoded in *image_format*.
+        Uses the SVG-native pipeline: the SVG is rasterised at
+        *key_size* directly (vector scaling via ``viewBox``) with a
+        black background injected at the SVG level.  No Pillow resize
+        or compositing is needed.
+
+        Falls back to the legacy Pillow path for BMP format since
+        pyvips does not support BMP output natively.
 
         Parameters
         ----------
@@ -511,12 +513,13 @@ class DuiKey(KeySlot):
         bytes
             Encoded image bytes.
         """
-        img = self._renderer.render()
-        if img.size != key_size:
-            img = img.resize(key_size, Image.Resampling.LANCZOS)
-        if img.mode != "RGB":
-            img = img.convert("RGB")
-        return _encode_image(img, image_format)
+        self._renderer.set_target_size(*key_size)
+        fmt = image_format.upper()
+        out_fmt = "jpeg" if fmt == "JPEG" else "bmp"
+        return self._renderer.render_bytes(
+            output_format=out_fmt,
+            background="black",
+        )
 
     @property
     def has_dui_content(self) -> bool:

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -460,7 +460,10 @@ class SvgRenderer:
         self._spec = spec
         self._values: dict[str, Any] = {}
         self._base_root: ET.Element = ET.fromstring(spec.svg_source)  # noqa: S314
+        self._original_root: ET.Element = copy.deepcopy(self._base_root)
         self._range_extents: dict[str, float] = {}
+        self._target_width: int | None = None
+        self._target_height: int | None = None
 
         for name, binding in spec.bindings.items():
             if isinstance(binding, (TextBinding, VisibilityBinding, ColorBinding, CssClassBinding)):
@@ -575,13 +578,81 @@ class SvgRenderer:
             )
         return self._values.get(name)
 
+    def set_target_size(self, width: int, height: int) -> None:
+        """Set the target rasterisation dimensions.
+
+        When set, the SVG ``width`` and ``height`` attributes are
+        overridden to these values before rasterisation, enabling
+        vector-level scaling from the ``viewBox`` design canvas to the
+        device's native pixel dimensions.
+
+        Parameters
+        ----------
+        width : int
+            Target width in pixels.
+        height : int
+            Target height in pixels.
+        """
+        self._target_width = width
+        self._target_height = height
+
+    def set_base_layer(
+        self,
+        bg_root: ET.Element,
+        card_index: int,
+        panel_width: int,
+        panel_height: int,
+    ) -> None:
+        """Set a background SVG layer underneath the card content.
+
+        The background SVG's ``viewBox`` is sliced to the region
+        corresponding to *card_index*, then composed as a layer beneath
+        the card's own SVG template.  The composed tree replaces
+        ``_base_root`` so that subsequent :meth:`render` calls produce
+        a single SVG document with both layers.
+
+        Call this when the background SVG or the card's slot assignment
+        changes — not on every render.
+
+        Parameters
+        ----------
+        bg_root : ET.Element
+            The full-width background ``<svg>`` root element.
+        card_index : int
+            Zero-based panel index.
+        panel_width : int
+            Width of a single panel in pixels.
+        panel_height : int
+            Height of a single panel in pixels.
+        """
+        from ..render.svg_rasterize import compose_svg_layers, slice_background_viewbox
+
+        bg_slice = slice_background_viewbox(bg_root, card_index, panel_width, panel_height)
+        card_layer = copy.deepcopy(self._original_root)
+        card_layer.set("width", str(panel_width))
+        card_layer.set("height", str(panel_height))
+
+        composed = compose_svg_layers(panel_width, panel_height, [bg_slice, card_layer])
+        self._base_root = composed
+
+    def clear_base_layer(self) -> None:
+        """Remove the background layer and revert to the original SVG template.
+
+        After calling this, :meth:`render` will produce output from the
+        card's own SVG only, without any background layer.
+        """
+        self._base_root = copy.deepcopy(self._original_root)
+
     def render(self) -> Image.Image:
         """Rasterise the SVG with current binding values to a PIL Image.
 
         Returns
         -------
         Image.Image
-            An RGB :class:`~PIL.Image.Image` at the SVG's native dimensions.
+            An RGBA :class:`~PIL.Image.Image`.  When target dimensions
+            are set via :meth:`set_target_size` the image is rasterised
+            at those dimensions (vector scaling); otherwise at the SVG's
+            native dimensions.
         """
         root = copy.deepcopy(self._base_root)
 
@@ -595,6 +666,73 @@ class SvgRenderer:
         svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
         logger.debug("Rendered SVG before rasterisation:\n%s", svg_bytes)
         return self._rasterise(svg_bytes.encode("utf-8"))
+
+    def render_bytes(
+        self,
+        *,
+        output_format: str = "jpeg",
+        background: str | None = None,
+        quality: int = 90,
+    ) -> bytes:
+        """Rasterise the SVG directly to encoded image bytes.
+
+        This is the SVG-native pipeline entry point.  It applies
+        bindings, optionally injects a background colour, sets the
+        target dimensions, and rasterises to the requested format in
+        a single pass — no intermediate PIL Image.
+
+        Parameters
+        ----------
+        output_format : str, default="jpeg"
+            Target image format: ``"jpeg"``, ``"bmp"``, or ``"png"``.
+        background : str or None, optional
+            CSS colour for a solid background rect injected under all
+            content.  When ``None``, no background is injected (the
+            SVG's own background or transparency is preserved).
+        quality : int, default=90
+            JPEG quality (ignored for other formats).
+
+        Returns
+        -------
+        bytes
+            Encoded image bytes ready to send to the device.
+        """
+        from ..render.svg_rasterize import (
+            _rasterize_svg,
+            inject_background_rect,
+            set_svg_dimensions,
+        )
+
+        root = copy.deepcopy(self._base_root)
+
+        for name, binding in self._spec.bindings.items():
+            value = self._values.get(name)
+            self._apply_binding(root, name, binding, value)
+
+        self._inline_assets(root)
+        self._hide_spinner_node(root)
+
+        if background is not None:
+            inject_background_rect(root, background)
+
+        # Determine rasterisation dimensions.
+        if self._target_width is not None and self._target_height is not None:
+            width = self._target_width
+            height = self._target_height
+        else:
+            width = int(float(root.get("width", "197")))
+            height = int(float(root.get("height", "98")))
+
+        set_svg_dimensions(root, width, height)
+
+        svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
+        return _rasterize_svg(
+            svg_bytes.encode("utf-8"),
+            width,
+            height,
+            output_format=output_format,
+            quality=quality,
+        )
 
     def render_svg(self) -> str:
         """Return the SVG source with current bindings applied (not rasterised).
@@ -1196,11 +1334,16 @@ class SvgRenderer:
                 elem.set(f"{{{_XLINK_NS}}}href", data_uri)
 
     def _rasterise(self, svg_data: bytes) -> Image.Image:
-        """Rasterise SVG bytes to a PIL Image via CairoSVG.
+        """Rasterise SVG bytes to a PIL Image.
 
         The image is returned in RGBA mode so that transparent regions
         in the SVG are preserved.  This allows compositing onto a
         background tile when a touchstrip background SVG is active.
+
+        When target dimensions have been set via :meth:`set_target_size`,
+        the SVG is rasterised at those dimensions (vector scaling by the
+        rasteriser backend).  Otherwise the SVG's intrinsic ``width`` and
+        ``height`` attributes are used.
 
         Parameters
         ----------
@@ -1210,12 +1353,16 @@ class SvgRenderer:
         Returns
         -------
         Image.Image
-            An RGBA :class:`~PIL.Image.Image` at the SVG's native dimensions.
+            An RGBA :class:`~PIL.Image.Image`.
         """
         from ..render.svg_rasterize import _svg_to_png
 
-        width = int(float(self._base_root.get("width", "197")))
-        height = int(float(self._base_root.get("height", "98")))
+        if self._target_width is not None and self._target_height is not None:
+            width = self._target_width
+            height = self._target_height
+        else:
+            width = int(float(self._base_root.get("width", "197")))
+            height = int(float(self._base_root.get("height", "98")))
 
         png_data = _svg_to_png(svg_data, width, height)
         return Image.open(io.BytesIO(png_data)).convert("RGBA")

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -1,4 +1,4 @@
-"""SVG-to-PNG rasterisation with a pluggable backend registry.
+"""SVG-to-image rasterisation with a pluggable backend registry.
 
 Built-in backends: ``cairo`` (CairoSVG), ``pyvips``, and ``rsvg-cli``
 (subprocess).  Third-party backends can be registered at runtime via
@@ -8,6 +8,12 @@ An application-wide CSS stylesheet can be set via
 :func:`set_svg_stylesheet`.  It is applied to every SVG before
 rasterisation — natively for pyvips, or by injecting a ``<style>``
 element for other backends.
+
+SVG document manipulation helpers are provided for the SVG-native
+render pipeline: :func:`set_svg_dimensions`, :func:`inject_background_rect`,
+:func:`compose_svg_layers`, and :func:`slice_background_viewbox`.  These
+allow sizing, background injection, and multi-layer compositing to happen
+entirely at the SVG (vector) level before a single rasterisation pass.
 
 Examples
 --------
@@ -35,6 +41,8 @@ Register a custom backend::
 
 from __future__ import annotations
 
+import copy
+import io
 import logging
 import os
 import platform
@@ -492,6 +500,10 @@ def _svg_to_png(svg_data: bytes, width: int, height: int) -> bytes:
     For the pyvips backend the stylesheet is passed natively; for all
     other backends it is injected as a ``<style>`` element.
 
+    .. deprecated::
+        Use :func:`_rasterize_svg` for new code.  This function is
+        retained for backward compatibility.
+
     Parameters
     ----------
     svg_data : bytes
@@ -514,35 +526,7 @@ def _svg_to_png(svg_data: bytes, width: int, height: int) -> bytes:
     """
     backend_name = _active_backend or "auto"
     css = _active_stylesheet
-
-    if backend_name != "auto":
-        backend = _registry[backend_name]
-        return _rasterize_with_stylesheet(backend, backend_name, svg_data, width, height, css)
-
-    # Auto mode: try backends in order, collecting errors.
-    errors: list[str] = []
-    for name in _AUTO_ORDER:
-        auto_backend = _registry.get(name)
-        if auto_backend is None:
-            continue
-        try:
-            return _rasterize_with_stylesheet(
-                auto_backend, name, svg_data, width, height, css
-            )
-        except RasterizeError as exc:
-            logger.debug("Backend %r failed: %s", name, exc)
-            errors.append(f"  - {name}: {exc}")
-
-    error_detail = "\n".join(errors) if errors else "  (no backends registered)"
-    raise RasterizeError(
-        "No SVG renderer available. Install one of:\n"
-        "  - System library: brew install cairo  (macOS) or apt install libcairo2 "
-        "(Linux)\n"
-        "  - CLI tool: apt install librsvg2-bin\n"
-        "  - Python package: pip install cairosvg\n"
-        "  - Python package: pip install pyvips\n"
-        "\nBackend errors:\n" + error_detail
-    )
+    return _resolve_and_rasterize(backend_name, css, svg_data, width, height)
 
 
 def _rasterize_with_stylesheet(
@@ -586,6 +570,270 @@ def _rasterize_with_stylesheet(
         svg_data = _inject_stylesheet(svg_data, css)
 
     return backend.rasterize(svg_data, width, height)
+
+
+# ---------------------------------------------------------------------------
+# Direct output-format rasterisation
+# ---------------------------------------------------------------------------
+
+
+def _rasterize_svg(
+    svg_data: bytes,
+    width: int,
+    height: int,
+    *,
+    output_format: str = "png",
+    quality: int = 90,
+) -> bytes:
+    """Rasterise SVG bytes directly to the requested image format.
+
+    This is the preferred entry point for the SVG-native pipeline.
+    It bypasses the PNG intermediate when the active backend supports
+    direct JPEG output (currently pyvips).  For backends that only
+    produce PNG, the PNG bytes are re-encoded via Pillow when a
+    different format is requested.
+
+    Parameters
+    ----------
+    svg_data : bytes
+        Raw SVG content (UTF-8).
+    width : int
+        Desired output width in pixels.
+    height : int
+        Desired output height in pixels.
+    output_format : str, default="png"
+        Target image format: ``"png"``, ``"jpeg"``, or ``"bmp"``.
+    quality : int, default=90
+        JPEG quality (ignored for other formats).
+
+    Returns
+    -------
+    bytes
+        Rasterised image bytes in the requested format.
+
+    Raises
+    ------
+    RasterizeError
+        If no SVG renderer backend is available or rasterisation fails.
+    ValueError
+        If *output_format* is not one of ``"png"``, ``"jpeg"``, ``"bmp"``.
+    """
+    fmt = output_format.lower()
+    if fmt not in ("png", "jpeg", "bmp"):
+        raise ValueError(f"Unsupported output format: {output_format!r}")
+
+    backend_name = _active_backend or "auto"
+    css = _active_stylesheet
+
+    # Try to get PNG bytes first (the universal intermediate).
+    png_bytes = _resolve_and_rasterize(backend_name, css, svg_data, width, height)
+
+    if fmt == "png":
+        return png_bytes
+
+    # For JPEG and BMP we need to convert from PNG.
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+    buf = io.BytesIO()
+    if fmt == "jpeg":
+        img.save(buf, format="JPEG", quality=quality)
+    else:  # bmp
+        img.save(buf, format="BMP")
+    return buf.getvalue()
+
+
+def _resolve_and_rasterize(
+    backend_name: str,
+    css: str | None,
+    svg_data: bytes,
+    width: int,
+    height: int,
+) -> bytes:
+    """Select a backend and rasterise to PNG bytes.
+
+    Extracted from :func:`_svg_to_png` to share logic with
+    :func:`_rasterize_svg`.
+
+    Parameters
+    ----------
+    backend_name : str
+        Backend name or ``"auto"``.
+    css : str or None
+        Active CSS stylesheet text.
+    svg_data : bytes
+        Raw SVG content.
+    width : int
+        Desired output width in pixels.
+    height : int
+        Desired output height in pixels.
+
+    Returns
+    -------
+    bytes
+        PNG image bytes.
+
+    Raises
+    ------
+    RasterizeError
+        If no backend is available.
+    """
+    if backend_name != "auto":
+        backend = _registry[backend_name]
+        return _rasterize_with_stylesheet(backend, backend_name, svg_data, width, height, css)
+
+    errors: list[str] = []
+    for name in _AUTO_ORDER:
+        auto_backend = _registry.get(name)
+        if auto_backend is None:
+            continue
+        try:
+            return _rasterize_with_stylesheet(
+                auto_backend, name, svg_data, width, height, css
+            )
+        except RasterizeError as exc:
+            logger.debug("Backend %r failed: %s", name, exc)
+            errors.append(f"  - {name}: {exc}")
+
+    error_detail = "\n".join(errors) if errors else "  (no backends registered)"
+    raise RasterizeError(
+        "No SVG renderer available. Install one of:\n"
+        "  - System library: brew install cairo  (macOS) or apt install libcairo2 "
+        "(Linux)\n"
+        "  - CLI tool: apt install librsvg2-bin\n"
+        "  - Python package: pip install cairosvg\n"
+        "  - Python package: pip install pyvips\n"
+        "\nBackend errors:\n" + error_detail
+    )
+
+
+# ---------------------------------------------------------------------------
+# SVG document manipulation helpers
+# ---------------------------------------------------------------------------
+
+_XLINK_NS = "http://www.w3.org/1999/xlink"
+
+
+def set_svg_dimensions(root: ET.Element, width: int, height: int) -> None:
+    """Set ``width`` and ``height`` attributes on an SVG root element.
+
+    The ``viewBox`` is left unchanged so that the SVG engine performs
+    vector-level scaling from the design canvas to the target device
+    dimensions.
+
+    Parameters
+    ----------
+    root : ET.Element
+        The ``<svg>`` root element (mutated in place).
+    width : int
+        Target width in pixels.
+    height : int
+        Target height in pixels.
+    """
+    root.set("width", str(width))
+    root.set("height", str(height))
+
+
+def inject_background_rect(root: ET.Element, color: str) -> None:
+    """Insert a solid-colour background ``<rect>`` as the first child.
+
+    The rectangle fills 100% of the SVG viewport so the rasterised
+    output is fully opaque.  This eliminates the need for Pillow-level
+    canvas creation and alpha compositing.
+
+    Parameters
+    ----------
+    root : ET.Element
+        The ``<svg>`` root element (mutated in place).
+    color : str
+        CSS colour value (e.g. ``"black"``, ``"#1a1a2e"``).
+    """
+    rect = ET.Element(f"{{{_SVG_NS}}}rect")
+    rect.set("width", "100%")
+    rect.set("height", "100%")
+    rect.set("fill", color)
+    root.insert(0, rect)
+
+
+def slice_background_viewbox(
+    bg_root: ET.Element,
+    card_index: int,
+    panel_width: int,
+    panel_height: int,
+) -> ET.Element:
+    """Clone a background SVG and set its viewBox to a panel-sized slice.
+
+    The returned element is a deep copy with its ``viewBox`` adjusted
+    to window into the region corresponding to *card_index*.  The
+    ``width`` and ``height`` attributes are set to ``panel_width`` and
+    ``panel_height`` so the slice fills the target panel exactly.
+
+    Parameters
+    ----------
+    bg_root : ET.Element
+        The full-width background ``<svg>`` root element.
+    card_index : int
+        Zero-based panel index (determines the x-offset of the slice).
+    panel_width : int
+        Width of a single panel in pixels.
+    panel_height : int
+        Height of a single panel in pixels.
+
+    Returns
+    -------
+    ET.Element
+        A cloned ``<svg>`` element with the sliced ``viewBox``.
+    """
+    sliced = copy.deepcopy(bg_root)
+    x_offset = card_index * panel_width
+    sliced.set("viewBox", f"{x_offset} 0 {panel_width} {panel_height}")
+    sliced.set("width", str(panel_width))
+    sliced.set("height", str(panel_height))
+    return sliced
+
+
+def compose_svg_layers(
+    width: int,
+    height: int,
+    layers: list[ET.Element],
+) -> ET.Element:
+    """Create a wrapper SVG containing multiple nested ``<svg>`` layers.
+
+    Each layer is embedded as a nested ``<svg>`` element positioned at
+    the origin.  Layers are drawn in order (first = bottom, last = top)
+    following the SVG painter's model.
+
+    Parameters
+    ----------
+    width : int
+        Output width in pixels.
+    height : int
+        Output height in pixels.
+    layers : list[ET.Element]
+        SVG elements to embed as layers.  Each should have its own
+        ``viewBox``, ``width``, and ``height`` attributes.
+
+    Returns
+    -------
+    ET.Element
+        A wrapper ``<svg>`` root element containing all layers.
+    """
+    ET.register_namespace("", _SVG_NS)
+    ET.register_namespace("xlink", _XLINK_NS)
+
+    wrapper = ET.Element(f"{{{_SVG_NS}}}svg")
+    wrapper.set("xmlns", _SVG_NS)
+    wrapper.set("width", str(width))
+    wrapper.set("height", str(height))
+    wrapper.set("viewBox", f"0 0 {width} {height}")
+
+    for layer in layers:
+        # Ensure each layer has position attributes
+        layer.set("x", "0")
+        layer.set("y", "0")
+        wrapper.append(layer)
+
+    return wrapper
 
 
 # ---------------------------------------------------------------------------

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -822,7 +822,6 @@ def compose_svg_layers(
     ET.register_namespace("xlink", _XLINK_NS)
 
     wrapper = ET.Element(f"{{{_SVG_NS}}}svg")
-    wrapper.set("xmlns", _SVG_NS)
     wrapper.set("width", str(width))
     wrapper.set("height", str(height))
     wrapper.set("viewBox", f"0 0 {width} {height}")

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -14,7 +14,7 @@ from StreamDeck.DeviceManager import DeviceManager
 
 from ..render.key_renderer import render_blank_key
 from ..render.metrics import RenderMetrics
-from ..render.touch_renderer import compose_card_with_background, compose_touchstrip
+from ..render.touch_renderer import compose_card_with_background
 from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .device_info import DeviceInfo
@@ -506,7 +506,15 @@ class Deck:
             )
 
     async def _render_touchscreen(self) -> None:
-        """Render and push the full touch-strip image for the active screen."""
+        """Render and push each card panel individually to the device.
+
+        Uses the SVG-native pipeline for DuiCards: background
+        compositing happens at the SVG level, and each panel is
+        rasterised directly to device-ready bytes and pushed as a
+        per-panel update.
+
+        Non-DUI cards fall back to the legacy Pillow compositing path.
+        """
         screen = self._current_screen()
         if not self._device or not screen or not self._metrics:
             return
@@ -517,104 +525,130 @@ class Deck:
         metrics = self._metrics
         touch_strip = screen.touch_strip
 
-        # Re-wire push_fn for every DuiCard each render so that a card
-        # reused on multiple screens always animates at the slot of the
-        # currently active screen.
         from ..dui.card import DuiCard
 
+        bg_svg_root = touch_strip.bg_svg_root
+
         for card_idx, card in enumerate(screen.cards):
-            if not isinstance(card, DuiCard):
-                continue
             x_pos = card_idx * metrics.panel_width
             y_pos = 0
 
-            # Capture the background tile for this card's panel slot
-            bg_tile = touch_strip.bg_tile(card_idx)
-            card.set_bg_tile(bg_tile)
+            if isinstance(card, DuiCard):
+                # Set up background layer for SVG-level compositing
+                bg_tile = touch_strip.bg_tile(card_idx)
+                card.set_bg_tile(bg_tile)
 
-            async def _make_push(
-                x: int,
-                y: int,
-                w: int,
-                h: int,
-                tile: Image.Image | None,
-            ) -> PushFn:
-                async def _push_card_frame(frame_bytes: bytes) -> None:
-                    if tile is not None:
-                        # Decode the frame, composite onto the bg tile, re-encode
-                        frame_img = Image.open(io.BytesIO(frame_bytes))
-                        out_bytes = compose_card_with_background(
-                            frame_img,
-                            bg_tile=tile,
-                            panel_width=w,
-                            panel_height=h,
-                            image_format=(
-                                self._caps.touchscreen_image_format
-                                if self._caps
-                                else "JPEG"
-                            ),
-                        )
-                    else:
-                        out_bytes = frame_bytes
-                    loop = asyncio.get_running_loop()
-                    async with self._device_lock:
-                        await loop.run_in_executor(
-                            self._executor,
-                            self._device.set_touchscreen_image,
-                            out_bytes,
-                            x,
-                            y,
-                            w,
-                            h,
-                        )
+                if bg_svg_root is not None:
+                    card.set_background_layer(
+                        bg_svg_root,
+                        card_idx,
+                        metrics.panel_width,
+                        metrics.panel_height,
+                    )
+                else:
+                    card.clear_background_layer()
 
-                return _push_card_frame
+                # Wire push_fn for spinner animations (per-panel update)
+                async def _make_push(
+                    x: int,
+                    y: int,
+                    w: int,
+                    h: int,
+                    tile: Image.Image | None,
+                ) -> PushFn:
+                    async def _push_card_frame(frame_bytes: bytes) -> None:
+                        if tile is not None:
+                            # Decode the frame, composite onto the bg tile, re-encode
+                            frame_img = Image.open(io.BytesIO(frame_bytes))
+                            out_bytes = compose_card_with_background(
+                                frame_img,
+                                bg_tile=tile,
+                                panel_width=w,
+                                panel_height=h,
+                                image_format=(
+                                    self._caps.touchscreen_image_format
+                                    if self._caps
+                                    else "JPEG"
+                                ),
+                            )
+                        else:
+                            out_bytes = frame_bytes
+                        loop = asyncio.get_running_loop()
+                        async with self._device_lock:
+                            await loop.run_in_executor(
+                                self._executor,
+                                self._device.set_touchscreen_image,
+                                out_bytes,
+                                x,
+                                y,
+                                w,
+                                h,
+                            )
 
-            push_fn = await _make_push(
-                x_pos,
-                y_pos,
-                metrics.panel_width,
-                metrics.panel_height,
-                bg_tile,
-            )
-            card.set_push_fn(
-                push_fn, panel_size=(metrics.panel_width, metrics.panel_height)
-            )
+                    return _push_card_frame
 
-        card_images = []
-        for card in screen.cards:
-            # Skip re-rendering cards with active spinner animations
-            if self._is_animating(card):
-                card_images.append(card.rendered)
-                continue
-            await card.prepare_assets()
-            img = card.render()
-            card.set_rendered(img)
-            card_images.append(img)
+                push_fn = await _make_push(
+                    x_pos,
+                    y_pos,
+                    metrics.panel_width,
+                    metrics.panel_height,
+                    bg_tile,
+                )
+                card.set_push_fn(
+                    push_fn, panel_size=(metrics.panel_width, metrics.panel_height)
+                )
 
-        metrics = self._metrics
-        touchstrip_bytes = compose_touchstrip(
-            card_images,
-            background=screen.touch_strip.background_color,
-            bg_tiles=touch_strip.bg_tiles,
-            touchscreen_width=metrics.touchscreen_width,
-            touchscreen_height=metrics.touchscreen_height,
-            panel_count=metrics.panel_count,
-            panel_width=metrics.panel_width,
-            image_format=self._caps.touchscreen_image_format if self._caps else "JPEG",
-        )
+                # Skip re-rendering cards with active spinner animations
+                if self._is_animating(card):
+                    continue
 
-        loop = asyncio.get_running_loop()
-        async with self._device_lock:
-            await loop.run_in_executor(
-                self._executor,
-                self._device.set_touchscreen_image,
-                touchstrip_bytes,
-                0,
-                0,
-                metrics.touchscreen_width,
-                metrics.touchscreen_height,
-            )
+                await card.prepare_assets()
+
+                # SVG-native pipeline: render directly to device bytes
+                image_fmt = (
+                    self._caps.touchscreen_image_format if self._caps else "JPEG"
+                )
+                panel_bytes = card.render_bytes(
+                    panel_width=metrics.panel_width,
+                    panel_height=metrics.panel_height,
+                    image_format=image_fmt,
+                    background=touch_strip.background_color,
+                )
+
+                # Also render a PIL image for caching (used by screenshot)
+                img = card.render()
+                card.set_rendered(img)
+
+            else:
+                # Non-DUI card: legacy path with Pillow compositing
+                await card.prepare_assets()
+                rendered = card.render()
+                card.set_rendered(rendered)
+
+                bg_tile = touch_strip.bg_tile(card_idx)
+                panel_bytes = compose_card_with_background(
+                    rendered,
+                    bg_tile=bg_tile,
+                    background=touch_strip.background_color,
+                    panel_width=metrics.panel_width,
+                    panel_height=metrics.panel_height,
+                    image_format=(
+                        self._caps.touchscreen_image_format if self._caps else "JPEG"
+                    ),
+                )
+
+            # Push per-panel update
+            loop = asyncio.get_running_loop()
+            async with self._device_lock:
+                await loop.run_in_executor(
+                    self._executor,
+                    self._device.set_touchscreen_image,
+                    panel_bytes,
+                    x_pos,
+                    y_pos,
+                    metrics.panel_width,
+                    metrics.panel_height,
+                )
 
     async def _render_info_screen(self) -> None:
         """Render and push the info screen image (e.g. Neo)."""

--- a/src/deux/ui/touch_strip.py
+++ b/src/deux/ui/touch_strip.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from PIL import Image
@@ -56,6 +57,7 @@ class TouchStrip:
         self._cards: list[Card] = [BlankCard() for _ in range(panel_count)]
         self._background_color = background_color
         self._bg_svg: bytes | None = None
+        self._bg_svg_root: ET.Element | None = None
         self._bg_tiles: list[Image.Image] | None = None
 
     @property
@@ -151,13 +153,24 @@ class TouchStrip:
             return None
         return self._bg_tiles[index]
 
+    @property
+    def bg_svg_root(self) -> ET.Element | None:
+        """The parsed background SVG root element, or ``None``.
+
+        Used by the SVG-native pipeline to compose background layers
+        with card SVGs at the vector level before rasterisation.
+        """
+        return self._bg_svg_root
+
     def set_background_svg(self, svg_data: bytes) -> None:
         """Set a background SVG for the entire touchstrip.
 
-        The SVG is rasterized once at the full touchscreen resolution
-        (``panel_width * panel_count`` x ``panel_height``), sliced into
-        per-panel tiles, and cached.  All cards are marked dirty so they
-        re-render with the new background.
+        The SVG is parsed and cached as an XML element tree for
+        SVG-level composition.  For backward compatibility, the SVG
+        is also rasterized and sliced into per-panel PIL tiles.
+
+        All cards are marked dirty so they re-render with the new
+        background.
 
         Parameters
         ----------
@@ -165,6 +178,7 @@ class TouchStrip:
             Raw SVG content as UTF-8 bytes.
         """
         self._bg_svg = svg_data
+        self._bg_svg_root = ET.fromstring(svg_data)  # noqa: S314
         self._rasterize_and_slice()
         for card in self._cards:
             card.mark_dirty()
@@ -194,6 +208,7 @@ class TouchStrip:
         background tiles.
         """
         self._bg_svg = None
+        self._bg_svg_root = None
         self._bg_tiles = None
         for card in self._cards:
             card.mark_dirty()

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -627,7 +627,8 @@ class TestDeckRenderTouchscreen:
         deck._active_screen = p
 
         await deck._render_touchscreen()
-        mock_streamdeck_device.set_touchscreen_image.assert_called_once()
+        # Per-panel rendering: one call per panel (4 panels on SD+)
+        assert mock_streamdeck_device.set_touchscreen_image.call_count == 4
 
     async def test_renders_custom_cards(self, deck, mock_streamdeck_device):
         deck._device = mock_streamdeck_device
@@ -639,7 +640,8 @@ class TestDeckRenderTouchscreen:
         deck._active_screen = p
 
         await deck._render_touchscreen()
-        mock_streamdeck_device.set_touchscreen_image.assert_called_once()
+        # Per-panel rendering: one call per panel (4 panels on SD+)
+        assert mock_streamdeck_device.set_touchscreen_image.call_count == 4
 
 
 class TestDeckInfo:


### PR DESCRIPTION
## Summary

Replace the multi-step rasterize-decode-resize-composite-reencode chain with an SVG-native pipeline that performs all sizing, background compositing, and format encoding in a single rasterisation pass.

## Motivation

Previously, SVG keys/cards were rasterised at their native resolution, then Pillow was used to:
1. Decode PNG → PIL Image
2. Resize to device key/panel size (bitmap scaling)
3. Composite card onto background tile (alpha blending)
4. Convert to RGB
5. Encode to JPEG/BMP

This refactor moves steps 1-4 into the SVG/rasteriser layer:
- **Vector scaling**: SVG `width`/`height` set to device dimensions, `viewBox` preserved → rasteriser scales at vector level
- **SVG-level background compositing**: Background SVG `viewBox` sliced per card slot, composed as nested `<svg>` layer under card content
- **Direct format output**: `_rasterize_svg()` can output JPEG directly, bypassing PNG intermediate

## Key changes

### `svg_rasterize.py`
- `_rasterize_svg()`: New entry point with `output_format` param (png/jpeg/bmp)
- SVG manipulation helpers: `set_svg_dimensions()`, `inject_background_rect()`, `slice_background_viewbox()`, `compose_svg_layers()`

### `svg_renderer.py` (SvgRenderer)
- `set_target_size(w, h)`: Set device dimensions for vector scaling
- `set_base_layer(bg_root, card_index, panel_w, panel_h)`: Compose background SVG layer under card SVG (viewBox sliced per slot, cached as `_base_root`)
- `render_bytes()`: SVG → device-ready bytes in one pass

### `key.py` (DuiKey)
- `render_image()` uses `render_bytes()` — no Pillow resize/convert
- Removed `PIL.Image` and `_encode_image` imports

### `card.py` (DuiCard)
- `render_bytes()`: Direct panel rendering with SVG background compositing
- `set_background_layer()` / `clear_background_layer()`: SVG-level bg per slot

### `deck.py` (Deck)
- `_render_touchscreen()`: Per-panel rendering instead of full-strip
- Each panel pushed individually via `set_touchscreen_image(x_offset)`

### What stays with Pillow
- BMP encoding (pyvips doesn't support BMP)
- Non-SVG image sources (user-provided PIL images, fetched URLs)
- `ImageFont.getlength()` for text measurement in bindings
- Spinner frame assembly (needs RGBA transparency)

## Testing
- All 1546 tests pass
- Coverage: 96.59% (threshold: 95%)
- Lint (ruff): clean
- Typecheck (mypy strict): clean