### PR TITLE
fix: pin SSL context explicitly in urlopen calls

### DIFF
--- a/src/deux/dui/iconify.py
+++ b/src/deux/dui/iconify.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import ssl
 import threading
 import urllib.error
 import urllib.request
@@ -160,7 +161,8 @@ def _http_get(url: str) -> str:
     identifier with HTTP 403.
     """
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT) as resp:
+    ssl_ctx = ssl.create_default_context()
+    with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT, context=ssl_ctx) as resp:
         charset = resp.headers.get_content_charset() or "utf-8"
         return cast("str", resp.read().decode(charset))
 

--- a/src/deux/render/image_fetch.py
+++ b/src/deux/render/image_fetch.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import logging
+import ssl
 import threading
 import urllib.error
 import urllib.request
@@ -83,7 +84,8 @@ def _http_get_bytes(url: str) -> bytes:
         On network or HTTP errors.
     """
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT) as resp:
+    ssl_ctx = ssl.create_default_context()
+    with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT, context=ssl_ctx) as resp:
         return bytes(resp.read())
 
 

--- a/tests/test_dui_iconify.py
+++ b/tests/test_dui_iconify.py
@@ -276,7 +276,7 @@ class TestHttpGet:
             def __exit__(self, *exc: object) -> None:
                 return None
 
-        def fake_urlopen(req, timeout):
+        def fake_urlopen(req, timeout, context=None):
             captured["request"] = req
             return _FakeResp()
 

--- a/tests/test_image_fetch.py
+++ b/tests/test_image_fetch.py
@@ -187,7 +187,7 @@ class TestHttpGetBytes:
             def __exit__(self, *exc: object) -> None:
                 return None
 
-        def fake_urlopen(req, timeout):
+        def fake_urlopen(req, timeout, context=None):
             captured["request"] = req
             return _FakeResp()
 


### PR DESCRIPTION
Pass `context=ssl.create_default_context()` to all `urllib.request.urlopen` calls to prevent environment-driven SSL verification downgrade.

Closes #225