### PR TITLE
fix: log device probe failures in _scan_once (#196)

### DIFF
--- a/src/deux/runtime/manager.py
+++ b/src/deux/runtime/manager.py
@@ -79,6 +79,7 @@ class DeckManager:
         self._scan_task: asyncio.Task[None] | None = None
 
         self._decks: dict[str, Deck] = {}
+        self._failed_probe_paths: set[str] = set()
 
         self._connect_handlers: list[tuple[dict[str, str | None], AsyncHandler]] = []
         self._disconnect_handler: AsyncHandler | None = None
@@ -255,6 +256,16 @@ class DeckManager:
                 device_by_serial[serial] = d
                 await loop.run_in_executor(self._executor, d.close)
             except Exception:
+                dev_path = d.id()
+                if dev_path not in self._failed_probe_paths:
+                    self._failed_probe_paths.add(dev_path)
+                    logger.info(
+                        "Failed to probe new device at %s", dev_path, exc_info=True
+                    )
+                else:
+                    logger.debug(
+                        "Failed to probe device at %s", dev_path, exc_info=True
+                    )
                 continue
 
         for serial in list(self._decks):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from deux.runtime.manager import DeckManager
@@ -278,6 +279,52 @@ class TestDeckManagerScanOnce:
             await m._scan_once()
 
         assert m._decks == {}
+
+    async def test_scan_device_open_error_logs_info_then_debug(self, caplog):
+        """Permission / probe errors are logged at info (first) then debug (subsequent).
+
+        Verifies acceptance criteria from issue #196: device probe failures
+        are logged at ``info`` level for the first occurrence and ``debug``
+        for subsequent ones, with exception info attached.
+        """
+        m = DeckManager(poll_interval=10.0)
+
+        @m.on_connect()
+        async def handler(deck):
+            pass
+
+        dev = _make_raw_device(serial="PERM_ERR")
+        dev.open.side_effect = PermissionError("Permission denied")
+
+        with patch("deux.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [dev]
+
+            # First scan — should log at INFO level
+            with caplog.at_level(logging.DEBUG, logger="deux.runtime.manager"):
+                caplog.clear()
+                await m._scan_once()
+
+            info_records = [
+                r
+                for r in caplog.records
+                if r.levelno == logging.INFO and "Failed to probe new device" in r.message
+            ]
+            assert len(info_records) == 1
+            assert info_records[0].exc_info is not None
+            assert info_records[0].exc_info[0] is PermissionError
+
+            # Second scan — same path, should log at DEBUG level
+            with caplog.at_level(logging.DEBUG, logger="deux.runtime.manager"):
+                caplog.clear()
+                await m._scan_once()
+
+            debug_records = [
+                r
+                for r in caplog.records
+                if r.levelno == logging.DEBUG and "Failed to probe device" in r.message
+            ]
+            assert len(debug_records) == 1
+            assert debug_records[0].exc_info is not None
 
 
 class TestDeckManagerDecks:


### PR DESCRIPTION
## Problem
`_scan_once` had a broad `except Exception: continue` that silently swallowed all errors during device probing. Users with permission issues saw no output and no error.

## Solution
- First-seen probe failures logged at `INFO` level with `exc_info=True`
- Subsequent failures for the same device path logged at `DEBUG` level with `exc_info=True`
- Control flow unchanged (still continues to next device)
- Tracked via `_failed_probe_paths` set on the manager

## Testing
- Added `test_scan_device_open_error_logs_info_then_debug` verifying both log levels and exception info
- All 1566 tests pass, coverage 96.81% (>95% gate)
- ruff and mypy clean

Closes #196