### PR TITLE
fix: wrap HID write calls with asyncio.wait_for timeout

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -37,6 +37,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Timeout in seconds for HID write calls dispatched to the executor.
+#: If a call blocks longer than this (e.g. USB suspend), the device is
+#: treated as potentially disconnected.
+_HID_WRITE_TIMEOUT: float = 2.0
+
+
+class HidWriteTimeout(Exception):
+    """Raised when a HID write exceeds :data:`_HID_WRITE_TIMEOUT`."""
+
 
 class DeckError(Exception):
     """Raised for deck-level errors."""
@@ -131,10 +140,8 @@ class Deck:
             )
         self._device = target
 
-        await loop.run_in_executor(get_executor(), self._device.reset)
-        await loop.run_in_executor(
-            get_executor(), self._device.set_brightness, self._brightness
-        )
+        await self._exec_device_io(self._device.reset)
+        await self._exec_device_io(self._device.set_brightness, self._brightness)
 
         self._caps = DeviceCapabilities.from_device(self._device)
         self._metrics = RenderMetrics(self._caps)
@@ -174,11 +181,10 @@ class Deck:
                 await self._event_task
 
         if self._device:
-            loop = asyncio.get_running_loop()
             try:
-                await loop.run_in_executor(get_executor(), self._device.reset)
-                await loop.run_in_executor(get_executor(), self._device.close)
-            except Exception as e:
+                await self._exec_device_io(self._device.reset)
+                await self._exec_device_io(self._device.close)
+            except (HidWriteTimeout, Exception) as e:
                 logger.warning("Error closing device: %s", e)
 
         self._closed_event.set()
@@ -188,6 +194,38 @@ class Deck:
     async def wait_closed(self) -> None:
         """Block until the deck is closed (e.g. by stop() or disconnect)."""
         await self._closed_event.wait()
+
+    async def _exec_device_io(self, func: Any, *args: Any) -> None:
+        """Run a device I/O call in the executor with a timeout.
+
+        Parameters
+        ----------
+        func
+            The blocking HID function to call (e.g.
+            ``self._device.set_key_image``).
+        *args
+            Positional arguments forwarded to *func*.
+
+        Raises
+        ------
+        HidWriteTimeout
+            If the call does not complete within
+            :data:`_HID_WRITE_TIMEOUT` seconds.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            await asyncio.wait_for(
+                loop.run_in_executor(get_executor(), func, *args),
+                timeout=_HID_WRITE_TIMEOUT,
+            )
+        except TimeoutError:
+            logger.error(
+                "HID write timed out after %.1fs — device may be disconnected",
+                _HID_WRITE_TIMEOUT,
+            )
+            raise HidWriteTimeout(
+                f"HID write to {func!r} timed out after {_HID_WRITE_TIMEOUT}s"
+            ) from None
 
     @property
     def device_path(self) -> str | None:
@@ -302,11 +340,8 @@ class Deck:
         if clamped == self._brightness:
             return
         if self._device is not None:
-            loop = asyncio.get_running_loop()
             async with self._device_lock:
-                await loop.run_in_executor(
-                    get_executor(), self._device.set_brightness, clamped
-                )
+                await self._exec_device_io(self._device.set_brightness, clamped)
         self._brightness = clamped
         await self.on_brightness_changed.emit(clamped)
 
@@ -418,7 +453,6 @@ class Deck:
         if caps is None:
             return
 
-        loop = asyncio.get_running_loop()
         metrics = self._metrics
 
         if metrics is None:
@@ -438,8 +472,7 @@ class Deck:
                         image_format=caps.key_image_format,
                     )
                 async with self._device_lock:
-                    await loop.run_in_executor(
-                        get_executor(),
+                    await self._exec_device_io(
                         self._device.set_key_image,
                         key_index,
                         image_bytes,
@@ -481,10 +514,8 @@ class Deck:
         # Re-wire push_fn every render so a DuiKey reused across screens
         # always animates at the slot of the currently active screen.
         async def _push_key_frame(frame_bytes: bytes) -> None:
-            loop = asyncio.get_running_loop()
             async with self._device_lock:
-                await loop.run_in_executor(
-                    get_executor(),
+                await self._exec_device_io(
                     self._device.set_key_image,
                     key_index,
                     frame_bytes,
@@ -501,10 +532,8 @@ class Deck:
         )
         dui_key.set_rendered_image(image_bytes)
 
-        loop = asyncio.get_running_loop()
         async with self._device_lock:
-            await loop.run_in_executor(
-                get_executor(),
+            await self._exec_device_io(
                 self._device.set_key_image,
                 key_index,
                 image_bytes,
@@ -578,10 +607,8 @@ class Deck:
                             )
                         else:
                             out_bytes = frame_bytes
-                        loop = asyncio.get_running_loop()
                         async with self._device_lock:
-                            await loop.run_in_executor(
-                                get_executor(),
+                            await self._exec_device_io(
                                 self._device.set_touchscreen_image,
                                 out_bytes,
                                 x,
@@ -643,10 +670,8 @@ class Deck:
                 )
 
             # Push per-panel update
-            loop = asyncio.get_running_loop()
             async with self._device_lock:
-                await loop.run_in_executor(
-                    get_executor(),
+                await self._exec_device_io(
                     self._device.set_touchscreen_image,
                     panel_bytes,
                     x_pos,
@@ -667,10 +692,8 @@ class Deck:
 
         image_bytes = info.render_bytes()
 
-        loop = asyncio.get_running_loop()
         async with self._device_lock:
-            await loop.run_in_executor(
-                get_executor(),
+            await self._exec_device_io(
                 self._device.set_screen_image,
                 image_bytes,
                 0,

--- a/src/deux/tools/preview.py
+++ b/src/deux/tools/preview.py
@@ -46,6 +46,7 @@ from PIL import Image
 from deux.render.key_renderer import _encode_image
 from deux.render.svg_rasterize import _svg_to_png, list_svg_backends, set_svg_backend
 from deux.runtime.capabilities import DeviceCapabilities
+from deux.runtime.deck import _HID_WRITE_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -454,10 +455,13 @@ async def push_to_device(
         )
 
         brightness = max(0, min(100, args.brightness))
-        await loop.run_in_executor(
-            None,
-            deck.set_brightness,
-            brightness,
+        await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                deck.set_brightness,
+                brightness,
+            ),
+            timeout=_HID_WRITE_TIMEOUT,
         )
 
         key_images, touchstrip_bytes = render_preview(args, caps)
@@ -465,22 +469,28 @@ async def push_to_device(
         for key_index in range(caps.key_count):
             jpeg = key_images.get(key_index)
             if jpeg is not None:
-                await loop.run_in_executor(
-                    None,
-                    deck.set_key_image,
-                    key_index,
-                    jpeg,
+                await asyncio.wait_for(
+                    loop.run_in_executor(
+                        None,
+                        deck.set_key_image,
+                        key_index,
+                        jpeg,
+                    ),
+                    timeout=_HID_WRITE_TIMEOUT,
                 )
 
         if caps.has_touchscreen:
-            await loop.run_in_executor(
-                None,
-                deck.set_touchscreen_image,
-                touchstrip_bytes,
-                0,
-                0,
-                caps.touchscreen_width,
-                caps.touchscreen_height,
+            await asyncio.wait_for(
+                loop.run_in_executor(
+                    None,
+                    deck.set_touchscreen_image,
+                    touchstrip_bytes,
+                    0,
+                    0,
+                    caps.touchscreen_width,
+                    caps.touchscreen_height,
+                ),
+                timeout=_HID_WRITE_TIMEOUT,
             )
 
         if args.watch:
@@ -493,8 +503,12 @@ async def push_to_device(
             print("Preview pushed — press Ctrl+C to exit", file=sys.stderr)  # noqa: T201
             await _wait_for_interrupt()
     finally:
-        await loop.run_in_executor(None, deck.reset)
-        await loop.run_in_executor(None, deck.close)
+        await asyncio.wait_for(
+            loop.run_in_executor(None, deck.reset), timeout=_HID_WRITE_TIMEOUT
+        )
+        await asyncio.wait_for(
+            loop.run_in_executor(None, deck.close), timeout=_HID_WRITE_TIMEOUT
+        )
 
 
 async def _wait_for_interrupt() -> None:
@@ -595,22 +609,28 @@ async def _watch_and_reload(
                 for key_index in range(caps.key_count):
                     jpeg = key_images.get(key_index)
                     if jpeg is not None:
-                        await loop.run_in_executor(
-                            None,
-                            deck.set_key_image,
-                            key_index,
-                            jpeg,
+                        await asyncio.wait_for(
+                            loop.run_in_executor(
+                                None,
+                                deck.set_key_image,
+                                key_index,
+                                jpeg,
+                            ),
+                            timeout=_HID_WRITE_TIMEOUT,
                         )
 
                 if caps.has_touchscreen:
-                    await loop.run_in_executor(
-                        None,
-                        deck.set_touchscreen_image,
-                        touchstrip_bytes,
-                        0,
-                        0,
-                        caps.touchscreen_width,
-                        caps.touchscreen_height,
+                    await asyncio.wait_for(
+                        loop.run_in_executor(
+                            None,
+                            deck.set_touchscreen_image,
+                            touchstrip_bytes,
+                            0,
+                            0,
+                            caps.touchscreen_width,
+                            caps.touchscreen_height,
+                        ),
+                        timeout=_HID_WRITE_TIMEOUT,
                     )
                 _ = panel_width  # carried for symmetry; geometry comes from caps
                 print("Preview updated", file=sys.stderr)  # noqa: T201

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1054,3 +1054,52 @@ class TestDeckRenderCrossScreen:
         frame_b = _make_jpeg_frame(metrics.panel_width, metrics.panel_height)
         await push_fn(frame_b)
         assert mock_streamdeck_device.set_touchscreen_image.call_args.args[1] == expected_x(3)
+
+
+class TestHidWriteTimeout:
+    """Tests for HID write timeout behaviour (issue #197)."""
+
+    async def test_set_key_image_timeout_raises(self, deck, mock_streamdeck_device):
+        """A hanging set_key_image call raises HidWriteTimeout."""
+        from deux.runtime.deck import _HID_WRITE_TIMEOUT, HidWriteTimeout
+
+        # Make the mock block longer than the timeout
+        async def _block_forever():
+            await asyncio.sleep(_HID_WRITE_TIMEOUT + 10)
+
+        def _blocking_set_key_image(*args):
+            import time
+
+            time.sleep(_HID_WRITE_TIMEOUT + 10)
+
+        mock_streamdeck_device.set_key_image = _blocking_set_key_image
+        deck._device = mock_streamdeck_device
+
+        with patch("deux.runtime.deck._HID_WRITE_TIMEOUT", 0.05), pytest.raises(HidWriteTimeout):
+                await deck._exec_device_io(
+                    mock_streamdeck_device.set_key_image, 0, b"fake"
+                )
+
+    async def test_set_brightness_timeout_logs_and_raises(self, deck, mock_streamdeck_device):
+        """A hanging set_brightness call raises HidWriteTimeout."""
+        import time
+
+        from deux.runtime.deck import HidWriteTimeout
+
+        def _hang(*args):
+            time.sleep(10)
+
+        mock_streamdeck_device.set_brightness = _hang
+        deck._device = mock_streamdeck_device
+
+        with patch("deux.runtime.deck._HID_WRITE_TIMEOUT", 0.05), pytest.raises(HidWriteTimeout):
+                await deck._exec_device_io(mock_streamdeck_device.set_brightness, 50)
+
+    async def test_successful_call_no_timeout(self, deck, mock_streamdeck_device):
+        """Normal fast calls complete without raising."""
+        mock_streamdeck_device.set_key_image = MagicMock()
+        deck._device = mock_streamdeck_device
+
+        # Should not raise
+        await deck._exec_device_io(mock_streamdeck_device.set_key_image, 0, b"data")
+        mock_streamdeck_device.set_key_image.assert_called_once_with(0, b"data")


### PR DESCRIPTION
## Summary

Wraps all HID device I/O executor calls (`set_key_image`, `set_touchscreen_image`, `set_screen_image`, `set_brightness`, `reset`, `close`) with `asyncio.wait_for(..., timeout=2.0)`.

If a call blocks beyond the timeout (e.g. USB suspend), a `HidWriteTimeout` exception is raised and the failure is logged, treating the device as potentially disconnected.

## Changes

- **`src/deux/runtime/deck.py`**: Added `_HID_WRITE_TIMEOUT` constant (2.0s), `HidWriteTimeout` exception, and `_exec_device_io()` helper method. Replaced all `run_in_executor` device I/O calls with the timeout-wrapped helper.
- **`src/deux/tools/preview.py`**: Wrapped preview device I/O calls with `asyncio.wait_for` using the shared timeout constant.
- **`tests/test_deck.py`**: Added `TestHidWriteTimeout` class with tests verifying timeout raises, and normal calls succeed.

## Acceptance Criteria

- [x] All HID write calls wrapped in `asyncio.wait_for` with 2s timeout
- [x] `TimeoutError` handled gracefully (logged, raises `HidWriteTimeout`)
- [x] Test simulates hanging HID call and verifies timeout behavior
- [x] All existing tests pass (1616 passed, 97% coverage)

Closes #197