### PR TITLE
fix: implement on_detach lifecycle to unsubscribe AsyncEvent handlers (#205)

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import xml.etree.ElementTree as ET
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from ..ui.cards.base import Card
@@ -74,6 +75,7 @@ class DuiCard(Card):
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events, spec.regions)
+        self._subscriptions: list[tuple[AsyncEvent, AsyncHandler]] = []
         self._busy = False
         self._animator: SpinnerAnimator | None = None
         self._spinner_frames: SpinnerFrames | None = None
@@ -422,8 +424,8 @@ class DuiCard(Card):
         callable is invoked with all event ``args``/``kwargs`` and its
         return value becomes the binding value.
 
-        The subscriber lives for the lifetime of the card -- there is
-        no automatic teardown.  Bind once during construction or
+        The subscriber lives for the lifetime of the card unless
+        :meth:`detach` is called.  Bind once during construction or
         :meth:`on_attach`-style lifecycle hooks.
 
         Parameters
@@ -454,6 +456,7 @@ class DuiCard(Card):
                 await self.request_refresh()
 
         event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
         return self
 
     def bind_range(
@@ -510,6 +513,7 @@ class DuiCard(Card):
                 await self.request_refresh()
 
         event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
         return self
 
     def bind_many(
@@ -545,7 +549,20 @@ class DuiCard(Card):
                 await self.request_refresh()
 
         event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
         return self
+
+    def detach(self) -> None:
+        """Unsubscribe all handlers registered via :meth:`bind` and friends.
+
+        Call this during teardown (e.g. from
+        :meth:`~deux.ui.controller.CardController.on_detach`) to prevent
+        leaked handlers accumulating across reconnect cycles.
+        """
+        for event, handler in self._subscriptions:
+            with suppress(ValueError):
+                event.unsubscribe(handler)
+        self._subscriptions.clear()
 
     def forward(
         self,

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from ..ui.controls.key_slot import KeySlot
@@ -72,6 +73,7 @@ class DuiKey(KeySlot):
         self._spec = spec
         self._renderer = SvgRenderer(spec)
         self._events = EventMap(spec.events)
+        self._subscriptions: list[tuple[AsyncEvent, AsyncHandler]] = []
         self._dirty = True
         self._busy = False
         self._animator: SpinnerAnimator | None = None
@@ -374,6 +376,7 @@ class DuiKey(KeySlot):
                 await self.request_refresh()
 
         event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
         return self
 
     def bind_range(
@@ -428,6 +431,7 @@ class DuiKey(KeySlot):
                 await self.request_refresh()
 
         event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
         return self
 
     def bind_many(
@@ -461,7 +465,20 @@ class DuiKey(KeySlot):
                 await self.request_refresh()
 
         event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
         return self
+
+    def detach(self) -> None:
+        """Unsubscribe all handlers registered via :meth:`bind` and friends.
+
+        Call this during teardown (e.g. from
+        :meth:`~deux.ui.controller.KeyController.on_detach`) to prevent
+        leaked handlers accumulating across reconnect cycles.
+        """
+        for event, handler in self._subscriptions:
+            with suppress(ValueError):
+                event.unsubscribe(handler)
+        self._subscriptions.clear()
 
     def forward(
         self,

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -172,6 +172,8 @@ class Deck:
 
         self._running = False
 
+        self._detach_all_cards()
+
         if self._transport:
             self._transport.stop()
 
@@ -190,6 +192,20 @@ class Deck:
         self._closed_event.set()
         shutdown_executor(wait=True)
         logger.info("Deck stopped")
+
+    def _detach_all_cards(self) -> None:
+        """Unsubscribe all AsyncEvent handlers on every DuiCard across all screens.
+
+        Prevents handler accumulation across reconnect cycles.
+        """
+        from ..dui.card import DuiCard
+
+        for screen in self._screens.values():
+            if screen.touch_strip is None:
+                continue
+            for card in screen.touch_strip.cards:
+                if isinstance(card, DuiCard):
+                    card.detach()
 
     async def wait_closed(self) -> None:
         """Block until the deck is closed (e.g. by stop() or disconnect)."""

--- a/src/deux/ui/controller.py
+++ b/src/deux/ui/controller.py
@@ -92,9 +92,15 @@ class CardController:
     async def on_detach(self) -> None:
         """Hook invoked from the app's ``on_disconnect`` callback.
 
-        Default implementation is a no-op.  Override to cancel
-        background tasks or release deck-linked resources.
+        The default implementation calls :meth:`~deux.DuiCard.detach`
+        to unsubscribe all ``AsyncEvent`` handlers wired via
+        :meth:`~deux.DuiCard.bind`, :meth:`~deux.DuiCard.bind_range`,
+        or :meth:`~deux.DuiCard.bind_many`.  Override to add additional
+        teardown logic, but call ``await super().on_detach()`` to
+        preserve the unsubscription behaviour.
         """
+        if hasattr(self, "card"):
+            self.card.detach()
 
 
 class KeyController:
@@ -128,5 +134,12 @@ class KeyController:
     async def on_detach(self) -> None:
         """Hook invoked from the app's ``on_disconnect`` callback.
 
-        Default implementation is a no-op.
+        The default implementation calls :meth:`~deux.DuiKey.detach`
+        to unsubscribe all ``AsyncEvent`` handlers wired via
+        :meth:`~deux.DuiKey.bind`, :meth:`~deux.DuiKey.bind_range`,
+        or :meth:`~deux.DuiKey.bind_many`.  Override to add additional
+        teardown logic, but call ``await super().on_detach()`` to
+        preserve the unsubscription behaviour.
         """
+        if hasattr(self, "key"):
+            self.key.detach()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -11,6 +11,7 @@ from deux.dui.schema import (
     PackageType,
     TextBinding,
 )
+from deux.runtime.async_event import AsyncEvent
 from deux.ui.controller import CardController, KeyController
 
 _CARD_SVG = (
@@ -57,6 +58,16 @@ class TestCardController:
         controller.card = DuiCard(_card_spec())
         await controller.on_detach()
 
+    async def test_on_detach_unsubscribes_bound_events(self):
+        """Default on_detach calls card.detach(), removing event handlers."""
+        controller = CardController()
+        controller.card = DuiCard(_card_spec())
+        event = AsyncEvent()
+        controller.card.bind("title", event)
+        assert event.subscriber_count == 1
+        await controller.on_detach()
+        assert event.subscriber_count == 0
+
     async def test_subclass_can_override_lifecycle(self):
         attached: list[object] = []
         detached: list[bool] = []
@@ -99,6 +110,16 @@ class TestKeyController:
         controller = KeyController()
         controller.key = DuiKey(_key_spec())
         await controller.on_detach()
+
+    async def test_on_detach_unsubscribes_bound_events(self):
+        """Default on_detach calls key.detach(), removing event handlers."""
+        controller = KeyController()
+        controller.key = DuiKey(_key_spec())
+        event = AsyncEvent()
+        controller.key.bind("label", event)
+        assert event.subscriber_count == 1
+        await controller.on_detach()
+        assert event.subscriber_count == 0
 
     async def test_subclass_can_override_lifecycle(self):
         attached: list[object] = []

--- a/tests/test_dui_bind.py
+++ b/tests/test_dui_bind.py
@@ -614,3 +614,108 @@ class TestDuiCardBindCssClass:
         await event.emit("active")
         await event.emit("")
         assert card.get("style") == ""
+
+
+# ---------------------------------------------------------------------------
+# Detach lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestDuiCardDetach:
+    """Verify that DuiCard.detach() unsubscribes all handlers."""
+
+    def _card(self) -> DuiCard:
+        spec = _card_spec(
+            bindings={
+                "title": TextBinding(node="title", default=""),
+                "bar": RangeBinding(node="bar", default=0.0),
+            }
+        )
+        return DuiCard(spec)
+
+    async def test_detach_removes_bind_handler(self):
+        """After detach(), the event's subscriber count drops to zero."""
+        card = self._card()
+        event = AsyncEvent()
+        card.bind("title", event)
+        assert event.subscriber_count == 1
+        card.detach()
+        assert event.subscriber_count == 0
+
+    async def test_detach_removes_bind_range_handler(self):
+        """bind_range handlers are also removed by detach()."""
+        card = self._card()
+        event = AsyncEvent()
+        card.bind_range("bar", event, min_val=0, max_val=100)
+        assert event.subscriber_count == 1
+        card.detach()
+        assert event.subscriber_count == 0
+
+    async def test_detach_removes_bind_many_handler(self):
+        """bind_many handlers are also removed by detach()."""
+        card = self._card()
+        event = AsyncEvent()
+        card.bind_many(event, lambda v: {"title": v})
+        assert event.subscriber_count == 1
+        card.detach()
+        assert event.subscriber_count == 0
+
+    async def test_detach_idempotent(self):
+        """Calling detach() twice does not raise."""
+        card = self._card()
+        event = AsyncEvent()
+        card.bind("title", event)
+        card.detach()
+        card.detach()  # should not raise
+        assert event.subscriber_count == 0
+
+    async def test_handler_count_stable_across_reconnect_cycles(self):
+        """Simulates N reconnect cycles; handler count never grows."""
+        event = AsyncEvent()
+        for _ in range(5):
+            card = self._card()
+            card.bind("title", event)
+            assert event.subscriber_count == 1
+            card.detach()
+            assert event.subscriber_count == 0
+
+
+class TestDuiKeyDetach:
+    """Verify that DuiKey.detach() unsubscribes all handlers."""
+
+    def _key(self) -> DuiKey:
+        spec = _key_spec(
+            bindings={
+                "label": TextBinding(node="label", default=""),
+                "bar": RangeBinding(node="bar", default=0.0),
+            }
+        )
+        return DuiKey(spec)
+
+    async def test_detach_removes_bind_handler(self):
+        """After detach(), the event's subscriber count drops to zero."""
+        key = self._key()
+        event = AsyncEvent()
+        key.bind("label", event)
+        assert event.subscriber_count == 1
+        key.detach()
+        assert event.subscriber_count == 0
+
+    async def test_detach_removes_bind_range_handler(self):
+        """bind_range handlers are also removed by detach()."""
+        key = self._key()
+        event = AsyncEvent()
+        key.bind_range("bar", event, min_val=0, max_val=100)
+        assert event.subscriber_count == 1
+        key.detach()
+        assert event.subscriber_count == 0
+
+    async def test_handler_count_stable_across_reconnect_cycles(self):
+        """Simulates N reconnect cycles; handler count never grows."""
+        event = AsyncEvent()
+        for _ in range(5):
+            key = self._key()
+            key.bind("label", event)
+            assert event.subscriber_count == 1
+            key.detach()
+            assert event.subscriber_count == 0


### PR DESCRIPTION
## Summary

Implements the `on_detach` lifecycle to prevent handler accumulation across reconnect cycles.

## Changes

- **`DuiCard` / `DuiKey`**: Track all handlers registered via `bind()`, `bind_range()`, and `bind_many()` in a `_subscriptions` list. New `detach()` method unsubscribes them all.
- **`CardController.on_detach()` / `KeyController.on_detach()`**: Default implementation now calls `card.detach()` / `key.detach()` automatically.
- **`Deck.stop()`**: Calls `detach()` on every `DuiCard` across all screens before closing the device.
- **Tests**: Verify handler count drops to zero after detach, stays stable across simulated reconnect cycles, and controllers auto-detach.

## Acceptance Criteria

- [x] `on_detach` unsubscribes all `AsyncEvent` handlers wired by `bind()`
- [x] `Deck.stop()` calls detach on all installed cards
- [x] Handler count does not grow across reconnect cycles
- [x] Test simulates multiple reconnect cycles and verifies handler count
- [x] `on_attach`/`on_detach` lifecycle documented

Closes #205