### PR TITLE
fix(api): unify DuiKey.on_event to DuiKey.on

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -47,7 +47,7 @@ All entry points are importable from `deux` directly.
 | Method | Description |
 |---|---|
 | `@card.on("event_name")` | Decorator to handle a semantic event (cards) |
-| `@key.on_event("event_name")` | Decorator to handle a semantic event (keys) |
+| `@key.on("event_name")` | Decorator to handle a semantic event (keys) |
 | `.bind_event(name, handler)` | Programmatic event binding |
 | `.forward(event_name, coroutine)` | Forward an event directly to an async function |
 
@@ -296,7 +296,7 @@ async def setup(deck):
     key = DuiKey("PowerKey")
     key.set("label", "Power")
 
-    @key.on_event("activate")
+    @key.on("activate")
     async def handle_power():
         ...
 
@@ -313,7 +313,7 @@ await manager.wait_closed()
 
 ## What NOT to Use
 
-**Never register event handlers directly on key slots.** Patterns like `@screen.key(0).on_press` bypass the DUI event system entirely. Always use the semantic events declared in the package manifest via `@key.on_event("event_name")`. For example, the bundled `IconKey` package defines `click`, `hold`, `press`, and `release` events — use those instead of raw slot decorators.
+**Never register event handlers directly on key slots.** Patterns like `@screen.key(0).on_press` bypass the DUI event system entirely. Always use the semantic events declared in the package manifest via `@key.on("event_name")`. For example, the bundled `IconKey` package defines `click`, `hold`, `press`, and `release` events — use those instead of raw slot decorators.
 
 The following are internal implementation details. Never suggest these to developers:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ async def main():
         key.set("label", "Hello")
         key.set("icon", "mdi:hand-wave")
 
-        @key.on_event("click")
+        @key.on("click")
         async def on_click():
             print("Clicked!")
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -116,17 +116,17 @@ the foreground and background colours so the key visually flashes while
 held; click logs the scene name:
 
 ```python
-@key.on_event("press")
+@key.on("press")
 async def _press():
     key.set_many(background=FG, foreground=BG)
     await key.request_refresh()
 
-@key.on_event("release")
+@key.on("release")
 async def _release():
     key.set_many(background=BG, foreground=FG)
     await key.request_refresh()
 
-@key.on_event("click")
+@key.on("click")
 async def _click():
     log.info("Scene activated: %s", label)
 ```

--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -473,7 +473,7 @@ immediately while the spinner keeps running until an external signal
 arrives.
 
 ```python
-@key.on_event("toggle")
+@key.on("toggle")
 async def handle():
     await key.start_busy()
     # Fire the API call. The spinner keeps running
@@ -489,7 +489,7 @@ async def on_state_update(new_state):
 If the work completes within the handler, call both in the same handler:
 
 ```python
-@key.on_event("toggle")
+@key.on("toggle")
 async def handle():
     await key.start_busy()
     new_state = await smart_home_api.toggle_light()
@@ -542,7 +542,7 @@ from deux.dui import DuiKey, load_package
 spec = load_package("./SmartLight.dui")
 key = DuiKey(spec)
 
-@key.on_event("toggle")
+@key.on("toggle")
 async def handle():
     await key.start_busy()
     # Spinner starts — the key still shows the current
@@ -717,7 +717,7 @@ key = DuiKey(spec, slot)
 key.set("label", "Deploy")
 key.set("indicator_color", "#00ff00")
 
-@key.on_event("activate")
+@key.on("activate")
 async def on_activate():
     ...
 

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -756,7 +756,7 @@ class FavoritesController:
 
             # Late-bind *media* per iteration so each forward target
             # captures its own dict instead of the shared loop variable.
-            @key.on_event("click")
+            @key.on("click")
             async def _click(k=key, m=media):
                 await k.start_busy()
                 await self._audio_svc.play(m)
@@ -947,17 +947,17 @@ class SceneController:
 
         background_class = key.get("background_class")
 
-        @key.on_event("press")
+        @key.on("press")
         async def _press() -> None:
             key.set("background_class", "success")
             await key.request_refresh()
 
-        @key.on_event("release")
+        @key.on("release")
         async def _release() -> None:
             key.set("background_class", background_class)
             await key.request_refresh()
 
-        @key.on_event("click")
+        @key.on("click")
         async def _click() -> None:
             key.set("background_class", background_class)
             await key.request_refresh()

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from ..ui.controls.key_slot import KeySlot
@@ -39,7 +40,7 @@ class DuiKey(KeySlot):
         key = DuiKey("IconKey")
         key.set("label", "Shutdown")
 
-        @key.on_event("activate")
+        @key.on("activate")
         async def handle():
             ...
 
@@ -263,14 +264,14 @@ class DuiKey(KeySlot):
         current_norm = float(self.get(name) or 0.0)
         return min_val + current_norm * (max_val - min_val)
 
-    def on_event(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
+    def on(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
         """Decorator to register a handler for a named semantic event.
 
         Examples
         --------
         ::
 
-            @key.on_event("activate")
+            @key.on("activate")
             async def handle():
                 ...
 
@@ -290,6 +291,30 @@ class DuiKey(KeySlot):
             return fn
 
         return decorator
+
+    def on_event(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
+        """Deprecated alias for :meth:`on`.
+
+        .. deprecated:: 0.1
+            Use :meth:`on` instead. ``on_event`` will be removed in a
+            future release.
+
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
+
+        Returns
+        -------
+        Callable
+            A decorator that registers the handler and returns it unchanged.
+        """
+        warnings.warn(
+            "DuiKey.on_event() is deprecated, use DuiKey.on() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.on(event_name)
 
     def bind_event(self, event_name: str, handler: AsyncHandler) -> None:
         """Imperatively register a handler for a named semantic event.

--- a/tests/test_dui_key.py
+++ b/tests/test_dui_key.py
@@ -228,15 +228,28 @@ class TestDuiKeyToggleBinding:
 
 
 class TestDuiKeyEvents:
-    def test_on_event_decorator(self):
+    def test_on_decorator(self):
         spec = _make_key_spec(
             events=(EventMapping(name="activate", source="key_press"),),
         )
         key = DuiKey(spec)
 
-        @key.on_event("activate")
+        @key.on("activate")
         async def handler():
             pass
+
+        assert handler is not None
+
+    def test_on_event_deprecated_alias(self):
+        spec = _make_key_spec(
+            events=(EventMapping(name="activate", source="key_press"),),
+        )
+        key = DuiKey(spec)
+
+        with pytest.warns(DeprecationWarning, match="use DuiKey.on"):
+            @key.on_event("activate")
+            async def handler():
+                pass
 
         assert handler is not None
 


### PR DESCRIPTION
## Summary

Resolves #186 — Unifies the handler registration API so both `DuiCard` and `DuiKey` use `.on(name)`.

## Changes

- **`src/deux/dui/key.py`**: Renamed `on_event()` to `on()` as the primary method. Added `on_event()` as a deprecated alias that emits `DeprecationWarning`.
- **`tests/test_dui_key.py`**: Updated existing test to use `.on()`. Added new test `test_on_event_deprecated_alias` verifying the deprecation warning.
- **`examples/streamdeck.py`**: All `@key.on_event(...)` calls updated to `@key.on(...)`.
- **`README.md`**, **`AI_USAGE.md`**, **`docs/`**: All references updated to `.on()`.

## Acceptance Criteria

- [x] `DuiKey` exposes `.on(name)` as the primary handler registration method
- [x] `DuiKey.on_event(name)` exists as a deprecated alias (emits `DeprecationWarning`)
- [x] `DuiCard.on(name)` unchanged
- [x] All tests updated to use `.on(name)`
- [x] README and examples use `.on(name)` consistently

## Verification

- ruff: clean
- mypy: clean
- pytest: 1567 passed, 1 skipped, 96.81% coverage (>95% gate)