### PR TITLE
Mitigate SSRF via image_fetch and iconify URL bindings

### DIFF
--- a/src/deux/__init__.py
+++ b/src/deux/__init__.py
@@ -28,6 +28,7 @@ Examples
 
 from __future__ import annotations
 
+from ._url_safety import SSRFError, set_allow_private_urls
 from .dui import (
     DuiCard,
     DuiKey,
@@ -116,6 +117,7 @@ __all__ = [
     "PackageError",
     "PackageSpec",
     "RenderMetrics",
+    "SSRFError",
     "Screen",
     "SurfaceBackgrounds",
     "SvgRasterizer",
@@ -142,6 +144,7 @@ __all__ = [
     "remove_dui_path",
     "resolve_dui",
     "set_active_theme",
+    "set_allow_private_urls",
     "set_svg_backend",
     "set_svg_stylesheet",
 ]

--- a/src/deux/_url_safety.py
+++ b/src/deux/_url_safety.py
@@ -1,0 +1,126 @@
+"""URL safety checks to mitigate SSRF via .dui package bindings.
+
+By default, URLs targeting private, loopback, link-local, and cloud
+metadata IP ranges are rejected.  An opt-in ``allow_private_urls``
+flag can be set to permit LAN resources when explicitly needed.
+
+Threat Model
+------------
+``.dui`` packages are designed to be distributed between users.  A
+malicious package can embed ``image:`` bindings or ``iconify:`` URLs
+that point at internal network endpoints, enabling Server-Side Request
+Forgery (SSRF).  Blocked ranges include:
+
+* Loopback — ``127.0.0.0/8``, ``::1``
+* Private (RFC 1918) — ``10.0.0.0/8``, ``172.16.0.0/12``,
+  ``192.168.0.0/16``
+* Link-local — ``169.254.0.0/16``, ``fe80::/10``
+* Cloud metadata — ``169.254.169.254``
+
+Users who genuinely need LAN resources can call
+:func:`set_allow_private_urls` to opt in.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_allow_private_urls: bool = False
+
+
+class SSRFError(Exception):
+    """Raised when a URL targets a blocked private/internal address."""
+
+
+def set_allow_private_urls(allow: bool) -> None:
+    """Opt in or out of private URL access.
+
+    Parameters
+    ----------
+    allow : bool
+        When ``True``, SSRF checks are disabled and private/internal
+        URLs are permitted.  When ``False`` (the default), requests to
+        loopback, RFC 1918, link-local, and metadata addresses are
+        blocked.
+    """
+    global _allow_private_urls  # noqa: PLW0603
+    _allow_private_urls = allow
+
+
+def get_allow_private_urls() -> bool:
+    """Return the current private-URL policy.
+
+    Returns
+    -------
+    bool
+        ``True`` if private URLs are currently allowed.
+    """
+    return _allow_private_urls
+
+
+def _is_private_ip(addr: str) -> bool:
+    """Return ``True`` if *addr* is a private, loopback, or link-local IP.
+
+    Parameters
+    ----------
+    addr : str
+        An IPv4 or IPv6 address string.
+
+    Returns
+    -------
+    bool
+        ``True`` when the address falls within a blocked range.
+    """
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved
+
+
+def check_url(url: str) -> None:
+    """Validate that *url* does not target a private/internal address.
+
+    Resolves the hostname via DNS and checks whether any resulting IP
+    address falls within a blocked range.  This guards against SSRF
+    even when hostnames like ``localhost`` or attacker-controlled DNS
+    resolve to private IPs.
+
+    Parameters
+    ----------
+    url : str
+        Fully-qualified HTTP(S) URL.
+
+    Raises
+    ------
+    SSRFError
+        If the resolved address is private/loopback/link-local and
+        :func:`set_allow_private_urls` has not been called with
+        ``True``.
+    """
+    if _allow_private_urls:
+        return
+
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFError(f"Cannot extract hostname from URL: {url!r}")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise SSRFError(f"Cannot resolve hostname {hostname!r}: {exc}") from exc
+
+    for _family, _type, _proto, _canonname, sockaddr in infos:
+        ip_str = str(sockaddr[0])
+        if _is_private_ip(ip_str):
+            raise SSRFError(
+                f"URL {url!r} resolves to private address {ip_str} — "
+                "blocked to prevent SSRF. Call "
+                "deux.set_allow_private_urls(True) to allow."
+            )

--- a/src/deux/dui/iconify.py
+++ b/src/deux/dui/iconify.py
@@ -24,6 +24,7 @@ from typing import cast
 
 import platformdirs
 
+from deux._url_safety import check_url
 from deux._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -188,6 +189,9 @@ def fetch_icon(name: str) -> str:
     IconifyError
         If the name is malformed, the icon does not
         exist, or the network request fails.
+    SSRFError
+        If the constructed API URL resolves to a private address
+        and private URLs have not been explicitly allowed.
     """
     prefix, icon = _parse_name(name)
     key = f"{prefix}:{icon}"
@@ -210,6 +214,7 @@ def fetch_icon(name: str) -> str:
 
     # 3. Network fetch
     url = f"{ICONIFY_API_URL}/{prefix}/{icon}.svg"
+    check_url(url)
     try:
         body = _http_get(url)
     except (urllib.error.URLError, OSError) as exc:

--- a/src/deux/render/image_fetch.py
+++ b/src/deux/render/image_fetch.py
@@ -15,6 +15,7 @@ import urllib.request
 
 from PIL import Image, UnidentifiedImageError
 
+from deux._url_safety import check_url
 from deux._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -98,8 +99,13 @@ def fetch_image(url: str) -> Image.Image:
     ImageFetchError
         If the URL is malformed, the network request fails, or the
         response cannot be decoded as a valid image.
+    SSRFError
+        If the URL resolves to a private/loopback/link-local address
+        and private URLs have not been explicitly allowed via
+        :func:`deux.set_allow_private_urls`.
     """
     _validate_url(url)
+    check_url(url)
 
     with _cache_lock:
         if url in _cache:

--- a/tests/test_dui_iconify.py
+++ b/tests/test_dui_iconify.py
@@ -42,6 +42,13 @@ def _isolate_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     clear_cache(persistent=True)
 
 
+@pytest.fixture(autouse=True)
+def _bypass_ssrf():
+    """Bypass SSRF checks in iconify tests (tested separately)."""
+    with patch("deux.dui.iconify.check_url"):
+        yield
+
+
 class TestParseName:
     def test_simple(self):
         assert _parse_name("line-md:home") == ("line-md", "home")

--- a/tests/test_image_fetch.py
+++ b/tests/test_image_fetch.py
@@ -34,6 +34,13 @@ def _isolate_cache():
     clear_cache()
 
 
+@pytest.fixture(autouse=True)
+def _bypass_ssrf():
+    """Bypass SSRF checks in image fetch tests (tested separately)."""
+    with patch("deux.render.image_fetch.check_url"):
+        yield
+
+
 class TestValidateUrl:
     """Tests for :func:`_validate_url`."""
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,6 +38,7 @@ class TestPublicAPI:
             "PackageError",
             "PackageSpec",
             "RenderMetrics",
+            "SSRFError",
             "Screen",
             "SurfaceBackgrounds",
             "SvgRasterizer",
@@ -64,6 +65,7 @@ class TestPublicAPI:
             "remove_dui_path",
             "resolve_dui",
             "set_active_theme",
+            "set_allow_private_urls",
             "set_svg_backend",
             "set_svg_stylesheet",
         }

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,244 @@
+"""Tests for deux._url_safety — SSRF mitigation for URL bindings."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from deux._url_safety import (
+    SSRFError,
+    _is_private_ip,
+    check_url,
+    get_allow_private_urls,
+    set_allow_private_urls,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_policy():
+    """Ensure private-URL policy is reset around every test."""
+    set_allow_private_urls(False)
+    yield
+    set_allow_private_urls(False)
+
+
+class TestIsPrivateIp:
+    """Tests for :func:`_is_private_ip`."""
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "127.0.0.1",
+            "127.0.0.2",
+            "10.0.0.1",
+            "10.255.255.255",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.0.1",
+            "192.168.1.100",
+            "169.254.169.254",
+            "169.254.0.1",
+            "::1",
+            "0.0.0.0",
+        ],
+    )
+    def test_private_addresses_detected(self, addr: str):
+        assert _is_private_ip(addr) is True
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2606:4700::1111",
+        ],
+    )
+    def test_public_addresses_allowed(self, addr: str):
+        assert _is_private_ip(addr) is False
+
+    def test_invalid_address_returns_false(self):
+        assert _is_private_ip("not-an-ip") is False
+
+
+class TestCheckUrl:
+    """Tests for :func:`check_url`."""
+
+    def test_public_url_passes(self):
+        """A URL resolving to a public IP should not raise."""
+        info = [(socket.AF_INET, 0, 0, "", ("93.184.216.34", 0))]
+        with patch("deux._url_safety.socket.getaddrinfo", return_value=info):
+            check_url("https://example.com/image.png")
+
+    def test_localhost_blocked(self):
+        info = [(socket.AF_INET, 0, 0, "", ("127.0.0.1", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://localhost/secret")
+
+    def test_metadata_endpoint_blocked(self):
+        info = [(socket.AF_INET, 0, 0, "", ("169.254.169.254", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_rfc1918_10_blocked(self):
+        info = [(socket.AF_INET, 0, 0, "", ("10.0.0.5", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://internal.corp/api")
+
+    def test_rfc1918_172_blocked(self):
+        info = [(socket.AF_INET, 0, 0, "", ("172.16.5.1", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://nas.local/file")
+
+    def test_rfc1918_192_blocked(self):
+        info = [(socket.AF_INET, 0, 0, "", ("192.168.1.1", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://router.local/admin")
+
+    def test_ipv6_loopback_blocked(self):
+        info = [(socket.AF_INET6, 0, 0, "", ("::1", 0, 0, 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://[::1]/")
+
+    def test_dns_failure_raises_ssrf_error(self):
+        with (
+            patch(
+                "deux._url_safety.socket.getaddrinfo",
+                side_effect=socket.gaierror("nxdomain"),
+            ),
+            pytest.raises(SSRFError, match="Cannot resolve"),
+        ):
+            check_url("http://nonexistent.invalid/x")
+
+    def test_no_hostname_raises(self):
+        with pytest.raises(SSRFError, match="Cannot extract hostname"):
+            check_url("http:///no-host")
+
+    def test_allow_private_urls_bypasses_check(self):
+        """When opted in, private URLs should be allowed."""
+        set_allow_private_urls(True)
+        info = [(socket.AF_INET, 0, 0, "", ("127.0.0.1", 0))]
+        with patch("deux._url_safety.socket.getaddrinfo", return_value=info):
+            check_url("http://localhost/ok")  # should not raise
+
+    def test_multiple_addresses_one_private_blocked(self):
+        """If any resolved address is private, the URL is blocked."""
+        info = [
+            (socket.AF_INET, 0, 0, "", ("93.184.216.34", 0)),
+            (socket.AF_INET, 0, 0, "", ("127.0.0.1", 0)),
+        ]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            check_url("http://dual.example.com/")
+
+
+class TestPolicy:
+    """Tests for :func:`set_allow_private_urls` / :func:`get_allow_private_urls`."""
+
+    def test_default_is_false(self):
+        assert get_allow_private_urls() is False
+
+    def test_set_true(self):
+        set_allow_private_urls(True)
+        assert get_allow_private_urls() is True
+
+    def test_set_false(self):
+        set_allow_private_urls(True)
+        set_allow_private_urls(False)
+        assert get_allow_private_urls() is False
+
+
+class TestIntegrationImageFetch:
+    """Verify SSRF check is wired into :func:`fetch_image`."""
+
+    def test_fetch_image_blocks_private_url(self):
+        from deux.render.image_fetch import clear_cache, fetch_image
+
+        clear_cache()
+        info = [(socket.AF_INET, 0, 0, "", ("127.0.0.1", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            fetch_image("http://localhost/evil.png")
+        clear_cache()
+
+    def test_fetch_image_allows_public_url(self):
+        """Public URLs pass SSRF check (network fetch itself is mocked)."""
+        import io
+
+        from PIL import Image
+
+        from deux.render import image_fetch as mod
+        from deux.render.image_fetch import clear_cache, fetch_image
+
+        clear_cache()
+        img = Image.new("RGB", (4, 4), "red")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_data = buf.getvalue()
+
+        info = [(socket.AF_INET, 0, 0, "", ("93.184.216.34", 0))]
+        with (
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            patch.object(mod, "_http_get_bytes", return_value=png_data),
+        ):
+            result = fetch_image("https://example.com/ok.png")
+        assert isinstance(result, Image.Image)
+        clear_cache()
+
+
+class TestIntegrationIconify:
+    """Verify SSRF check is wired into :func:`fetch_icon`."""
+
+    def test_fetch_icon_blocks_private_api_url(self):
+        from deux.dui import iconify as iconify_mod
+        from deux.dui.iconify import clear_cache, fetch_icon
+
+        clear_cache(persistent=True)
+        info = [(socket.AF_INET, 0, 0, "", ("127.0.0.1", 0))]
+        with (
+            patch.object(iconify_mod, "ICONIFY_API_URL", "http://localhost"),
+            patch("deux._url_safety.socket.getaddrinfo", return_value=info),
+            pytest.raises(SSRFError, match="private address"),
+        ):
+            fetch_icon("mdi:home")
+        clear_cache(persistent=True)
+
+
+class TestPackageExports:
+    """Ensure SSRF utilities are accessible from the top-level package."""
+
+    def test_ssrf_error_exported(self):
+        import deux
+
+        assert hasattr(deux, "SSRFError")
+        assert deux.SSRFError is SSRFError
+
+    def test_set_allow_private_urls_exported(self):
+        import deux
+
+        assert hasattr(deux, "set_allow_private_urls")
+        assert callable(deux.set_allow_private_urls)


### PR DESCRIPTION
## Summary

Adds SSRF mitigation for `.dui` package URL bindings as described in #189.

## Changes

- **New module** `src/deux/_url_safety.py`: DNS-resolving URL validator that rejects private/loopback/link-local/metadata IPs
- **`fetch_image()`**: Now calls `check_url()` before HTTP requests
- **`fetch_icon()`**: Now calls `check_url()` on the constructed API URL before fetching
- **Public API**: Exports `SSRFError` and `set_allow_private_urls()` from `deux`
- **Opt-in**: Users needing LAN resources call `deux.set_allow_private_urls(True)`

## Blocked Ranges (default)

- Loopback: `127.0.0.0/8`, `::1`
- RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
- Link-local: `169.254.0.0/16`, `fe80::/10`
- Cloud metadata: `169.254.169.254`

## Testing

- 85 new/updated tests covering blocked patterns, allowed patterns, opt-in bypass, and integration with both `fetch_image` and `fetch_icon`
- All 1603 tests pass, coverage 97%
- Lint (ruff) and typecheck (mypy strict) pass

Closes #189