### PR TITLE
Cache path-to-serial mapping in _scan_once to avoid redundant HID open/close

### DIFF
--- a/src/deux/runtime/manager.py
+++ b/src/deux/runtime/manager.py
@@ -79,6 +79,7 @@ class DeckManager:
 
         self._decks: dict[str, Deck] = {}
         self._failed_probe_paths: set[str] = set()
+        self._path_serial_cache: dict[str, str] = {}
 
         self._connect_handlers: list[tuple[dict[str, str | None], AsyncHandler]] = []
         self._disconnect_handler: AsyncHandler | None = None
@@ -243,16 +244,24 @@ class DeckManager:
         connected_serials: set[str] = set()
         device_by_serial: dict[str, Any] = {}
 
+        current_paths: set[str] = set()
         for d in visual:
             dev_path = d.id()
+            current_paths.add(dev_path)
             if dev_path in managed_paths:
                 connected_serials.add(managed_paths[dev_path])
+                continue
+            if dev_path in self._path_serial_cache:
+                serial = self._path_serial_cache[dev_path]
+                connected_serials.add(serial)
+                device_by_serial[serial] = d
                 continue
             try:
                 await loop.run_in_executor(get_executor(), d.open)
                 serial = d.get_serial_number()
                 connected_serials.add(serial)
                 device_by_serial[serial] = d
+                self._path_serial_cache[dev_path] = serial
                 await loop.run_in_executor(get_executor(), d.close)
             except Exception:
                 dev_path = d.id()
@@ -266,6 +275,12 @@ class DeckManager:
                         "Failed to probe device at %s", dev_path, exc_info=True
                     )
                 continue
+
+        # Invalidate cache for disconnected paths
+        stale_paths = set(self._path_serial_cache) - current_paths
+        for path in stale_paths:
+            del self._path_serial_cache[path]
+            self._failed_probe_paths.discard(path)
 
         for serial in list(self._decks):
             if serial not in connected_serials:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -472,3 +472,60 @@ class TestDeckManagerReconnect:
             await m._scan_once()
 
         assert "DISC_ERR" not in m._decks
+
+
+class TestPathSerialCache:
+    """Tests for path-to-serial caching in _scan_once."""
+
+    async def test_cache_avoids_repeated_open_close(self):
+        """Second scan uses cached serial, no additional open/close for probe."""
+        m = DeckManager(poll_interval=10.0)
+        # No connect handler — device won't become managed, so we can
+        # isolate the probe open/close behavior.
+
+        dev = _make_raw_device(serial="CACHE1")
+
+        with patch("deux.runtime.manager.DeviceManager") as mgr_dm:
+            mgr_dm.return_value.enumerate.return_value = [dev]
+            await m._scan_once()
+
+        assert dev.open.call_count == 1
+        assert dev.close.call_count == 1
+        assert m._path_serial_cache["/dev/hid/CACHE1"] == "CACHE1"
+
+        # Reset and scan again — should use cache, no open/close
+        dev.open.reset_mock()
+        dev.close.reset_mock()
+        dev.get_serial_number.reset_mock()
+
+        with patch("deux.runtime.manager.DeviceManager") as mgr_dm:
+            mgr_dm.return_value.enumerate.return_value = [dev]
+            await m._scan_once()
+
+        assert dev.open.call_count == 0
+        assert dev.close.call_count == 0
+        assert dev.get_serial_number.call_count == 0
+
+    async def test_cache_invalidated_on_disconnect(self):
+        """Cache entry removed when device path disappears."""
+        m = DeckManager(poll_interval=10.0)
+        m._path_serial_cache["/dev/hid/GONE"] = "GONE_SERIAL"
+
+        with patch("deux.runtime.manager.DeviceManager") as mgr_dm:
+            mgr_dm.return_value.enumerate.return_value = []
+            await m._scan_once()
+
+        assert "/dev/hid/GONE" not in m._path_serial_cache
+
+    async def test_cache_not_populated_on_probe_failure(self):
+        """Failed probe does not add entry to cache."""
+        m = DeckManager(poll_interval=10.0)
+
+        dev = _make_raw_device(serial="FAIL1")
+        dev.open.side_effect = OSError("USB busy")
+
+        with patch("deux.runtime.manager.DeviceManager") as mgr_dm:
+            mgr_dm.return_value.enumerate.return_value = [dev]
+            await m._scan_once()
+
+        assert "/dev/hid/FAIL1" not in m._path_serial_cache


### PR DESCRIPTION
Fixes #202

## Changes

- Add `_path_serial_cache` dict to `DeckManager` storing path→serial after first successful probe
- Skip open/get_serial_number/close on subsequent scan cycles when path is already cached
- Invalidate cache entries when device paths disappear (device disconnect)
- Add tests verifying reduced HID I/O calls and cache invalidation on disconnect

## Impact

Eliminates unnecessary HID open/close on every 2-second poll cycle for already-probed devices. On a single-deck setup this removes ~30 redundant USB transactions per minute.