### PR TITLE
fix: correct broken API call in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ async def main():
         async def on_click():
             print("Clicked!")
 
-        screen.key(0).set_dui(key)
+        screen.set_key(0, key)
 
         await deck.set_screen("main")
 


### PR DESCRIPTION
Fixes #187

Replaces `screen.key(0).set_dui(key)` with `screen.set_key(0, key)` in the README usage example. The `set_dui` method does not exist; `screen.set_key(index, key)` is the correct public API (defined in `src/deux/ui/screen.py:210`).

All tests pass (1558 passed, 97% coverage).