### PR TITLE
fix: replace per-Deck/Manager executor with shared pool (#190)

### DIFF
--- a/src/deux/runtime/__init__.py
+++ b/src/deux/runtime/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ._executor import get_executor, shutdown_executor
 from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .deck import Deck, DeckError
@@ -34,5 +35,7 @@ __all__ = [
     "EventType",
     "KeyEvent",
     "TouchEvent",
+    "get_executor",
     "list_devices",
+    "shutdown_executor",
 ]

--- a/src/deux/runtime/_executor.py
+++ b/src/deux/runtime/_executor.py
@@ -1,0 +1,47 @@
+"""Shared thread-pool executor for blocking HID I/O.
+
+Provides a single module-level :class:`~concurrent.futures.ThreadPoolExecutor`
+used by :class:`Deck`, :class:`DeckManager`, and :func:`list_devices` instead
+of per-instance pools.  This eliminates idle-thread waste at multi-deck scale
+and ensures deterministic shutdown via :func:`shutdown_executor`.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+_MAX_WORKERS = 4
+
+_executor: ThreadPoolExecutor | None = None
+
+
+def get_executor() -> ThreadPoolExecutor:
+    """Return the shared executor, creating it on first access.
+
+    The pool is lazily initialised so that import-time side-effects are
+    avoided.  All callers share the same instance.
+
+    Returns
+    -------
+    ThreadPoolExecutor
+        The shared executor.
+    """
+    global _executor  # noqa: PLW0603
+    if _executor is None or _executor._shutdown:
+        _executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS)
+    return _executor
+
+
+def shutdown_executor(*, wait: bool = True) -> None:
+    """Shut down the shared executor.
+
+    Parameters
+    ----------
+    wait : bool, default=True
+        If ``True``, block until all in-flight tasks complete, ensuring
+        no HID locks are held non-deterministically.
+    """
+    global _executor  # noqa: PLW0603
+    if _executor is not None:
+        _executor.shutdown(wait=wait)
+        _executor = None

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import io
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
@@ -15,6 +14,7 @@ from StreamDeck.DeviceManager import DeviceManager
 from ..render.key_renderer import render_blank_key
 from ..render.metrics import RenderMetrics
 from ..render.touch_renderer import compose_card_with_background
+from ._executor import get_executor, shutdown_executor
 from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .device_info import DeviceInfo
@@ -87,7 +87,6 @@ class Deck:
         self._event_task: asyncio.Task[None] | None = None
         self._closed_event = asyncio.Event()
         self._running = False
-        self._executor = ThreadPoolExecutor(max_workers=2)
         self._device_lock = asyncio.Lock()
 
         self._screens: dict[str, Screen] = {}
@@ -104,7 +103,7 @@ class Deck:
 
         loop = asyncio.get_running_loop()
 
-        devices = await loop.run_in_executor(self._executor, DeviceManager().enumerate)
+        devices = await loop.run_in_executor(get_executor(), DeviceManager().enumerate)
 
         if not devices:
             raise DeckError("No Stream Deck devices found")
@@ -116,12 +115,12 @@ class Deck:
         target = None
         for d in visual:
             try:
-                await loop.run_in_executor(self._executor, d.open)
+                await loop.run_in_executor(get_executor(), d.open)
                 serial = d.get_serial_number()
                 if serial == self._serial_number:
                     target = d
                     break
-                await loop.run_in_executor(self._executor, d.close)
+                await loop.run_in_executor(get_executor(), d.close)
             except Exception:
                 continue
         if target is None:
@@ -130,9 +129,9 @@ class Deck:
             )
         self._device = target
 
-        await loop.run_in_executor(self._executor, self._device.reset)
+        await loop.run_in_executor(get_executor(), self._device.reset)
         await loop.run_in_executor(
-            self._executor, self._device.set_brightness, self._brightness
+            get_executor(), self._device.set_brightness, self._brightness
         )
 
         self._caps = DeviceCapabilities.from_device(self._device)
@@ -175,13 +174,13 @@ class Deck:
         if self._device:
             loop = asyncio.get_running_loop()
             try:
-                await loop.run_in_executor(self._executor, self._device.reset)
-                await loop.run_in_executor(self._executor, self._device.close)
+                await loop.run_in_executor(get_executor(), self._device.reset)
+                await loop.run_in_executor(get_executor(), self._device.close)
             except Exception as e:
                 logger.warning("Error closing device: %s", e)
 
         self._closed_event.set()
-        self._executor.shutdown(wait=False)
+        shutdown_executor(wait=True)
         logger.info("Deck stopped")
 
     async def wait_closed(self) -> None:
@@ -304,7 +303,7 @@ class Deck:
             loop = asyncio.get_running_loop()
             async with self._device_lock:
                 await loop.run_in_executor(
-                    self._executor, self._device.set_brightness, clamped
+                    get_executor(), self._device.set_brightness, clamped
                 )
         self._brightness = clamped
         await self.on_brightness_changed.emit(clamped)
@@ -438,7 +437,7 @@ class Deck:
                     )
                 async with self._device_lock:
                     await loop.run_in_executor(
-                        self._executor,
+                        get_executor(),
                         self._device.set_key_image,
                         key_index,
                         image_bytes,
@@ -483,7 +482,7 @@ class Deck:
             loop = asyncio.get_running_loop()
             async with self._device_lock:
                 await loop.run_in_executor(
-                    self._executor,
+                    get_executor(),
                     self._device.set_key_image,
                     key_index,
                     frame_bytes,
@@ -503,7 +502,7 @@ class Deck:
         loop = asyncio.get_running_loop()
         async with self._device_lock:
             await loop.run_in_executor(
-                self._executor,
+                get_executor(),
                 self._device.set_key_image,
                 key_index,
                 image_bytes,
@@ -580,7 +579,7 @@ class Deck:
                         loop = asyncio.get_running_loop()
                         async with self._device_lock:
                             await loop.run_in_executor(
-                                self._executor,
+                                get_executor(),
                                 self._device.set_touchscreen_image,
                                 out_bytes,
                                 x,
@@ -645,7 +644,7 @@ class Deck:
             loop = asyncio.get_running_loop()
             async with self._device_lock:
                 await loop.run_in_executor(
-                    self._executor,
+                    get_executor(),
                     self._device.set_touchscreen_image,
                     panel_bytes,
                     x_pos,
@@ -669,7 +668,7 @@ class Deck:
         loop = asyncio.get_running_loop()
         async with self._device_lock:
             await loop.run_in_executor(
-                self._executor,
+                get_executor(),
                 self._device.set_screen_image,
                 image_bytes,
                 0,

--- a/src/deux/runtime/discovery.py
+++ b/src/deux/runtime/discovery.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from StreamDeck.DeviceManager import DeviceManager
 
+from ._executor import get_executor
 from .device_info import DeviceInfo
 
 
@@ -37,40 +37,37 @@ async def list_devices(
         A list of :class:`DeviceInfo` for each discovered device.
     """
     loop = asyncio.get_running_loop()
-    executor = ThreadPoolExecutor(max_workers=2)
+    executor = get_executor()
 
-    try:
-        devices: list[Any] = await loop.run_in_executor(executor, DeviceManager().enumerate)
+    devices: list[Any] = await loop.run_in_executor(executor, DeviceManager().enumerate)
 
-        if visual_only:
-            devices = [d for d in devices if d.DECK_VISUAL]
+    if visual_only:
+        devices = [d for d in devices if d.DECK_VISUAL]
 
-        results: list[DeviceInfo] = []
-        for d in devices:
-            try:
-                await loop.run_in_executor(executor, d.open)
-                info = DeviceInfo(
-                    deck_type=d.deck_type(),
-                    serial=d.get_serial_number(),
-                    firmware=d.get_firmware_version(),
-                    key_count=d.key_count(),
-                    key_layout=d.key_layout(),
-                    encoder_count=d.dial_count(),
-                    key_pixel_size=(d.KEY_PIXEL_WIDTH, d.KEY_PIXEL_HEIGHT),
-                    touchscreen_size=(
-                        d.TOUCHSCREEN_PIXEL_WIDTH,
-                        d.TOUCHSCREEN_PIXEL_HEIGHT,
-                    ),
-                    key_image_format=d.KEY_IMAGE_FORMAT,
-                )
-                if deck_type is not None and info.deck_type != deck_type:
-                    await loop.run_in_executor(executor, d.close)
-                    continue
-                results.append(info)
+    results: list[DeviceInfo] = []
+    for d in devices:
+        try:
+            await loop.run_in_executor(executor, d.open)
+            info = DeviceInfo(
+                deck_type=d.deck_type(),
+                serial=d.get_serial_number(),
+                firmware=d.get_firmware_version(),
+                key_count=d.key_count(),
+                key_layout=d.key_layout(),
+                encoder_count=d.dial_count(),
+                key_pixel_size=(d.KEY_PIXEL_WIDTH, d.KEY_PIXEL_HEIGHT),
+                touchscreen_size=(
+                    d.TOUCHSCREEN_PIXEL_WIDTH,
+                    d.TOUCHSCREEN_PIXEL_HEIGHT,
+                ),
+                key_image_format=d.KEY_IMAGE_FORMAT,
+            )
+            if deck_type is not None and info.deck_type != deck_type:
                 await loop.run_in_executor(executor, d.close)
-            except Exception:
                 continue
+            results.append(info)
+            await loop.run_in_executor(executor, d.close)
+        except Exception:
+            continue
 
-        return results
-    finally:
-        executor.shutdown(wait=False)
+    return results

--- a/src/deux/runtime/manager.py
+++ b/src/deux/runtime/manager.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from StreamDeck.DeviceManager import DeviceManager
 
+from ._executor import get_executor, shutdown_executor
 from .deck import Deck, DeckError
 from .device_info import DeviceInfo
 
@@ -75,7 +75,6 @@ class DeckManager:
         self._auto_reconnect = auto_reconnect
         self._running = False
         self._closed_event = asyncio.Event()
-        self._executor = ThreadPoolExecutor(max_workers=2)
         self._scan_task: asyncio.Task[None] | None = None
 
         self._decks: dict[str, Deck] = {}
@@ -123,7 +122,7 @@ class DeckManager:
         self._decks.clear()
 
         self._closed_event.set()
-        self._executor.shutdown(wait=False)
+        shutdown_executor(wait=True)
         logger.info("DeckManager stopped")
 
     async def wait_closed(self) -> None:
@@ -227,7 +226,7 @@ class DeckManager:
 
         try:
             devices = await loop.run_in_executor(
-                self._executor, DeviceManager().enumerate
+                get_executor(), DeviceManager().enumerate
             )
         except Exception:
             logger.debug("Device enumeration failed")
@@ -250,11 +249,11 @@ class DeckManager:
                 connected_serials.add(managed_paths[dev_path])
                 continue
             try:
-                await loop.run_in_executor(self._executor, d.open)
+                await loop.run_in_executor(get_executor(), d.open)
                 serial = d.get_serial_number()
                 connected_serials.add(serial)
                 device_by_serial[serial] = d
-                await loop.run_in_executor(self._executor, d.close)
+                await loop.run_in_executor(get_executor(), d.close)
             except Exception:
                 dev_path = d.id()
                 if dev_path not in self._failed_probe_paths:

--- a/tests/test_shared_executor.py
+++ b/tests/test_shared_executor.py
@@ -1,0 +1,141 @@
+"""Tests for the shared executor module (issue #190).
+
+Verifies that a single shared executor is used across Deck, DeckManager,
+and discovery, and that shutdown uses ``wait=True`` for clean termination.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from deux.runtime._executor import get_executor, shutdown_executor
+from deux.runtime.deck import Deck
+from deux.runtime.manager import DeckManager
+
+
+class TestSharedExecutor:
+    """Shared executor singleton behaviour."""
+
+    def test_get_executor_returns_same_instance(self):
+        """Consecutive calls return the same pool."""
+        shutdown_executor(wait=True)
+        a = get_executor()
+        b = get_executor()
+        assert a is b
+        shutdown_executor(wait=True)
+
+    def test_get_executor_recreates_after_shutdown(self):
+        """A new pool is created after shutdown."""
+        shutdown_executor(wait=True)
+        a = get_executor()
+        shutdown_executor(wait=True)
+        b = get_executor()
+        assert a is not b
+        shutdown_executor(wait=True)
+
+    def test_shutdown_executor_is_idempotent(self):
+        """Calling shutdown when already shut down does not raise."""
+        shutdown_executor(wait=True)
+        shutdown_executor(wait=True)
+
+
+class TestDeckUsesSharedExecutor:
+    """Deck no longer creates its own ThreadPoolExecutor."""
+
+    def test_deck_has_no_private_executor(self):
+        """Deck instances must not carry a per-instance ``_executor``."""
+        d = Deck(serial_number="TEST")
+        assert not hasattr(d, "_executor")
+
+    async def test_deck_stop_calls_shutdown_wait_true(self, mock_streamdeck_device):
+        """stop() shuts down the shared executor with wait=True."""
+        d = Deck(serial_number="TEST123")
+        with patch("deux.runtime.deck.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = [mock_streamdeck_device]
+            await d.start()
+
+        with patch("deux.runtime.deck.shutdown_executor") as mock_shutdown:
+            await d.stop()
+            mock_shutdown.assert_called_once_with(wait=True)
+
+
+class TestDeckManagerUsesSharedExecutor:
+    """DeckManager no longer creates its own ThreadPoolExecutor."""
+
+    def test_manager_has_no_private_executor(self):
+        """DeckManager instances must not carry a per-instance ``_executor``."""
+        m = DeckManager()
+        assert not hasattr(m, "_executor")
+
+    async def test_manager_stop_calls_shutdown_wait_true(self):
+        """stop() shuts down the shared executor with wait=True."""
+        m = DeckManager(poll_interval=0.05)
+
+        with patch("deux.runtime.manager.DeviceManager") as mock_dm:
+            mock_dm.return_value.enumerate.return_value = []
+            await m.start()
+
+        with patch("deux.runtime.manager.shutdown_executor") as mock_shutdown:
+            await m.stop()
+            mock_shutdown.assert_called_once_with(wait=True)
+
+
+class TestMultiDeckThreadLeak:
+    """Verify no thread leak when multiple decks are started and stopped."""
+
+    async def test_no_thread_leak_on_multi_deck_stop(self, mock_streamdeck_device):
+        """Starting and stopping 4 decks must not leak worker threads.
+
+        Before the fix each Deck created its own 2-worker pool, leaving
+        abandoned threads on ``stop()``.  Now they all share one pool
+        which is cleanly shut down with ``wait=True``.
+        """
+        baseline = threading.active_count()
+
+        decks: list[Deck] = []
+        for i in range(4):
+            dev = MagicMock()
+            dev.DECK_VISUAL = True
+            dev.DECK_TOUCH = True
+            dev.DECK_TYPE = "Stream Deck +"
+            dev.KEY_PIXEL_WIDTH = 120
+            dev.KEY_PIXEL_HEIGHT = 120
+            dev.KEY_IMAGE_FORMAT = "JPEG"
+            dev.KEY_FLIP = [False, False]
+            dev.KEY_ROTATION = 0
+            dev.TOUCHSCREEN_PIXEL_WIDTH = 800
+            dev.TOUCHSCREEN_PIXEL_HEIGHT = 100
+            dev.TOUCHSCREEN_IMAGE_FORMAT = "JPEG"
+            dev.TOUCHSCREEN_FLIP = [False, False]
+            dev.TOUCHSCREEN_ROTATION = 0
+            dev.SCREEN_PIXEL_WIDTH = 0
+            dev.SCREEN_PIXEL_HEIGHT = 0
+            dev.SCREEN_IMAGE_FORMAT = ""
+            dev.SCREEN_FLIP = [False, False]
+            dev.SCREEN_ROTATION = 0
+            dev.TOUCH_KEY_COUNT = 0
+            serial = f"LEAK_TEST_{i}"
+            dev.get_serial_number.return_value = serial
+            dev.get_firmware_version.return_value = "1.0.0"
+            dev.deck_type.return_value = "Stream Deck +"
+            dev.key_count.return_value = 8
+            dev.key_layout.return_value = (4, 2)
+            dev.dial_count.return_value = 4
+            dev.id.return_value = f"/dev/hid/{serial}"
+
+            d = Deck(serial_number=serial)
+            with patch("deux.runtime.deck.DeviceManager") as dm:
+                dm.return_value.enumerate.return_value = [dev]
+                await d.start()
+            decks.append(d)
+
+        for d in decks:
+            await d.stop()
+
+        after = threading.active_count()
+        # After stopping all decks the thread count must not exceed
+        # the baseline (tolerance of 1 for asyncio internal threads).
+        assert after <= baseline + 1, (
+            f"Thread leak detected: {after - baseline} extra threads after stopping 4 decks"
+        )


### PR DESCRIPTION
## Summary

Replaces per-instance `ThreadPoolExecutor` in `Deck`, `DeckManager`, and `list_devices` with a single shared module-level executor via `get_executor()`/`shutdown_executor()` in `src/deux/runtime/_executor.py`.

## Changes

- **`_executor.py`** (new): Shared lazy-init executor with `get_executor()` and `shutdown_executor(wait=True)`
- **`deck.py`**: Removed per-instance `ThreadPoolExecutor`; uses shared executor
- **`manager.py`**: Removed per-instance `ThreadPoolExecutor`; uses shared executor  
- **`discovery.py`**: Removed local `ThreadPoolExecutor`; uses shared executor
- **`__init__.py`**: Exports `get_executor` and `shutdown_executor`

## Key Fixes

- **Thread waste**: Was 2 threads per Deck + 2 per Manager (10+ threads for 4 decks). Now max 4 shared.
- **Unsafe shutdown**: Changed `shutdown(wait=False)` → `shutdown(wait=True)` to prevent abandoned threads holding HID locks.
- **Auto-recreate**: Executor lazily recreates after shutdown for reuse across start/stop cycles.

## Acceptance Criteria

- [x] Only one executor exists (shared module-level)
- [x] `shutdown(wait=True)` used on cleanup
- [x] Multi-deck tests verify no thread leak on stop
- [x] No regression in stop/disconnect latency
- [x] All 1611 tests pass, 97% coverage, ruff + mypy clean

Closes #190