### PR TITLE
fix: make touchstrip_background setter consistent with SVG methods on non-touch devices

### DIFF
--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -310,8 +310,21 @@ class Screen:
 
     @touchstrip_background.setter
     def touchstrip_background(self, value: str) -> None:
-        if self._touch_strip is not None:
-            self._touch_strip.background_color = value
+        """Set the fill colour for the touchscreen canvas behind cards.
+
+        Parameters
+        ----------
+        value : str
+            CSS colour string for the background.
+
+        Raises
+        ------
+        IndexError
+            If the device has no touchscreen.
+        """
+        if self._touch_strip is None:
+            raise IndexError("This device has no touchscreen")
+        self._touch_strip.background_color = value
 
     def set_touchstrip_background_svg(self, svg_data: bytes) -> None:
         """Set a background SVG for the touchstrip.

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -70,6 +70,12 @@ class TestScreenForMini:
         screen = Screen("mini", STREAM_DECK_MINI)
         assert screen.touchstrip_background == "black"
 
+    def test_touchstrip_background_setter_raises_no_touch(self):
+        """Setting touchstrip_background raises IndexError on non-touch device."""
+        screen = Screen("mini", STREAM_DECK_MINI)
+        with pytest.raises(IndexError, match="no touchscreen"):
+            screen.touchstrip_background = "red"
+
 
 class TestScreenForNeo:
     """Screen for Neo: 8 keys, no encoders, no touchscreen, info screen."""


### PR DESCRIPTION
## Summary

The `touchstrip_background` setter previously silently no-oped on non-touch devices, while `set_touchstrip_background_svg` and related methods raised `IndexError`. This inconsistency made debugging harder.

## Changes

- `touchstrip_background` setter now raises `IndexError` with message "This device has no touchscreen" (matching other methods)
- Added NumPy-style docstring to the setter
- Added test verifying the new behaviour

Closes #209