### PR TITLE
fix: Set MAX_IMAGE_PIXELS and restrict decoders for downloaded images

### DIFF
--- a/src/deux/render/image_fetch.py
+++ b/src/deux/render/image_fetch.py
@@ -22,6 +22,17 @@ logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = 10.0
 
+# Limit pixel count to prevent decompression bombs from untrusted images.
+# 20 megapixels is generous for Stream Deck rendering (keys are typically 72x72
+# or 96x96) while still catching malicious payloads.
+MAX_IMAGE_PIXELS: int = 20_000_000
+Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
+
+#: Image formats accepted from remote sources.  Restricting decoders narrows
+#: the attack surface — BMP and TIFF decoders have historically been involved
+#: in Pillow CVEs and are unlikely to appear in legitimate .dui bindings.
+ALLOWED_FORMATS: frozenset[str] = frozenset({"PNG", "JPEG", "GIF", "WEBP"})
+
 USER_AGENT = f"deux/{__version__} (+https://github.com/graphras-com/DeUX)"
 
 _cache: dict[str, Image.Image | None] = {}
@@ -123,8 +134,14 @@ def fetch_image(url: str) -> Image.Image:
 
     try:
         img = Image.open(io.BytesIO(data))
+        fmt = (img.format or "").upper()
+        if fmt not in ALLOWED_FORMATS:
+            raise ImageFetchError(
+                f"Image format '{fmt}' from '{url}' is not allowed. "
+                f"Supported formats: {sorted(ALLOWED_FORMATS)}"
+            )
         img.load()  # force full decode so errors surface now
-    except (UnidentifiedImageError, OSError) as exc:
+    except (UnidentifiedImageError, OSError, Image.DecompressionBombError) as exc:
         with _cache_lock:
             _cache[url] = None
         raise ImageFetchError(

--- a/tests/test_image_fetch.py
+++ b/tests/test_image_fetch.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 from deux.render import image_fetch as mod
 from deux.render.image_fetch import (
+    ALLOWED_FORMATS,
     ImageFetchError,
     _validate_url,
     clear_cache,
@@ -23,6 +24,14 @@ def _png_bytes(size: tuple[int, int] = (4, 4), color: str = "red") -> bytes:
     img = Image.new("RGB", size, color)
     buf = io.BytesIO()
     img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _image_bytes(fmt: str, size: tuple[int, int] = (4, 4), color: str = "red") -> bytes:
+    """Create minimal image bytes in a given format for testing."""
+    img = Image.new("RGB", size, color)
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
     return buf.getvalue()
 
 
@@ -208,3 +217,53 @@ class TestPackageExports:
         assert hasattr(deux, "fetch_image")
         assert hasattr(deux, "ImageFetchError")
         assert hasattr(deux, "clear_image_cache")
+
+
+class TestImageSecurity:
+    """Tests for decompression bomb and format restrictions."""
+
+    def test_disallowed_format_bmp_rejected(self):
+        data = _image_bytes("BMP")
+        with (
+            patch.object(mod, "_http_get_bytes", return_value=data),
+            pytest.raises(ImageFetchError, match="not allowed"),
+        ):
+            fetch_image("https://example.com/img.bmp")
+
+    def test_disallowed_format_tiff_rejected(self):
+        data = _image_bytes("TIFF")
+        with (
+            patch.object(mod, "_http_get_bytes", return_value=data),
+            pytest.raises(ImageFetchError, match="not allowed"),
+        ):
+            fetch_image("https://example.com/img.tiff")
+
+    def test_allowed_formats_accepted(self):
+        for fmt in ("PNG", "JPEG", "GIF", "WEBP"):
+            clear_cache()
+            mode = "RGBA" if fmt in ("PNG", "GIF", "WEBP") else "RGB"
+            img = Image.new(mode, (4, 4), "red")
+            buf = io.BytesIO()
+            img.save(buf, format=fmt)
+            data = buf.getvalue()
+            with patch.object(mod, "_http_get_bytes", return_value=data):
+                result = fetch_image(f"https://example.com/img.{fmt.lower()}")
+            assert isinstance(result, Image.Image)
+
+    def test_decompression_bomb_rejected(self):
+        """An image exceeding MAX_IMAGE_PIXELS is rejected."""
+        # Pillow raises DecompressionBombError at 2x MAX_IMAGE_PIXELS
+        data = _png_bytes(size=(5, 5))  # 25 pixels > 2*4=8
+        with (
+            patch.object(mod.Image, "MAX_IMAGE_PIXELS", 4),
+            patch.object(mod, "_http_get_bytes", return_value=data),
+            pytest.raises(ImageFetchError, match="not a valid image"),
+        ):
+            fetch_image("https://example.com/bomb.png")
+
+    def test_max_image_pixels_is_set(self):
+        assert mod.MAX_IMAGE_PIXELS == 20_000_000
+        assert Image.MAX_IMAGE_PIXELS == 20_000_000
+
+    def test_allowed_formats_constant(self):
+        assert frozenset({"PNG", "JPEG", "GIF", "WEBP"}) == ALLOWED_FORMATS


### PR DESCRIPTION
## Summary

Hardens remote image fetching against decompression bombs and decoder exploits.

### Changes
- Set `Image.MAX_IMAGE_PIXELS = 20_000_000` to reject decompression bombs
- Restrict accepted image formats to `PNG`, `JPEG`, `GIF`, `WEBP` (rejects BMP/TIFF which have historically had CVEs)
- Catch `DecompressionBombError` in the fetch pipeline
- Export `ALLOWED_FORMATS` constant for transparency
- Add comprehensive tests for format rejection and bomb detection

Closes #224