### PR TITLE
docs: list all required system dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ you need to get started.
 - **Python 3.11+**
 - **[uv](https://docs.astral.sh/uv/)** for dependency management
 - **System libraries:**
-  - macOS: `brew install cairo hidapi`
-  - Linux (Debian/Ubuntu): `sudo apt install libcairo2-dev libhidapi-dev`
+  - macOS: `brew install vips cairo hidapi`
+  - Linux (Debian/Ubuntu): `sudo apt install libvips-dev libcairo2-dev libhidapi-dev`
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ A high-level, asyncio-native Python library for Elgato Stream Deck devices. Defi
 - Python 3.11+
 - [HIDAPI](https://github.com/libusb/hidapi) (For USB HID communication)
 - [libvips](https://github.com/libvips/libvips) (For SVG rendering)
+- [Cairo](https://www.cairographics.org/) (For 2D graphics rendering)
 
 ## Quick Start (macOS)
 
 Install system dependencies, clone the repo, and run the example:
 
 ```bash
-brew install hidapi vips
+brew install hidapi vips cairo
 
 git clone https://github.com/graphras-com/DeUX.git
 cd DeUX
@@ -51,7 +52,7 @@ python examples/streamdeck.py
 Install system dependencies, clone the repo, and run the example:
 
 ```bash
-apt-get install libhidapi libvips-dev
+apt-get install libhidapi-dev libvips-dev libcairo2-dev
 
 git clone https://github.com/graphras-com/DeUX.git
 cd DeUX


### PR DESCRIPTION
Adds missing system dependencies to CONTRIBUTING.md and README.md so new contributors can set up their environment without guesswork.

**Changes:**
- CONTRIBUTING.md: added `vips` to macOS command, added `libvips-dev` to Linux command
- README.md: added Cairo to system requirements list, added `cairo` to macOS command, fixed Linux command to use `libhidapi-dev` and added `libcairo2-dev`

Closes #223