### PR TITLE
fix: standardise defensive copies for mutable collections (#207)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,21 @@ Every pull request runs the following checks on Python 3.11, 3.12, and 3.13:
 
 All checks must pass for a PR to be merged.
 
+## Immutable Collection Convention
+
+Public properties that expose internal collections **must not** leak mutable
+references. Follow these rules:
+
+| Internal type | Return strategy | Return type annotation |
+|---------------|----------------|------------------------|
+| `dict` | `MappingProxyType(self._x)` | `Mapping[K, V]` |
+| `list` | `list(self._x)` (shallow copy) | `list[T]` |
+| `set` | `frozenset(self._x)` | `frozenset[T]` |
+
+- Import `Mapping` from `collections.abc` and `MappingProxyType` from `types`.
+- If the internal value can be `None`, return `None` directly (no copy needed).
+- Mutation must go through dedicated setter methods (e.g., `set_card()`).
+
 ## Reporting Issues
 
 Open an issue on GitHub with:

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import io
 import logging
+from collections.abc import Mapping
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from .controls.encoder_slot import EncoderSlot
@@ -274,14 +276,20 @@ class Screen:
         self._touch_strip.set_card(index, card)
 
     @property
-    def keys(self) -> dict[int, KeySlot]:
-        """Mapping of key index to :class:`KeySlot` for all configured keys."""
-        return self._keys
+    def keys(self) -> Mapping[int, KeySlot]:
+        """Mapping of key index to :class:`KeySlot` for all configured keys.
+
+        Returns a read-only view; external code cannot mutate internal state.
+        """
+        return MappingProxyType(self._keys)
 
     @property
-    def encoders(self) -> dict[int, EncoderSlot]:
-        """Mapping of encoder index to :class:`EncoderSlot` for all configured encoders."""
-        return self._encoders
+    def encoders(self) -> Mapping[int, EncoderSlot]:
+        """Mapping of encoder index to :class:`EncoderSlot` for all configured encoders.
+
+        Returns a read-only view; external code cannot mutate internal state.
+        """
+        return MappingProxyType(self._encoders)
 
     @property
     def touch_strip(self) -> TouchStrip | None:
@@ -364,10 +372,13 @@ class Screen:
 
     @property
     def cards(self) -> list[Card]:
-        """All touch-strip cards, or an empty list if the device has no touchscreen."""
+        """All touch-strip cards, or an empty list if the device has no touchscreen.
+
+        Returns a shallow copy; external code cannot mutate internal state.
+        """
         if self._touch_strip is None:
             return []
-        return self._touch_strip.cards
+        return list(self._touch_strip.cards)
 
     def mark_all_dirty(self) -> None:
         """Flag every control on this screen for re-rendering.

--- a/src/deux/ui/touch_strip.py
+++ b/src/deux/ui/touch_strip.py
@@ -119,8 +119,11 @@ class TouchStrip:
 
     @property
     def cards(self) -> list[Card]:
-        """All card zones on this touch strip."""
-        return self._cards
+        """All card zones on this touch strip.
+
+        Returns a shallow copy; external code cannot mutate internal state.
+        """
+        return list(self._cards)
 
     @property
     def panel_width(self) -> int:
@@ -134,8 +137,13 @@ class TouchStrip:
 
     @property
     def bg_tiles(self) -> list[Image.Image] | None:
-        """Pre-sliced background tiles, or ``None`` if no background SVG is set."""
-        return self._bg_tiles
+        """Pre-sliced background tiles, or ``None`` if no background SVG is set.
+
+        Returns a shallow copy when tiles exist; external code cannot mutate internal state.
+        """
+        if self._bg_tiles is None:
+            return None
+        return list(self._bg_tiles)
 
     def bg_tile(self, index: int) -> Image.Image | None:
         """Return the cached background tile for panel *index*, or ``None``.


### PR DESCRIPTION
## Summary

All public properties returning internal collections now use consistent encapsulation to prevent external mutation of internal state.

## Changes

- **`Screen.keys`** and **`Screen.encoders`** return `MappingProxyType` (read-only mapping views) instead of raw dicts
- **`Screen.cards`**, **`TouchStrip.cards`**, and **`TouchStrip.bg_tiles`** return shallow list copies instead of internal lists
- Documented the immutable-collection convention in `CONTRIBUTING.md`

## Acceptance Criteria

- [x] All public properties returning collections use consistent encapsulation
- [x] Convention documented in `CONTRIBUTING.md`
- [x] `Screen.keys` and `Screen.cards` no longer leak mutable internals
- [x] Existing tests pass (1634 passed, 95%+ coverage)

Closes #207