### PR TITLE
Validate set_brightness input at the API boundary

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -353,6 +353,10 @@ class Deck:
             Brightness level (0-100).  Values outside the range are
             clamped.
         """
+        if not isinstance(percent, int):
+            raise TypeError(
+                f"percent must be an int, got {type(percent).__name__}"
+            )
         clamped = max(0, min(100, percent))
         if clamped == self._brightness:
             return

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -143,6 +143,14 @@ class TestDeckBrightness:
         await deck.set_brightness(80)  # equal to default
         mock_streamdeck_device.set_brightness.assert_not_called()
 
+    async def test_set_brightness_rejects_non_int(self, deck):
+        """Passing a non-int raises TypeError at the API boundary."""
+        with pytest.raises(TypeError, match="percent must be an int"):
+            await deck.set_brightness(50.5)  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="percent must be an int"):
+            await deck.set_brightness("50")  # type: ignore[arg-type]
+
     async def test_set_brightness_emits_clamped_value(self, deck):
         seen: list[int] = []
 


### PR DESCRIPTION
## Summary

Adds input validation to `Deck.set_brightness()` so non-int values raise a clear `TypeError` at the API boundary instead of propagating into the StreamDeck library.

## Changes

- **`src/deux/runtime/deck.py`**: Added `isinstance(percent, int)` check before clamping, raising `TypeError` with a descriptive message.
- **`tests/test_deck.py`**: Added `test_set_brightness_rejects_non_int` covering float and string inputs.

## Checklist

- [x] ruff check passes
- [x] mypy passes
- [x] All 1661 tests pass
- [x] Coverage ≥ 95% (96.89%)

Closes #230