### PR TITLE
fix: make loader strict by default for unknown manifest keys

### DIFF
--- a/src/deux/dui/loader.py
+++ b/src/deux/dui/loader.py
@@ -774,13 +774,16 @@ def _parse_region(name: str, raw: dict[str, Any]) -> Region:
     )
 
 
-def load_package(path: str | Path) -> PackageSpec:
+def load_package(path: str | Path, *, strict: bool = True) -> PackageSpec:
     """Load a .dui package directory into a validated PackageSpec.
 
     Parameters
     ----------
     path
         Path to the ``.dui`` directory.
+    strict : bool, default=True
+        When ``True``, unknown manifest keys raise :exc:`PackageError`.
+        Set to ``False`` for forward-compatible loading that only warns.
 
     Returns
     -------
@@ -846,6 +849,10 @@ def load_package(path: str | Path) -> PackageSpec:
     # ── Optional metadata fields ──────────────────────────────────────
     unknown_keys = set(manifest.keys()) - KNOWN_MANIFEST_KEYS
     if unknown_keys:
+        if strict:
+            raise PackageError(
+                f"Package '{name}': unknown manifest keys: {sorted(unknown_keys)}"
+            )
         logger.warning(
             "Package '%s': unknown manifest keys: %s", name, sorted(unknown_keys)
         )

--- a/src/deux/tools/verify.py
+++ b/src/deux/tools/verify.py
@@ -90,7 +90,7 @@ def verify_package(path: str | Path, *, strict: bool = False) -> VerifyResult:
 
     # 1. Try loading the package (validates structure, bindings, events, regions)
     try:
-        spec = load_package(pkg_dir)
+        spec = load_package(pkg_dir, strict=False)
     except PackageError as exc:
         result.diagnostics.append(Diagnostic(Severity.ERROR, f"Load failed: {exc}"))
         return result

--- a/tests/test_dui_loader.py
+++ b/tests/test_dui_loader.py
@@ -1576,9 +1576,17 @@ class TestLoadPackageMetadata:
         with pytest.raises(PackageError, match="'category' must be a string"):
             load_package(self._make_pkg(tmp_path, "category: 123"))
 
-    def test_unknown_keys_logged(self, tmp_path, caplog):
+    def test_unknown_keys_raises_by_default(self, tmp_path):
+        with pytest.raises(PackageError, match="unknown manifest keys"):
+            load_package(self._make_pkg(tmp_path, "bindigs: typo"))
+
+    def test_unknown_keys_typo_in_bindings(self, tmp_path):
+        with pytest.raises(PackageError, match="unknown manifest keys.*bindigs"):
+            load_package(self._make_pkg(tmp_path, "bindigs: typo"))
+
+    def test_unknown_keys_non_strict_warns(self, tmp_path, caplog):
         with caplog.at_level(logging.WARNING):
-            load_package(self._make_pkg(tmp_path, "desciption: typo"))
+            load_package(self._make_pkg(tmp_path, "desciption: typo"), strict=False)
         assert "unknown manifest keys" in caplog.text
 
 


### PR DESCRIPTION
## Summary

Unknown manifest keys now raise `PackageError` by default instead of only logging a warning. This catches typos like `bindigs:` immediately rather than silently producing broken cards.

## Changes

- `load_package()` gains a `strict: bool = True` parameter
- When `strict=True` (default), unknown manifest keys raise `PackageError`
- When `strict=False`, the previous warning-only behavior is preserved
- `verify.py` uses `strict=False` since it handles unknown keys in its own diagnostic flow
- Tests added for typo detection and non-strict opt-out

Closes #214