### PR TITLE
fix: await DialAccumulator flush task on cancel and replacement

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -728,6 +728,6 @@ class DuiCard(Card):
             await self._animator.stop()
             self._animator = None
 
-    def cleanup(self) -> None:
+    async def cleanup(self) -> None:
         """Cancel pending accumulators and release resources."""
-        self._events.cancel_accumulators()
+        await self._events.cancel_accumulators()

--- a/src/deux/dui/event_map.py
+++ b/src/deux/dui/event_map.py
@@ -165,10 +165,10 @@ class EventMap:
             self._hold_task.cancel()
             self._hold_task = None
 
-    def cancel_accumulators(self) -> None:
+    async def cancel_accumulators(self) -> None:
         """Cancel all active dial accumulators and discard pending ticks."""
         for acc in self._accumulators.values():
-            acc.cancel()
+            await acc.cancel()
 
     def handle_encoder_turn(self, direction: int) -> AsyncHandler | None:
         """Match an encoder turn to a semantic event.

--- a/src/deux/ui/controls/dial_accumulator.py
+++ b/src/deux/ui/controls/dial_accumulator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 
@@ -51,15 +52,29 @@ class DialAccumulator:
         self._flush_task: asyncio.Task[None] | None = None
 
     def tick(self, direction: int) -> None:
-        """Add *direction* (+1 or -1). Clamps to ±max_steps."""
+        """Add *direction* (+1 or -1). Clamps to ±max_steps.
+
+        Cancels and awaits any previously scheduled flush task before
+        creating a new one, preventing orphaned task accumulation.
+        """
         logger.debug("DialAccumulator.tick: direction=%+d pending=%d", direction, self._pending)
         self._pending = max(-self._max_steps, min(self._max_steps, self._pending + direction))
-        if self._flush_task is not None:
-            self._flush_task.cancel()
-        self._flush_task = asyncio.create_task(self._schedule_flush())
+        old_task = self._flush_task
+        self._flush_task = asyncio.create_task(self._schedule_flush(old_task))
 
-    async def _schedule_flush(self) -> None:
-        """Wait for the debounce delay, then flush accumulated ticks."""
+    async def _schedule_flush(self, old_task: asyncio.Task[None] | None) -> None:
+        """Wait for the debounce delay, then flush accumulated ticks.
+
+        Parameters
+        ----------
+        old_task : asyncio.Task[None] | None
+            The previously scheduled flush task to cancel and await
+            before starting the new debounce timer.
+        """
+        if old_task is not None:
+            old_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await old_task
         try:
             logger.debug("DialAccumulator._schedule_flush: waiting %.2fs", self._delay)
             await asyncio.sleep(self._delay)
@@ -77,10 +92,16 @@ class DialAccumulator:
             return
         await self._callback(steps)
 
-    def cancel(self) -> None:
-        """Cancel any pending flush and reset the accumulated count."""
+    async def cancel(self) -> None:
+        """Cancel any pending flush and reset the accumulated count.
+
+        Awaits the task's cancellation to ensure the flush handler has
+        fully stopped before returning.
+        """
         if self._flush_task is not None:
             self._flush_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._flush_task
             self._flush_task = None
         self._pending = 0
         logger.debug("DialAccumulator.cancel: reset")

--- a/tests/test_dial_accumulator.py
+++ b/tests/test_dial_accumulator.py
@@ -145,7 +145,7 @@ class TestDialAccumulatorCancel:
 
         acc = DialAccumulator(cb, delay=0.05)
         acc.tick(1)
-        acc.cancel()
+        await acc.cancel()
         await asyncio.sleep(0.1)
         assert results == []
 
@@ -158,7 +158,7 @@ class TestDialAccumulatorCancel:
         acc = DialAccumulator(cb, delay=0.05)
         acc.tick(1)
         acc.tick(1)
-        acc.cancel()
+        await acc.cancel()
         # New tick after cancel should only have its own value
         acc.tick(-1)
         await asyncio.sleep(0.1)
@@ -169,4 +169,37 @@ class TestDialAccumulatorCancel:
             pass
 
         acc = DialAccumulator(cb, delay=0.05)
-        acc.cancel()  # should not raise
+        await acc.cancel()  # should not raise
+
+    async def test_cancel_awaits_task_completion(self) -> None:
+        """cancel() awaits the task's cancellation — no orphaned tasks."""
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        acc.tick(1)
+        await acc.cancel()
+        # After cancel returns, the flush task must be done
+        assert acc._flush_task is None
+        # Ensure no lingering tasks fire
+        await asyncio.sleep(0.1)
+        assert results == []
+
+    async def test_rapid_ticks_no_orphaned_tasks(self) -> None:
+        """Rapid tick() calls do not accumulate orphaned tasks."""
+        results: list[int] = []
+
+        async def cb(steps: int) -> None:
+            results.append(steps)
+
+        acc = DialAccumulator(cb, delay=0.05)
+        # Fire many rapid ticks
+        for _ in range(50):
+            acc.tick(1)
+        # Only one flush task should be active
+        assert acc._flush_task is not None
+        await asyncio.sleep(0.1)
+        # Should flush exactly once with clamped value (default max_steps=10)
+        assert results == [10]

--- a/tests/test_dui_event_map.py
+++ b/tests/test_dui_event_map.py
@@ -1019,7 +1019,7 @@ class TestAccumulatedTurns:
         em.on("vol_up", handler)
 
         em.handle_encoder_turn(1)
-        em.cancel_accumulators()
+        await em.cancel_accumulators()
 
         await asyncio.sleep(0.1)
         handler.assert_not_awaited()

--- a/tests/test_encoder_slot.py
+++ b/tests/test_encoder_slot.py
@@ -93,7 +93,7 @@ class TestEncoderSlotOnTurnAccumulated:
 
         await encoder.dispatch_turn(1)
         assert isinstance(handle, DialAccumulator)
-        handle.cancel()
+        await handle.cancel()
         await asyncio.sleep(0.1)
         assert results == []
 
@@ -247,7 +247,7 @@ class TestEncoderSlotOnPressTurnAccumulated:
         await encoder.dispatch_press(True)
         await encoder.dispatch_turn(1)
         assert isinstance(handle, DialAccumulator)
-        handle.cancel()
+        await handle.cancel()
         await asyncio.sleep(0.1)
         assert results == []
 


### PR DESCRIPTION
Fixes #192

## Changes

- **`cancel()` is now async** and awaits the flush task's cancellation before returning, ensuring the handler has fully stopped.
- **`tick()` passes the old task** to `_schedule_flush()`, which cancels and awaits it before starting the new debounce timer — preventing orphaned task accumulation.
- Updated call sites in `event_map.py`, `card.py`, and tests for the async `cancel()`.
- Added tests verifying clean cancellation and no orphaned tasks under rapid `tick()` calls.

All tests pass (1613 passed), coverage at 97%, ruff and mypy clean.