### PR TITLE
feat(api): trim deux.__init__ exports to user-facing surface only

### DIFF
--- a/src/deux/__init__.py
+++ b/src/deux/__init__.py
@@ -28,6 +28,9 @@ Examples
 
 from __future__ import annotations
 
+import warnings
+from typing import Any
+
 from ._url_safety import SSRFError, set_allow_private_urls
 from .dui import (
     DuiCard,
@@ -44,40 +47,21 @@ from .dui import (
     resolve_dui,
 )
 from .render import (
-    ImageFetchError,
-    RenderMetrics,
-    SurfaceBackgrounds,
-    SvgRasterizer,
     Theme,
-    clear_image_cache,
-    fetch_image,
     get_active_theme,
-    get_default_backgrounds,
-    get_default_font_family,
-    get_svg_backend,
-    get_svg_stylesheet,
-    list_supported_devices,
-    list_svg_backends,
-    load_svg_stylesheet,
-    register_svg_backend,
     set_active_theme,
-    set_svg_backend,
-    set_svg_stylesheet,
 )
 from .runtime import (
-    AsyncEvent,
     Deck,
     DeckError,
     DeckEvent,
     DeckManager,
-    DeviceCapabilities,
     DeviceInfo,
     EncoderPressEvent,
     EncoderTurnEvent,
     EventType,
     KeyEvent,
     TouchEvent,
-    list_devices,
 )
 from .ui import (
     BlankCard,
@@ -92,7 +76,6 @@ from .ui import (
 )
 
 __all__ = [
-    "AsyncEvent",
     "BlankCard",
     "Card",
     "CardController",
@@ -100,7 +83,6 @@ __all__ = [
     "DeckError",
     "DeckEvent",
     "DeckManager",
-    "DeviceCapabilities",
     "DeviceInfo",
     "DuiCard",
     "DuiKey",
@@ -109,46 +91,73 @@ __all__ = [
     "EncoderSlot",
     "EncoderTurnEvent",
     "EventType",
-    "ImageFetchError",
     "InfoScreen",
     "KeyController",
     "KeyEvent",
     "KeySlot",
     "PackageError",
     "PackageSpec",
-    "RenderMetrics",
     "SSRFError",
     "Screen",
-    "SurfaceBackgrounds",
-    "SvgRasterizer",
     "Theme",
     "TouchEvent",
     "TouchStrip",
+    "__version__",
     "add_dui_path",
     "clear_dui_cache",
-    "clear_image_cache",
-    "fetch_image",
     "get_active_theme",
-    "get_default_backgrounds",
-    "get_default_font_family",
-    "get_svg_backend",
-    "get_svg_stylesheet",
-    "list_devices",
     "list_dui_packages",
-    "list_supported_devices",
-    "list_svg_backends",
     "load_all_packages",
     "load_package",
-    "load_svg_stylesheet",
-    "register_svg_backend",
     "remove_dui_path",
     "resolve_dui",
     "set_active_theme",
     "set_allow_private_urls",
-    "set_svg_backend",
-    "set_svg_stylesheet",
 ]
 
 from deux._version import __version__
 
-__all__ += ["__version__"]
+# ---------------------------------------------------------------------------
+# Deprecated re-exports – available for one release cycle with a warning.
+# Advanced users should import from the relevant subpackage directly.
+# ---------------------------------------------------------------------------
+
+_DEPRECATED_IMPORTS: dict[str, tuple[str, str]] = {
+    "AsyncEvent": ("deux.runtime", "deux.runtime.AsyncEvent"),
+    "DeviceCapabilities": ("deux.runtime", "deux.runtime.DeviceCapabilities"),
+    "ImageFetchError": ("deux.render", "deux.render.ImageFetchError"),
+    "RenderMetrics": ("deux.render", "deux.render.RenderMetrics"),
+    "SurfaceBackgrounds": ("deux.render", "deux.render.SurfaceBackgrounds"),
+    "SvgRasterizer": ("deux.render", "deux.render.SvgRasterizer"),
+    "clear_image_cache": ("deux.render", "deux.render.clear_image_cache"),
+    "fetch_image": ("deux.render", "deux.render.fetch_image"),
+    "get_default_backgrounds": ("deux.render", "deux.render.get_default_backgrounds"),
+    "get_default_font_family": ("deux.render", "deux.render.get_default_font_family"),
+    "get_svg_backend": ("deux.render", "deux.render.get_svg_backend"),
+    "get_svg_stylesheet": ("deux.render", "deux.render.get_svg_stylesheet"),
+    "list_devices": ("deux.runtime", "deux.runtime.list_devices"),
+    "list_supported_devices": ("deux.render", "deux.render.list_supported_devices"),
+    "list_svg_backends": ("deux.render", "deux.render.list_svg_backends"),
+    "load_svg_stylesheet": ("deux.render", "deux.render.load_svg_stylesheet"),
+    "register_svg_backend": ("deux.render", "deux.render.register_svg_backend"),
+    "set_svg_backend": ("deux.render", "deux.render.set_svg_backend"),
+    "set_svg_stylesheet": ("deux.render", "deux.render.set_svg_stylesheet"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Provide deprecated access to internal symbols with a warning."""
+    if name in _DEPRECATED_IMPORTS:
+        subpackage, qualified = _DEPRECATED_IMPORTS[name]
+        warnings.warn(
+            f"Importing '{name}' from 'deux' is deprecated. "
+            f"Use '{qualified}' instead. "
+            f"This re-export will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        import importlib
+
+        module = importlib.import_module(subpackage)
+        return getattr(module, name)
+    raise AttributeError(f"module 'deux' has no attribute {name!r}")

--- a/tests/test_async_event.py
+++ b/tests/test_async_event.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from deux import AsyncEvent
+from deux.runtime import AsyncEvent
 from deux.runtime.async_event import AsyncEvent as AsyncEventInternal
 
 

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -1105,7 +1105,7 @@ class TestScreenCycler:
         semantics, so we wire one in by hand and have ``set_screen``
         emit it.
         """
-        from deux import AsyncEvent
+        from deux.runtime import AsyncEvent
 
         deck = MagicMock()
         deck.on_screen_changed = AsyncEvent()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
+
+import pytest
+
 import deux
 
 
@@ -13,7 +17,6 @@ class TestPublicAPI:
     def test_all_exports(self):
         expected = {
             "__version__",
-            "AsyncEvent",
             "BlankCard",
             "Card",
             "CardController",
@@ -21,7 +24,6 @@ class TestPublicAPI:
             "DeckError",
             "DeckEvent",
             "DeckManager",
-            "DeviceCapabilities",
             "DeviceInfo",
             "DuiCard",
             "DuiKey",
@@ -30,44 +32,27 @@ class TestPublicAPI:
             "EncoderSlot",
             "EncoderTurnEvent",
             "EventType",
-            "ImageFetchError",
             "InfoScreen",
             "KeyController",
             "KeyEvent",
             "KeySlot",
             "PackageError",
             "PackageSpec",
-            "RenderMetrics",
             "SSRFError",
             "Screen",
-            "SurfaceBackgrounds",
-            "SvgRasterizer",
             "Theme",
             "TouchEvent",
             "TouchStrip",
             "add_dui_path",
             "clear_dui_cache",
-            "clear_image_cache",
-            "fetch_image",
             "get_active_theme",
-            "get_default_backgrounds",
-            "get_default_font_family",
-            "get_svg_backend",
-            "get_svg_stylesheet",
-            "list_devices",
             "list_dui_packages",
-            "list_supported_devices",
-            "list_svg_backends",
             "load_all_packages",
             "load_package",
-            "load_svg_stylesheet",
-            "register_svg_backend",
             "remove_dui_path",
             "resolve_dui",
             "set_active_theme",
             "set_allow_private_urls",
-            "set_svg_backend",
-            "set_svg_stylesheet",
         }
         assert set(deux.__all__) == expected
 
@@ -168,17 +153,10 @@ class TestPublicAPI:
         assert BlankCard is not None
         assert TouchStrip is not None
 
-    def test_new_multi_device_exports(self):
-        from deux import DeviceCapabilities, InfoScreen, RenderMetrics
+    def test_info_screen_importable(self):
+        from deux import InfoScreen
 
-        assert DeviceCapabilities is not None
         assert InfoScreen is not None
-        assert RenderMetrics is not None
-
-    def test_async_event_importable(self):
-        from deux import AsyncEvent
-
-        assert AsyncEvent is not None
 
     def test_deck_importable(self):
         from deux import Deck
@@ -190,3 +168,44 @@ class TestPublicAPI:
 
         assert CardController is not None
         assert KeyController is not None
+
+
+class TestDeprecatedImports:
+    """Deprecated symbols still importable from deux with a warning."""
+
+    def test_deprecated_async_event(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from deux import AsyncEvent  # noqa: F401
+
+            # __getattr__ only fires on attribute access, not cached imports
+            _ = deux.AsyncEvent
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_deprecated_device_capabilities(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = deux.DeviceCapabilities
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_deprecated_render_metrics(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = deux.RenderMetrics
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_deprecated_svg_rasterizer(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = deux.SvgRasterizer
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_deprecated_list_devices(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = deux.list_devices
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_unknown_attribute_raises(self):
+        with pytest.raises(AttributeError, match="no attribute"):
+            _ = deux.nonexistent_symbol

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -500,6 +500,6 @@ class TestPublicImports:
         assert set_active_theme is not None
 
     def test_get_default_font_family_importable(self):
-        from deux import get_default_font_family
+        from deux.render import get_default_font_family
 
         assert get_default_font_family is not None


### PR DESCRIPTION
## Summary

Reduces `deux.__init__.__all__` from 50+ symbols to user-facing types only, addressing #206.

## Changes

- **`src/deux/__init__.py`**: Removed internal symbols from direct imports and `__all__`. Added `__getattr__` with `DeprecationWarning` for backward-compatible access during one release cycle.
- **Tests**: Updated imports in `test_async_event.py`, `test_example_streamdeck.py`, `test_theme.py` to use subpackage paths. Rewrote `test_init.py` to validate the trimmed surface and test deprecated access warnings.

## Deprecated symbols (accessible via subpackage)

`SvgRasterizer`, `register_svg_backend`, `get_svg_stylesheet`, `set_svg_stylesheet`, `get_svg_backend`, `set_svg_backend`, `list_svg_backends`, `load_svg_stylesheet`, `list_supported_devices`, `get_default_font_family`, `get_default_backgrounds`, `SurfaceBackgrounds`, `RenderMetrics`, `clear_image_cache`, `fetch_image`, `ImageFetchError`, `AsyncEvent`, `DeviceCapabilities`, `list_devices`

## Verification

- ruff: all checks passed
- mypy: no issues
- pytest: 1634 passed, 97% coverage (>95% threshold)

Closes #206