### PR TITLE
fix: replace asyncio.ensure_future with create_task and log hold-timer exceptions

### DIFF
--- a/src/deux/dui/event_map.py
+++ b/src/deux/dui/event_map.py
@@ -137,8 +137,9 @@ class EventMap:
             hold_ms = mapping.hold_ms
             if hold_ms is None:
                 continue  # pragma: no cover — validated by loader
-            self._hold_task = asyncio.ensure_future(
-                self._hold_delay(hold_ms / 1000.0, handler)
+            self._hold_task = asyncio.create_task(
+                self._hold_delay(hold_ms / 1000.0, handler),
+                name="dui-hold-timer",
             )
             return
 
@@ -153,7 +154,10 @@ class EventMap:
         if self._pressed:
             self._hold_fired = True
             self._hold_task = None
-            await handler()
+            try:
+                await handler()
+            except Exception:
+                logger.exception("Hold-timer handler raised an exception")
 
     def _cancel_hold_timer(self) -> None:
         """Cancel an in-progress hold timer if one is running."""

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -521,7 +521,7 @@ class TestKeyEvents:
         assert tap_handler in _handlers(result)
         assert release_handler in _handlers(result)
 
-    def test_press_always_fires_with_hold_configured(self):
+    async def test_press_always_fires_with_hold_configured(self):
         """key_press fires even when key_hold is also configured."""
         events = _make_events(
             ("down", "key_press"),
@@ -535,6 +535,7 @@ class TestKeyEvents:
 
         result = em.handle_key_press()
         assert press_handler in _handlers(result)
+        em.handle_key_release()
 
     def test_no_key_press_mapping_returns_empty(self):
         """handle_key_press returns empty list when no key_press mapping."""
@@ -1055,3 +1056,33 @@ class TestAccumulatedTurns:
         em.handle_encoder_turn(-1)
         await asyncio.sleep(0.1)
         handler.assert_awaited_once_with(-1)
+
+    async def test_hold_handler_exception_is_logged(self, caplog: pytest.LogCaptureFixture):
+        """A raising hold handler logs the exception instead of silently dropping it."""
+        events = _make_events(
+            ("long_hold", "key_hold", {"hold_ms": 10}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock(side_effect=RuntimeError("boom"))
+        em.on("long_hold", handler)
+
+        em.handle_key_press()
+        await asyncio.sleep(0.05)
+
+        handler.assert_awaited_once()
+        assert "Hold-timer handler raised an exception" in caplog.text
+        assert "boom" in caplog.text
+
+    async def test_hold_task_is_named(self):
+        """The hold-timer task receives the name 'dui-hold-timer'."""
+        events = _make_events(
+            ("long_hold", "key_hold", {"hold_ms": 5000}),
+        )
+        em = EventMap(events)
+        handler = AsyncMock()
+        em.on("long_hold", handler)
+
+        em.handle_key_press()
+        assert em._hold_task is not None
+        assert em._hold_task.get_name() == "dui-hold-timer"
+        em.handle_key_release()


### PR DESCRIPTION
## Summary

Fixes #191

## Changes

- ****: Replace `asyncio.ensure_future` with `asyncio.create_task(..., name="dui-hold-timer")` and wrap the hold handler invocation in `try/except Exception` with `logger.exception`.
- **`tests/test_dui_event_map.py`**: Add `test_hold_handler_exception_is_logged` verifying exceptions are logged, and `test_hold_task_is_named` verifying the task name. Convert `test_press_always_fires_with_hold_configured` to async (required since `create_task` needs a running event loop).

## Acceptance Criteria

- [x] `asyncio.create_task` used instead of `ensure_future`
- [x] Task named `"dui-hold-timer"`
- [x] Handler exceptions caught and logged explicitly
- [x] Test verifies that a raising hold handler logs the error
- [x] Existing hold-timer tests pass
- [x] All 1565 tests pass, coverage 96.80% (>95%), ruff clean, mypy clean