### PR TITLE
refactor: extract BindingMixin from DuiCard and DuiKey

### DIFF
--- a/src/deux/dui/binding_mixin.py
+++ b/src/deux/dui/binding_mixin.py
@@ -1,0 +1,320 @@
+"""Shared mixin for event-binding helpers used by DuiCard and DuiKey."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..runtime.async_event import AsyncEvent
+    from ..runtime.events import AsyncHandler
+    from .event_map import EventMap
+
+
+class BindingMixin:
+    """Mixin providing ``bind``, ``bind_range``, ``bind_many``, ``forward``, and helpers.
+
+    Subclasses must provide the following attributes/methods:
+
+    * ``_events: EventMap``
+    * ``_subscriptions: list[tuple[AsyncEvent, AsyncHandler]]``
+    * ``is_dirty: bool`` (property)
+    * ``request_refresh() -> Coroutine``
+    * ``set(name, value)``
+    * ``set_range(name, value, *, min_val, max_val)``
+    * ``set_many(**kwargs)``
+    """
+
+    # Attributes/methods expected on the concrete class (provided by Card/KeySlot).
+    # Declared here for type-checking only; no runtime implementations.
+    if TYPE_CHECKING:
+        _events: EventMap
+        _subscriptions: list[tuple[AsyncEvent, AsyncHandler]]
+
+        @property
+        def is_dirty(self) -> bool: ...
+
+        async def request_refresh(self) -> None: ...
+
+        def set(self, name: str, value: Any) -> Any: ...
+
+        def set_range(
+            self, name: str, value: float, *, min_val: float, max_val: float
+        ) -> Any: ...
+
+        def set_many(self, **kwargs: Any) -> Any: ...
+
+    def on(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
+        """Decorator to register a handler for a named semantic event.
+
+        Examples
+        --------
+        ::
+
+            @element.on("toggle")
+            async def handle():
+                ...
+
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
+
+        Returns
+        -------
+        Callable
+            A decorator that registers the handler and returns it unchanged.
+        """
+
+        def decorator(fn: AsyncHandler) -> AsyncHandler:
+            self._events.on(event_name, self._wrap_handler(fn))
+            return fn
+
+        return decorator
+
+    def bind_event(self, event_name: str, handler: AsyncHandler) -> None:
+        """Imperatively register a handler for a named semantic event.
+
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
+        handler
+            The async callable to invoke.
+        """
+        self._events.on(event_name, self._wrap_handler(handler))
+
+    def bind(
+        self,
+        name: str,
+        event: AsyncEvent,
+        *,
+        transform: Callable[..., Any] | None = None,
+    ) -> Self:
+        """Subscribe to *event*; on emit, write binding *name* and refresh.
+
+        This fuses three operations that otherwise repeat across every
+        controller: subscribe to a service ``AsyncEvent``, translate
+        the emitted value into the binding's domain, and request a
+        refresh.
+
+        Without *transform*, the binding receives the first positional
+        argument from the event (``args[0]``).  With *transform*, the
+        callable is invoked with all event ``args``/``kwargs`` and its
+        return value becomes the binding value.
+
+        The subscriber lives for the lifetime of the element unless
+        :meth:`detach` is called.  Bind once during construction or
+        lifecycle hooks.
+
+        Parameters
+        ----------
+        name
+            Binding name as defined in the manifest.
+        event
+            The :class:`~deux.runtime.async_event.AsyncEvent` to
+            subscribe to (e.g. a service's ``on_volume_changed``).
+        transform
+            Optional sync callable that maps event args to the binding
+            value.  If ``None``, ``args[0]`` is used.
+
+        Returns
+        -------
+        Self
+            self, for method chaining.
+        """
+
+        async def _on_event(*args: Any, **kwargs: Any) -> None:
+            value = (
+                (args[0] if args else None)
+                if transform is None
+                else transform(*args, **kwargs)
+            )
+            self.set(name, value)
+            if self.is_dirty:
+                await self.request_refresh()
+
+        event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
+        return self
+
+    def bind_range(
+        self,
+        name: str,
+        event: AsyncEvent,
+        *,
+        min_val: float = 0,
+        max_val: float = 1,
+        transform: Callable[..., float] | None = None,
+    ) -> Self:
+        """Subscribe to *event*; on emit, write binding *name* via :meth:`set_range`.
+
+        Same shape as :meth:`bind`, but routes through :meth:`set_range`
+        so the emitted value can be in domain units (e.g. a 0--100
+        percentage).
+
+        Parameters
+        ----------
+        name
+            Binding name (must be a ``range`` or ``slider`` binding).
+        event
+            The :class:`~deux.runtime.async_event.AsyncEvent` to
+            subscribe to.
+        min_val
+            Lower bound of the domain range.
+        max_val
+            Upper bound of the domain range.
+        transform
+            Optional sync callable that maps event args to a numeric
+            value in domain units.  If ``None``, ``args[0]`` is used.
+
+        Returns
+        -------
+        Self
+            self, for method chaining.
+
+        Raises
+        ------
+        ValueError
+            If *min_val* equals *max_val*.
+        """
+        if min_val == max_val:
+            raise ValueError("min_val and max_val must not be equal")
+
+        async def _on_event(*args: Any, **kwargs: Any) -> None:
+            value = (
+                float(args[0])
+                if transform is None
+                else float(transform(*args, **kwargs))
+            )
+            self.set_range(name, value, min_val=min_val, max_val=max_val)
+            if self.is_dirty:
+                await self.request_refresh()
+
+        event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
+        return self
+
+    def bind_many(
+        self,
+        event: AsyncEvent,
+        transform: Callable[..., dict[str, Any]],
+    ) -> Self:
+        """Subscribe to *event*; transform args into a dict and :meth:`set_many` it.
+
+        Use this when one event drives several bindings at once -- e.g.
+        a ``track_changed`` event populating ``artist``, ``title``,
+        ``album``, and ``state`` from a single track dict.
+
+        Parameters
+        ----------
+        event
+            The :class:`~deux.runtime.async_event.AsyncEvent` to
+            subscribe to.
+        transform
+            Required sync callable that maps event args to a dict of
+            binding names to values.
+
+        Returns
+        -------
+        Self
+            self, for method chaining.
+        """
+
+        async def _on_event(*args: Any, **kwargs: Any) -> None:
+            values = transform(*args, **kwargs)
+            self.set_many(**values)
+            if self.is_dirty:
+                await self.request_refresh()
+
+        event.subscribe(_on_event)
+        self._subscriptions.append((event, _on_event))
+        return self
+
+    def detach(self) -> None:
+        """Unsubscribe all handlers registered via :meth:`bind` and friends.
+
+        Call this during teardown to prevent leaked handlers
+        accumulating across reconnect cycles.
+        """
+        for event, handler in self._subscriptions:
+            with suppress(ValueError):
+                event.unsubscribe(handler)
+        self._subscriptions.clear()
+
+    def forward(
+        self,
+        event_name: str,
+        target: Callable[..., Any],
+    ) -> Self:
+        """Register *target* as the handler for manifest event *event_name*.
+
+        Sugar for the very common shape::
+
+            @element.on("toggle")
+            async def _h() -> None:
+                await svc.toggle()
+
+        which becomes::
+
+            element.forward("toggle", svc.toggle)
+
+        *target* may be an async function or any sync callable that
+        returns an awaitable.  All positional and keyword arguments
+        emitted by the event are forwarded to *target*.
+
+        Parameters
+        ----------
+        event_name
+            Semantic event name from the manifest.
+        target
+            Async-callable forwarding target.
+
+        Returns
+        -------
+        Self
+            self, for method chaining.
+        """
+
+        async def _handler(*args: Any, **kwargs: Any) -> None:
+            await target(*args, **kwargs)
+
+        self._events.on(event_name, self._wrap_handler(_handler))
+        return self
+
+    def _wrap_handler(self, fn: AsyncHandler) -> AsyncHandler:
+        """Wrap *fn* so any state changes trigger a refresh after it runs.
+
+        For events dispatched synchronously from the deck's event loop
+        (key press, encoder press, non-accumulated turns) the deck
+        already calls ``refresh()`` when the card is dirty after the
+        handler runs.  But several event paths fire from detached
+        asyncio tasks where the dispatcher is no longer in scope:
+
+        * Accumulator flushes (``accumulate: true`` encoder turns).
+        * Hold timers (``encoder_hold`` / ``key_hold``).
+
+        Without this wrapper, those handlers can mutate bindings
+        without ever triggering a render.  Wrapping at the registration
+        boundary makes every handler self-refreshing, regardless of how
+        it's dispatched.
+
+        The wrapper:
+
+        * Is a no-op when no refresh callback is wired (i.e. before the
+          element is installed on a screen).
+        * Is idempotent when the handler already calls
+          :meth:`request_refresh` itself -- the second call finds the
+          element clean and skips re-rendering.
+        """
+
+        async def _wrapped(*args: Any, **kwargs: Any) -> None:
+            await fn(*args, **kwargs)
+            if self.is_dirty:
+                await self.request_refresh()
+
+        # Preserve the original for testing / introspection.
+        _wrapped.__wrapped__ = fn  # type: ignore[attr-defined]
+        return _wrapped

--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -4,19 +4,17 @@ from __future__ import annotations
 
 import logging
 import xml.etree.ElementTree as ET
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from ..ui.cards.base import Card
 from .animator import PushFn, SpinnerAnimator
+from .binding_mixin import BindingMixin
 from .event_map import EventMap
 from .schema import PackageSpec
 from .spinner import SpinnerFrames
 from .svg_renderer import SvgRenderer
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from PIL import Image
 
     from ..runtime.async_event import AsyncEvent
@@ -25,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DuiCard(Card):
+class DuiCard(BindingMixin, Card):
     """A touchscreen card whose layout and events are defined by a .dui package.
 
     Instead of writing a Python class with imperative Pillow rendering,
@@ -365,282 +363,6 @@ class DuiCard(Card):
         current_norm = float(self.get(name) or 0.0)
         return min_val + current_norm * (max_val - min_val)
 
-    def on(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
-        """Decorator to register a handler for a named semantic event.
-
-        Examples
-        --------
-        ::
-
-            @card.on("toggle_play_pause")
-            async def handle():
-                ...
-
-        Parameters
-        ----------
-        event_name
-            Semantic event name from the manifest.
-
-        Returns
-        -------
-        Callable
-            A decorator that registers the handler and returns it unchanged.
-        """
-
-        def decorator(fn: AsyncHandler) -> AsyncHandler:
-            self._events.on(event_name, self._wrap_handler(fn))
-            return fn
-
-        return decorator
-
-    def bind_event(self, event_name: str, handler: AsyncHandler) -> None:
-        """Imperatively register a handler for a named semantic event.
-
-        Parameters
-        ----------
-        event_name
-            Semantic event name from the manifest.
-        handler
-            The async callable to invoke.
-        """
-        self._events.on(event_name, self._wrap_handler(handler))
-
-    def bind(
-        self,
-        name: str,
-        event: AsyncEvent,
-        *,
-        transform: Callable[..., Any] | None = None,
-    ) -> DuiCard:
-        """Subscribe to *event*; on emit, write binding *name* and refresh.
-
-        This fuses three operations that otherwise repeat across every
-        controller: subscribe to a service ``AsyncEvent``, translate
-        the emitted value into the binding's domain, and request a
-        refresh.
-
-        Without *transform*, the binding receives the first positional
-        argument from the event (``args[0]``).  With *transform*, the
-        callable is invoked with all event ``args``/``kwargs`` and its
-        return value becomes the binding value.
-
-        The subscriber lives for the lifetime of the card unless
-        :meth:`detach` is called.  Bind once during construction or
-        :meth:`on_attach`-style lifecycle hooks.
-
-        Parameters
-        ----------
-        name
-            Binding name as defined in the manifest.
-        event
-            The :class:`~deux.runtime.async_event.AsyncEvent` to
-            subscribe to (e.g. a service's ``on_volume_changed``).
-        transform
-            Optional sync callable that maps event args to the binding
-            value.  If ``None``, ``args[0]`` is used.
-
-        Returns
-        -------
-        DuiCard
-            self, for method chaining.
-        """
-
-        async def _on_event(*args: Any, **kwargs: Any) -> None:
-            value = (
-                (args[0] if args else None)
-                if transform is None
-                else transform(*args, **kwargs)
-            )
-            self.set(name, value)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        event.subscribe(_on_event)
-        self._subscriptions.append((event, _on_event))
-        return self
-
-    def bind_range(
-        self,
-        name: str,
-        event: AsyncEvent,
-        *,
-        min_val: float = 0,
-        max_val: float = 1,
-        transform: Callable[..., float] | None = None,
-    ) -> DuiCard:
-        """Subscribe to *event*; on emit, write binding *name* via :meth:`set_range`.
-
-        Same shape as :meth:`bind`, but routes through :meth:`set_range`
-        so the emitted value can be in domain units (e.g. a 0--100
-        percentage).
-
-        Parameters
-        ----------
-        name
-            Binding name (must be a ``range`` or ``slider`` binding).
-        event
-            The :class:`~deux.runtime.async_event.AsyncEvent` to
-            subscribe to.
-        min_val
-            Lower bound of the domain range.
-        max_val
-            Upper bound of the domain range.
-        transform
-            Optional sync callable that maps event args to a numeric
-            value in domain units.  If ``None``, ``args[0]`` is used.
-
-        Returns
-        -------
-        DuiCard
-            self, for method chaining.
-
-        Raises
-        ------
-        ValueError
-            If *min_val* equals *max_val*.
-        """
-        if min_val == max_val:
-            raise ValueError("min_val and max_val must not be equal")
-
-        async def _on_event(*args: Any, **kwargs: Any) -> None:
-            value = (
-                float(args[0])
-                if transform is None
-                else float(transform(*args, **kwargs))
-            )
-            self.set_range(name, value, min_val=min_val, max_val=max_val)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        event.subscribe(_on_event)
-        self._subscriptions.append((event, _on_event))
-        return self
-
-    def bind_many(
-        self,
-        event: AsyncEvent,
-        transform: Callable[..., dict[str, Any]],
-    ) -> DuiCard:
-        """Subscribe to *event*; transform args into a dict and :meth:`set_many` it.
-
-        Use this when one event drives several bindings at once -- e.g.
-        a ``track_changed`` event populating ``artist``, ``title``,
-        ``album``, and ``state`` from a single track dict.
-
-        Parameters
-        ----------
-        event
-            The :class:`~deux.runtime.async_event.AsyncEvent` to
-            subscribe to.
-        transform
-            Required sync callable that maps event args to a dict of
-            binding names to values.
-
-        Returns
-        -------
-        DuiCard
-            self, for method chaining.
-        """
-
-        async def _on_event(*args: Any, **kwargs: Any) -> None:
-            values = transform(*args, **kwargs)
-            self.set_many(**values)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        event.subscribe(_on_event)
-        self._subscriptions.append((event, _on_event))
-        return self
-
-    def detach(self) -> None:
-        """Unsubscribe all handlers registered via :meth:`bind` and friends.
-
-        Call this during teardown (e.g. from
-        :meth:`~deux.ui.controller.CardController.on_detach`) to prevent
-        leaked handlers accumulating across reconnect cycles.
-        """
-        for event, handler in self._subscriptions:
-            with suppress(ValueError):
-                event.unsubscribe(handler)
-        self._subscriptions.clear()
-
-    def forward(
-        self,
-        event_name: str,
-        target: Callable[..., Any],
-    ) -> DuiCard:
-        """Register *target* as the handler for manifest event *event_name*.
-
-        Sugar for the very common shape::
-
-            @card.on("toggle")
-            async def _h() -> None:
-                await svc.toggle()
-
-        which becomes::
-
-            card.forward("toggle", svc.toggle)
-
-        *target* may be an async function or any sync callable that
-        returns an awaitable (e.g. a lambda whose body invokes an
-        async method).  All positional and keyword arguments emitted
-        by the event are forwarded to *target*.
-
-        Parameters
-        ----------
-        event_name
-            Semantic event name from the manifest.
-        target
-            Async-callable forwarding target.
-
-        Returns
-        -------
-        DuiCard
-            self, for method chaining.
-        """
-
-        async def _handler(*args: Any, **kwargs: Any) -> None:
-            await target(*args, **kwargs)
-
-        self._events.on(event_name, self._wrap_handler(_handler))
-        return self
-
-    def _wrap_handler(self, fn: AsyncHandler) -> AsyncHandler:
-        """Wrap *fn* so any state changes trigger a refresh after it runs.
-
-        For events dispatched synchronously from the deck's event loop
-        (key press, encoder press, non-accumulated turns) the deck
-        already calls ``refresh()`` when the card is dirty after the
-        handler runs.  But several event paths fire from detached
-        asyncio tasks where the dispatcher is no longer in scope:
-
-        * Accumulator flushes (``accumulate: true`` encoder turns).
-        * Hold timers (``encoder_hold`` / ``key_hold``).
-
-        Without this wrapper, those handlers can mutate bindings
-        without ever triggering a render -- the user's display goes
-        silently stale (e.g. brightness slider lagging behind rapid
-        encoder spins).  Wrapping at the registration boundary makes
-        every handler self-refreshing, regardless of how it's
-        dispatched.
-
-        The wrapper:
-
-        * Is a no-op when no refresh callback is wired (i.e. before the
-          card is installed on a screen).
-        * Is idempotent when the handler already calls
-          :meth:`request_refresh` itself -- the second call finds the
-          card clean and skips re-rendering.
-        """
-
-        async def _wrapped(*args: Any, **kwargs: Any) -> None:
-            await fn(*args, **kwargs)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        # Preserve the original for testing / introspection.
-        _wrapped.__wrapped__ = fn  # type: ignore[attr-defined]
-        return _wrapped
 
     def render(self) -> Image.Image:
         """Render the SVG layout with current bindings to a PIL Image.

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import logging
 import warnings
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from ..ui.controls.key_slot import KeySlot
 from .animator import PushFn, SpinnerAnimator
+from .binding_mixin import BindingMixin
 from .event_map import EventMap
 from .schema import PackageSpec
 from .spinner import SpinnerFrames
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DuiKey(KeySlot):
+class DuiKey(BindingMixin, KeySlot):
     """A physical key whose layout and events are defined by a .dui package.
 
     ``DuiKey`` extends :class:`~deux.ui.controls.key_slot.KeySlot`
@@ -266,33 +266,6 @@ class DuiKey(KeySlot):
         current_norm = float(self.get(name) or 0.0)
         return min_val + current_norm * (max_val - min_val)
 
-    def on(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
-        """Decorator to register a handler for a named semantic event.
-
-        Examples
-        --------
-        ::
-
-            @key.on("activate")
-            async def handle():
-                ...
-
-        Parameters
-        ----------
-        event_name
-            Semantic event name from the manifest.
-
-        Returns
-        -------
-        Callable
-            A decorator that registers the handler and returns it unchanged.
-        """
-
-        def decorator(fn: AsyncHandler) -> AsyncHandler:
-            self._events.on(event_name, self._wrap_handler(fn))
-            return fn
-
-        return decorator
 
     def on_event(self, event_name: str) -> Callable[[AsyncHandler], AsyncHandler]:
         """Deprecated alias for :meth:`on`.
@@ -318,215 +291,6 @@ class DuiKey(KeySlot):
         )
         return self.on(event_name)
 
-    def bind_event(self, event_name: str, handler: AsyncHandler) -> None:
-        """Imperatively register a handler for a named semantic event.
-
-        Parameters
-        ----------
-        event_name
-            Semantic event name from the manifest.
-        handler
-            The async callable to invoke.
-        """
-        self._events.on(event_name, self._wrap_handler(handler))
-
-    def bind(
-        self,
-        name: str,
-        event: AsyncEvent,
-        *,
-        transform: Callable[..., Any] | None = None,
-    ) -> DuiKey:
-        """Subscribe to *event*; on emit, write binding *name* and refresh.
-
-        Mirror of :meth:`DuiCard.bind`.  Subscribes to a service
-        ``AsyncEvent``, optionally transforms the emitted value, calls
-        :meth:`set`, and requests a refresh if the binding changed.
-
-        Without *transform*, the binding receives the first positional
-        argument from the event.  With *transform*, the callable is
-        invoked with all event ``args``/``kwargs`` and its return
-        value becomes the binding value.
-
-        Parameters
-        ----------
-        name
-            Binding name as defined in the manifest.
-        event
-            The :class:`~deux.runtime.async_event.AsyncEvent` to
-            subscribe to.
-        transform
-            Optional sync callable that maps event args to the binding
-            value.  If ``None``, ``args[0]`` is used.
-
-        Returns
-        -------
-        DuiKey
-            self, for method chaining.
-        """
-
-        async def _on_event(*args: Any, **kwargs: Any) -> None:
-            value = (
-                (args[0] if args else None)
-                if transform is None
-                else transform(*args, **kwargs)
-            )
-            self.set(name, value)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        event.subscribe(_on_event)
-        self._subscriptions.append((event, _on_event))
-        return self
-
-    def bind_range(
-        self,
-        name: str,
-        event: AsyncEvent,
-        *,
-        min_val: float = 0,
-        max_val: float = 1,
-        transform: Callable[..., float] | None = None,
-    ) -> DuiKey:
-        """Subscribe to *event*; on emit, write binding *name* via :meth:`set_range`.
-
-        Mirror of :meth:`DuiCard.bind_range`.
-
-        Parameters
-        ----------
-        name
-            Binding name (must be a ``range`` or ``slider`` binding).
-        event
-            The :class:`~deux.runtime.async_event.AsyncEvent` to
-            subscribe to.
-        min_val
-            Lower bound of the domain range.
-        max_val
-            Upper bound of the domain range.
-        transform
-            Optional sync callable that maps event args to a numeric
-            value in domain units.  If ``None``, ``args[0]`` is used.
-
-        Returns
-        -------
-        DuiKey
-            self, for method chaining.
-
-        Raises
-        ------
-        ValueError
-            If *min_val* equals *max_val*.
-        """
-        if min_val == max_val:
-            raise ValueError("min_val and max_val must not be equal")
-
-        async def _on_event(*args: Any, **kwargs: Any) -> None:
-            value = (
-                float(args[0])
-                if transform is None
-                else float(transform(*args, **kwargs))
-            )
-            self.set_range(name, value, min_val=min_val, max_val=max_val)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        event.subscribe(_on_event)
-        self._subscriptions.append((event, _on_event))
-        return self
-
-    def bind_many(
-        self,
-        event: AsyncEvent,
-        transform: Callable[..., dict[str, Any]],
-    ) -> DuiKey:
-        """Subscribe to *event*; transform args into a dict and :meth:`set_many` it.
-
-        Mirror of :meth:`DuiCard.bind_many`.
-
-        Parameters
-        ----------
-        event
-            The :class:`~deux.runtime.async_event.AsyncEvent` to
-            subscribe to.
-        transform
-            Required sync callable that maps event args to a dict of
-            binding names to values.
-
-        Returns
-        -------
-        DuiKey
-            self, for method chaining.
-        """
-
-        async def _on_event(*args: Any, **kwargs: Any) -> None:
-            values = transform(*args, **kwargs)
-            self.set_many(**values)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        event.subscribe(_on_event)
-        self._subscriptions.append((event, _on_event))
-        return self
-
-    def detach(self) -> None:
-        """Unsubscribe all handlers registered via :meth:`bind` and friends.
-
-        Call this during teardown (e.g. from
-        :meth:`~deux.ui.controller.KeyController.on_detach`) to prevent
-        leaked handlers accumulating across reconnect cycles.
-        """
-        for event, handler in self._subscriptions:
-            with suppress(ValueError):
-                event.unsubscribe(handler)
-        self._subscriptions.clear()
-
-    def forward(
-        self,
-        event_name: str,
-        target: Callable[..., Any],
-    ) -> DuiKey:
-        """Register *target* as the handler for manifest event *event_name*.
-
-        Mirror of :meth:`DuiCard.forward`.  Sugar for forwarding a DUI
-        event directly to a service method or callable.
-
-        Parameters
-        ----------
-        event_name
-            Semantic event name from the manifest.
-        target
-            Async-callable forwarding target (async function or sync
-            callable returning an awaitable).
-
-        Returns
-        -------
-        DuiKey
-            self, for method chaining.
-        """
-
-        async def _handler(*args: Any, **kwargs: Any) -> None:
-            await target(*args, **kwargs)
-
-        self._events.on(event_name, self._wrap_handler(_handler))
-        return self
-
-    def _wrap_handler(self, fn: AsyncHandler) -> AsyncHandler:
-        """Wrap *fn* so any state changes trigger a refresh after it runs.
-
-        Mirrors :meth:`DuiCard._wrap_handler`.  Without this, hold-timer
-        handlers (``key_hold``) -- which fire from a detached asyncio
-        task -- would mutate bindings without ever triggering a render.
-        Wrapping at the registration boundary makes every handler
-        self-refreshing regardless of how it's dispatched.
-        """
-
-        async def _wrapped(*args: Any, **kwargs: Any) -> None:
-            await fn(*args, **kwargs)
-            if self.is_dirty:
-                await self.request_refresh()
-
-        _wrapped.__wrapped__ = fn  # type: ignore[attr-defined]
-        return _wrapped
 
     def render_image(
         self,


### PR DESCRIPTION
## Summary

Extracts duplicated `bind`, `bind_range`, `bind_many`, `forward`, `_wrap_handler`, `on`, `bind_event`, and `detach` methods into a shared `BindingMixin` class that both `DuiCard` and `DuiKey` inherit from.

## Changes

- **New file**: `src/deux/dui/binding_mixin.py` — contains the shared mixin with all previously duplicated methods
- **Modified**: `src/deux/dui/card.py` — `DuiCard` now inherits from `BindingMixin`; removed ~275 lines of duplicated code
- **Modified**: `src/deux/dui/key.py` — `DuiKey` now inherits from `BindingMixin`; removed ~210 lines of duplicated code

## Verification

- All 1642 tests pass
- Coverage: 96.96% (above 95% threshold)
- ruff: all checks passed
- mypy: no issues found

Closes #212