### PR TITLE
fix: apply default backgrounds to empty keys and touchstrip cards on initial load

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -428,10 +428,14 @@ class Deck:
             if key_slot and self._is_dui_key(key_slot):
                 await self._render_dui_key(key_slot, key_index)
             else:
-                image_bytes = render_blank_key(
-                    key_size=metrics.key_size,
-                    image_format=caps.key_image_format,
-                )
+                bg_image = screen.key_bg_image
+                if bg_image is not None:
+                    image_bytes = bg_image
+                else:
+                    image_bytes = render_blank_key(
+                        key_size=metrics.key_size,
+                        image_format=caps.key_image_format,
+                    )
                 async with self._device_lock:
                     await loop.run_in_executor(
                         self._executor,
@@ -693,6 +697,10 @@ class Deck:
         for key_index, key_slot in screen.keys.items():
             if key_slot.is_dirty and self._is_dui_key(key_slot):
                 await self._render_dui_key(key_slot, key_index)
+
+        if screen.key_bg_dirty:
+            await self._render_all_keys()
+            screen.clear_key_bg_dirty()
 
         if screen.touch_strip is not None and screen.touch_strip.any_dirty:
             await self._render_touchscreen()

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -49,6 +49,9 @@ class Screen:
         self._keys: dict[int, KeySlot] = {}
         self._encoders: dict[int, EncoderSlot] = {}
         self._theme: Theme | None = None
+        self._key_bg_svg: bytes | None = None
+        self._key_bg_image: bytes | None = None
+        self._key_bg_dirty: bool = False
 
         if self._caps.has_touchscreen and self._caps.dial_count > 0:
             from ..render.metrics import RenderMetrics
@@ -106,8 +109,61 @@ class Screen:
                 svg_data = backgrounds["touchscreen"]
                 self._touch_strip._bg_svg = svg_data
                 self._touch_strip._bg_svg_root = ET.fromstring(svg_data)  # noqa: S314
+                self._touch_strip._rasterize_and_slice()
             except Exception:
                 logger.debug("Failed to apply default touchscreen background", exc_info=True)
+
+        if "key" in backgrounds:
+            try:
+                self._key_bg_svg = backgrounds["key"]
+                self._rasterize_key_background()
+            except Exception:
+                logger.debug("Failed to apply default key background", exc_info=True)
+
+    def _rasterize_key_background(self) -> None:
+        """Rasterize the key background SVG into encoded image bytes.
+
+        Uses the device's key size and image format to produce a ready-to-send
+        blank key image with the default background applied.  If no key
+        background SVG is set, clears the cached image.
+        """
+        if self._key_bg_svg is None:
+            self._key_bg_image = None
+            return
+
+        from PIL import Image as PILImage
+
+        from ..render.key_renderer import _encode_image
+        from ..render.svg_rasterize import _svg_to_png
+
+        key_w, key_h = self._caps.key_size
+        png_data = _svg_to_png(self._key_bg_svg, key_w, key_h)
+        img = PILImage.open(io.BytesIO(png_data)).convert("RGB")
+        self._key_bg_image = _encode_image(
+            img, image_format=self._caps.key_image_format
+        )
+        logger.debug("Key background SVG rasterized: %dx%d", key_w, key_h)
+
+    @property
+    def key_bg_image(self) -> bytes | None:
+        """Pre-rendered default key background image, or ``None``.
+
+        Returns
+        -------
+        bytes or None
+            Encoded image bytes ready to push to the device, or ``None``
+            if no default key background is configured.
+        """
+        return self._key_bg_image
+
+    @property
+    def key_bg_dirty(self) -> bool:
+        """Whether the key background needs re-rendering on all blank keys."""
+        return self._key_bg_dirty
+
+    def clear_key_bg_dirty(self) -> None:
+        """Reset the key-background dirty flag after a full key render."""
+        self._key_bg_dirty = False
 
     @property
     def capabilities(self) -> DeviceCapabilities:
@@ -325,6 +381,9 @@ class Screen:
         """
         for key_slot in self._keys.values():
             key_slot.mark_dirty()
+        if self._key_bg_svg is not None:
+            self._rasterize_key_background()
+            self._key_bg_dirty = True
         if self._touch_strip is not None:
             self._touch_strip.invalidate_background()
         for card in self.cards:

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +22,14 @@ from deux.runtime.events import (
 from deux.ui.cards.base import Card
 from deux.ui.screen import Screen
 from tests.conftest import PANEL_HEIGHT, PANEL_WIDTH
+
+
+def _make_jpeg_frame(width: int, height: int) -> bytes:
+    """Create minimal valid JPEG bytes for push_fn tests."""
+    img = Image.new("RGB", (width, height), "black")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 class _TestCard(Card):
@@ -1025,7 +1034,8 @@ class TestDeckRenderCrossScreen:
         push_fn = shared_card._push_fn
         assert push_fn is not None
         mock_streamdeck_device.set_touchscreen_image.reset_mock()
-        await push_fn(b"frame_a")
+        frame_a = _make_jpeg_frame(metrics.panel_width, metrics.panel_height)
+        await push_fn(frame_a)
         # set_touchscreen_image(frame_bytes, x, y, w, h)
         assert mock_streamdeck_device.set_touchscreen_image.call_args.args[1] == expected_x(1)
 
@@ -1034,5 +1044,6 @@ class TestDeckRenderCrossScreen:
         push_fn = shared_card._push_fn
         assert push_fn is not None
         mock_streamdeck_device.set_touchscreen_image.reset_mock()
-        await push_fn(b"frame_b")
+        frame_b = _make_jpeg_frame(metrics.panel_width, metrics.panel_height)
+        await push_fn(frame_b)
         assert mock_streamdeck_device.set_touchscreen_image.call_args.args[1] == expected_x(3)


### PR DESCRIPTION
## Problem

Background SVGs were loaded in `_apply_default_backgrounds()` but never rasterized during screen construction. This caused:

- **Touchstrip**: Empty/unconfigured `BlankCard` slots showed plain black instead of the themed background on initial render. The background only appeared after a theme change (because `mark_all_dirty()` triggered `invalidate_background()` which called `_rasterize_and_slice()`).
- **Keys**: Blank (non-DUI) keys always rendered as plain black with no default background applied.

## Root Cause

`_apply_default_backgrounds()` set `_bg_svg` and `_bg_svg_root` on the TouchStrip but deferred rasterization. For touchstrip BlankCards, the non-DUI render path relies on `bg_tile()` which returned `None` because `_bg_tiles` was never populated. For keys, no background mechanism existed at all.

## Fix

- **Touchstrip**: Eagerly call `_rasterize_and_slice()` after setting the SVG so `_bg_tiles` are available from the first render
- **Keys**: Store and rasterize key background SVG on `Screen`, use pre-rendered image for blank keys instead of plain black
- **Theme changes**: Re-rasterize key background in `mark_all_dirty()` and trigger full key re-render via `_key_bg_dirty` flag
- **Test fix**: Updated spinner push_fn test to use valid JPEG frame bytes (now required since bg compositing is active)