### PR TITLE
fix: use dynamic __version__ in User-Agent header instead of hardcoded 0.1.0

### DIFF
--- a/src/deux/dui/iconify.py
+++ b/src/deux/dui/iconify.py
@@ -24,13 +24,15 @@ from typing import cast
 
 import platformdirs
 
+from deux._version import __version__
+
 logger = logging.getLogger(__name__)
 
 ICONIFY_API_URL = "https://api.iconify.design"
 
 _REQUEST_TIMEOUT = 10.0
 
-USER_AGENT = "deux/0.1.0 (+https://github.com/graphras-com/DeUX)"
+USER_AGENT = f"deux/{__version__} (+https://github.com/graphras-com/DeUX)"
 
 _cache: dict[str, str | None] = {}
 _cache_lock = threading.Lock()

--- a/src/deux/render/image_fetch.py
+++ b/src/deux/render/image_fetch.py
@@ -15,11 +15,13 @@ import urllib.request
 
 from PIL import Image, UnidentifiedImageError
 
+from deux._version import __version__
+
 logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = 10.0
 
-USER_AGENT = "deux/0.1.0 (+https://github.com/graphras-com/DeUX)"
+USER_AGENT = f"deux/{__version__} (+https://github.com/graphras-com/DeUX)"
 
 _cache: dict[str, Image.Image | None] = {}
 _cache_lock = threading.Lock()


### PR DESCRIPTION
## Summary

Replace hardcoded `deux/0.1.0` in the `USER_AGENT` constant with an f-string that imports `__version__` from `deux._version` (generated by hatch-vcs). Applied to both `src/deux/render/image_fetch.py` and `src/deux/dui/iconify.py`.

Uses `deux._version` (not `deux`) to avoid circular imports since these modules are imported during `deux.__init__` initialization.

## Checklist
- [x] No hardcoded version string
- [x] User-Agent references `deux.__version__`
- [x] ruff, mypy, and all 1566 tests pass
- [x] Coverage: 96.81% (>95% threshold)

Closes #235