### PR TITLE
Add DeuxError as common base for all library exceptions

### DIFF
--- a/src/deux/__init__.py
+++ b/src/deux/__init__.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import warnings
 from typing import Any
 
+from ._errors import DeuxError
 from ._url_safety import SSRFError, set_allow_private_urls
 from .dui import (
     DuiCard,
@@ -84,6 +85,7 @@ __all__ = [
     "DeckEvent",
     "DeckManager",
     "DeviceInfo",
+    "DeuxError",
     "DuiCard",
     "DuiKey",
     "DuiRepository",

--- a/src/deux/_errors.py
+++ b/src/deux/_errors.py
@@ -1,0 +1,21 @@
+"""Common base exception for the deux library.
+
+All public exception classes in deux inherit from :class:`DeuxError`,
+allowing callers to catch any library error with a single handler::
+
+    try:
+        ...
+    except deux.DeuxError:
+        ...
+"""
+
+from __future__ import annotations
+
+
+class DeuxError(Exception):
+    """Root exception for every error raised by the deux library.
+
+    Application code can catch ``DeuxError`` to handle any
+    library-level failure in a single clause while still being
+    able to catch more specific subclasses when needed.
+    """

--- a/src/deux/_url_safety.py
+++ b/src/deux/_url_safety.py
@@ -28,12 +28,14 @@ import logging
 import socket
 from urllib.parse import urlparse
 
+from deux._errors import DeuxError
+
 logger = logging.getLogger(__name__)
 
 _allow_private_urls: bool = False
 
 
-class SSRFError(Exception):
+class SSRFError(DeuxError):
     """Raised when a URL targets a blocked private/internal address."""
 
 

--- a/src/deux/dui/iconify.py
+++ b/src/deux/dui/iconify.py
@@ -28,6 +28,7 @@ from typing import cast
 
 import platformdirs
 
+from deux._errors import DeuxError
 from deux._url_safety import check_url
 from deux._version import __version__
 
@@ -46,7 +47,7 @@ _disk_cache_dir: Path | None = None
 _disk_cache_dir_lock = threading.Lock()
 
 
-class IconifyError(Exception):
+class IconifyError(DeuxError):
     """Raised when an Iconify icon cannot be resolved."""
 
 

--- a/src/deux/dui/loader.py
+++ b/src/deux/dui/loader.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import yaml
 
+from .._errors import DeuxError
 from .._xml import safe_fromstring
 from .schema import (
     DEFAULT_HOLD_MS,
@@ -48,13 +49,12 @@ from .schema import (
 )
 
 logger = logging.getLogger(__name__)
-
 _SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
 
 _PRESS_RELEASE_SOURCES = frozenset({"key_press_release", "encoder_press_release"})
 
 
-class PackageError(Exception):
+class PackageError(DeuxError):
     """Raised when a .dui package is invalid or cannot be loaded."""
 
 

--- a/src/deux/render/image_fetch.py
+++ b/src/deux/render/image_fetch.py
@@ -16,6 +16,7 @@ import urllib.request
 
 from PIL import Image, UnidentifiedImageError
 
+from deux._errors import DeuxError
 from deux._url_safety import check_url
 from deux._version import __version__
 
@@ -40,7 +41,7 @@ _cache: dict[str, Image.Image | None] = {}
 _cache_lock = threading.Lock()
 
 
-class ImageFetchError(Exception):
+class ImageFetchError(DeuxError):
     """Raised when a remote image cannot be fetched or decoded."""
 
 

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -51,10 +51,10 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
+from .._errors import DeuxError
 from .._xml import safe_fromstring
 
 logger = logging.getLogger(__name__)
-
 
 def _ensure_macos_lib_path() -> None:
     """Set ``DYLD_FALLBACK_LIBRARY_PATH`` on macOS if Homebrew libs exist.
@@ -70,7 +70,7 @@ def _ensure_macos_lib_path() -> None:
             os.environ.setdefault("DYLD_FALLBACK_LIBRARY_PATH", str(brew_lib))
 
 
-class RasterizeError(Exception):
+class RasterizeError(DeuxError):
     """Raised when SVG rasterisation fails."""
 
 

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 from PIL import Image
 from StreamDeck.DeviceManager import DeviceManager
 
+from .._errors import DeuxError
 from ..render.key_renderer import render_blank_key
 from ..render.metrics import RenderMetrics
 from ..render.touch_renderer import compose_card_with_background
@@ -43,11 +44,11 @@ logger = logging.getLogger(__name__)
 _HID_WRITE_TIMEOUT: float = 2.0
 
 
-class HidWriteTimeout(Exception):
+class HidWriteTimeout(DeuxError):
     """Raised when a HID write exceeds :data:`_HID_WRITE_TIMEOUT`."""
 
 
-class DeckError(Exception):
+class DeckError(DeuxError):
     """Raised for deck-level errors."""
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,6 +25,7 @@ class TestPublicAPI:
             "DeckEvent",
             "DeckManager",
             "DeviceInfo",
+            "DeuxError",
             "DuiCard",
             "DuiKey",
             "DuiRepository",
@@ -209,3 +210,55 @@ class TestDeprecatedImports:
     def test_unknown_attribute_raises(self):
         with pytest.raises(AttributeError, match="no attribute"):
             _ = deux.nonexistent_symbol
+
+
+class TestDeuxErrorHierarchy:
+    """All library exceptions inherit from DeuxError."""
+
+    def test_deux_error_importable(self):
+        from deux import DeuxError
+
+        assert DeuxError is not None
+
+    def test_deux_error_is_exception(self):
+        assert issubclass(deux.DeuxError, Exception)
+
+    def test_deck_error_is_deux_error(self):
+        assert issubclass(deux.DeckError, deux.DeuxError)
+
+    def test_package_error_is_deux_error(self):
+        assert issubclass(deux.PackageError, deux.DeuxError)
+
+    def test_ssrf_error_is_deux_error(self):
+        assert issubclass(deux.SSRFError, deux.DeuxError)
+
+    def test_image_fetch_error_is_deux_error(self):
+        from deux.render import ImageFetchError
+
+        assert issubclass(ImageFetchError, deux.DeuxError)
+
+    def test_rasterize_error_is_deux_error(self):
+        from deux.render import RasterizeError
+
+        assert issubclass(RasterizeError, deux.DeuxError)
+
+    def test_iconify_error_is_deux_error(self):
+        from deux.dui import IconifyError
+
+        assert issubclass(IconifyError, deux.DeuxError)
+
+    def test_hid_write_timeout_is_deux_error(self):
+        from deux.runtime.deck import HidWriteTimeout
+
+        assert issubclass(HidWriteTimeout, deux.DeuxError)
+
+    def test_catch_all_with_deux_error(self):
+        """Catching DeuxError catches any library exception."""
+        with pytest.raises(deux.DeuxError):
+            raise deux.DeckError("test")
+
+        with pytest.raises(deux.DeuxError):
+            raise deux.PackageError("test")
+
+        with pytest.raises(deux.DeuxError):
+            raise deux.SSRFError("test")


### PR DESCRIPTION
Closes #229

## Changes

- Added `DeuxError(Exception)` in `src/deux/_errors.py` as the root exception class
- All 7 library exceptions now inherit from `DeuxError`:
  - `SSRFError` (`_url_safety.py`)
  - `HidWriteTimeout` (`runtime/deck.py`)
  - `DeckError` (`runtime/deck.py`)
  - `PackageError` (`dui/loader.py`)
  - `IconifyError` (`dui/iconify.py`)
  - `ImageFetchError` (`render/image_fetch.py`)
  - `RasterizeError` (`render/svg_rasterize.py`)
- `DeuxError` exported from `deux` top-level package
- Added tests verifying the hierarchy and catch-all behavior
- Fully backward compatible: existing specific catches still work

## Verification

- All 1660 tests pass
- Coverage: 97% (above 95% threshold)
- ruff: clean
- mypy: clean