### PR TITLE
docs: use IconKey on_event decorator in Usage example

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -313,6 +313,8 @@ await manager.wait_closed()
 
 ## What NOT to Use
 
+**Never register event handlers directly on key slots.** Patterns like `@screen.key(0).on_press` bypass the DUI event system entirely. Always use the semantic events declared in the package manifest via `@key.on_event("event_name")`. For example, the bundled `IconKey` package defines `click`, `hold`, `press`, and `release` events — use those instead of raw slot decorators.
+
 The following are internal implementation details. Never suggest these to developers:
 
 | Module | Internal Components |

--- a/README.md
+++ b/README.md
@@ -100,11 +100,12 @@ async def main():
         key = DuiKey("IconKey")
         key.set("label", "Hello")
         key.set("icon", "mdi:hand-wave")
-        screen.key(0).set_dui(key)
 
-        @screen.key(0).on_press
-        async def on_press():
-            print("Pressed!")
+        @key.on_event("click")
+        async def on_click():
+            print("Clicked!")
+
+        screen.key(0).set_dui(key)
 
         await deck.set_screen("main")
 


### PR DESCRIPTION
Replaces @screen.key(0).on_press with @key.on_event("click") to use the event defined in the IconKey package manifest instead of raw key slot events.