### PR TITLE
perf: offload CPU-bound rasterisation to threads (fixes #185)

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any
@@ -446,17 +447,18 @@ class DuiCard(BindingMixin, Card):
 
         width, height = self._panel_size
         rendered_svg = self._renderer.render_svg()
-        self._spinner_frames = SpinnerFrames(
+        spinner_frames = SpinnerFrames(
             self._spec,
             width=width,
             height=height,
             rendered_svg=rendered_svg,
             bg_tile=self._bg_tile,
         )
+        self._spinner_frames = spinner_frames
 
         self._animator = SpinnerAnimator(
-            frames=self._spinner_frames.frames,
-            interval_ms=self._spinner_frames.interval_ms,
+            frames=await asyncio.to_thread(lambda: spinner_frames.frames),
+            interval_ms=spinner_frames.interval_ms,
             push_fn=self._push_fn,
         )
         await self._animator.start()

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import warnings
 from typing import TYPE_CHECKING, Any
@@ -391,16 +392,17 @@ class DuiKey(BindingMixin, KeySlot):
 
         width, height = self._key_size
         rendered_svg = self._renderer.render_svg()
-        self._spinner_frames = SpinnerFrames(
+        spinner_frames = SpinnerFrames(
             self._spec,
             width=width,
             height=height,
             rendered_svg=rendered_svg,
         )
+        self._spinner_frames = spinner_frames
 
         self._animator = SpinnerAnimator(
-            frames=self._spinner_frames.frames,
-            interval_ms=self._spinner_frames.interval_ms,
+            frames=await asyncio.to_thread(lambda: spinner_frames.frames),
+            interval_ms=spinner_frames.interval_ms,
             push_fn=self._push_fn,
         )
         await self._animator.start()

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -614,18 +614,23 @@ class Deck:
                     async def _push_card_frame(frame_bytes: bytes) -> None:
                         if tile is not None:
                             # Decode the frame, composite onto the bg tile, re-encode
-                            frame_img = Image.open(io.BytesIO(frame_bytes))
-                            out_bytes = compose_card_with_background(
-                                frame_img,
-                                bg_tile=tile,
-                                panel_width=w,
-                                panel_height=h,
-                                image_format=(
-                                    self._caps.touchscreen_image_format
-                                    if self._caps
-                                    else "JPEG"
-                                ),
-                            )
+                            # Offload CPU-bound PIL work to a thread to avoid
+                            # blocking the event loop.
+                            def _compose(fb: bytes = frame_bytes) -> bytes:
+                                frame_img = Image.open(io.BytesIO(fb))
+                                return compose_card_with_background(
+                                    frame_img,
+                                    bg_tile=tile,
+                                    panel_width=w,
+                                    panel_height=h,
+                                    image_format=(
+                                        self._caps.touchscreen_image_format
+                                        if self._caps
+                                        else "JPEG"
+                                    ),
+                                )
+
+                            out_bytes = await asyncio.to_thread(_compose)
                         else:
                             out_bytes = frame_bytes
                         async with self._device_lock:
@@ -657,29 +662,34 @@ class Deck:
 
                 await card.prepare_assets()
 
-                # SVG-native pipeline: render directly to device bytes
+                # SVG-native pipeline: render directly to device bytes.
+                # Offload CPU-bound rasterisation to a thread so the
+                # event loop stays responsive.
                 image_fmt = (
                     self._caps.touchscreen_image_format if self._caps else "JPEG"
                 )
-                panel_bytes = card.render_bytes(
+                panel_bytes = await asyncio.to_thread(
+                    card.render_bytes,
                     panel_width=metrics.panel_width,
                     panel_height=metrics.panel_height,
                     image_format=image_fmt,
                     background=touch_strip.background_color,
                 )
 
-                # Also render a PIL image for caching (used by screenshot)
-                img = card.render()
+                # Also render a PIL image for caching (used by screenshot).
+                # Likewise offloaded because it involves SVG rasterisation.
+                img = await asyncio.to_thread(card.render)
                 card.set_rendered(img)
 
             else:
                 # Non-DUI card: legacy path with Pillow compositing
                 await card.prepare_assets()
-                rendered = card.render()
+                rendered = await asyncio.to_thread(card.render)
                 card.set_rendered(rendered)
 
                 bg_tile = touch_strip.bg_tile(card_idx)
-                panel_bytes = compose_card_with_background(
+                panel_bytes = await asyncio.to_thread(
+                    compose_card_with_background,
                     rendered,
                     bg_tile=bg_tile,
                     background=touch_strip.background_color,

--- a/src/deux/ui/touch_strip.py
+++ b/src/deux/ui/touch_strip.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import xml.etree.ElementTree as ET
@@ -231,6 +232,32 @@ class TouchStrip:
         """
         if self._bg_svg is not None:
             self._rasterize_and_slice()
+
+    async def set_background_svg_async(self, svg_data: bytes) -> None:
+        """Async variant of :meth:`set_background_svg`.
+
+        Offloads the CPU-bound SVG rasterisation to a worker thread
+        so the event loop stays responsive.
+
+        Parameters
+        ----------
+        svg_data
+            Raw SVG content as UTF-8 bytes.
+        """
+        self._bg_svg = svg_data
+        self._bg_svg_root = safe_fromstring(svg_data)
+        await asyncio.to_thread(self._rasterize_and_slice)
+        for card in self._cards:
+            card.mark_dirty()
+
+    async def invalidate_background_async(self) -> None:
+        """Async variant of :meth:`invalidate_background`.
+
+        Offloads the CPU-bound SVG rasterisation to a worker thread
+        so the event loop stays responsive.
+        """
+        if self._bg_svg is not None:
+            await asyncio.to_thread(self._rasterize_and_slice)
 
     def _rasterize_and_slice(self) -> None:
         """Rasterize the background SVG and slice into per-panel tiles.

--- a/tests/test_busy_guard.py
+++ b/tests/test_busy_guard.py
@@ -382,3 +382,57 @@ class TestSpinnerManifestValidation:
 
         with pytest.raises(PackageError, match="background_node.*does not exist in the SVG"):
             load_package(pkg_dir)
+
+
+# ── Cancellation during in-flight rasterisation ─────────────────────
+
+
+class TestCancellationDuringRasterisation:
+    """Verify that cancelling during offloaded rasterisation is handled."""
+
+    @patch(
+        "deux.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_card_cancel_during_spinner_start(self, mock_raster):
+        """Cancelling the task that runs start_busy should not leave broken state."""
+        import asyncio
+
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
+        spec = _make_card_spec(spinner=spinner)
+        card = DuiCard(spec)
+        push_fn = AsyncMock()
+        card.set_push_fn(push_fn, panel_size=(200, 100))
+
+        task = asyncio.create_task(card.start_busy())
+        # Let the event loop progress then cancel
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Card may or may not be busy depending on timing, but must not raise
+        # on subsequent operations.
+        await card.finish_busy()
+
+    @patch(
+        "deux.render.svg_rasterize._svg_to_png",
+        side_effect=lambda b, w, h: _fake_png(w, h),
+    )
+    async def test_key_cancel_during_spinner_start(self, mock_raster):
+        """Cancelling the task that runs start_busy on a key should not leave broken state."""
+        import asyncio
+
+        spinner = SpinnerSpec(type=SpinnerType.ROTATION, node="spinner", frames=4)
+        spec = _make_key_spec(spinner=spinner)
+        key = DuiKey(spec)
+        push_fn = AsyncMock()
+        key.set_push_fn(push_fn, key_size=(120, 120))
+
+        task = asyncio.create_task(key.start_busy())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        await key.finish_busy()

--- a/tests/test_touch_strip.py
+++ b/tests/test_touch_strip.py
@@ -606,3 +606,63 @@ class TestTouchStripInvalidateBackground:
         ts = TouchStrip(panel_count=2, panel_width=100, panel_height=50)
         ts.invalidate_background()
         assert ts.bg_tiles is None
+
+
+class TestTouchStripAsyncRasterisation:
+    """Tests for async variants that offload rasterisation to a thread."""
+
+    @staticmethod
+    def _make_svg(width: int = 800, height: int = 100, fill: str = "red") -> bytes:
+        """Create a minimal solid-fill SVG for testing."""
+        return (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+            f'<rect width="{width}" height="{height}" fill="{fill}"/>'
+            f"</svg>"
+        ).encode()
+
+    async def test_set_background_svg_async_creates_tiles(self):
+        """set_background_svg_async should produce the same tiles as the sync variant."""
+        ts = TouchStrip(panel_count=4, panel_width=200, panel_height=100)
+        await ts.set_background_svg_async(self._make_svg())
+        assert ts.bg_tiles is not None
+        assert len(ts.bg_tiles) == 4
+        for tile in ts.bg_tiles:
+            assert tile.size == (200, 100)
+
+    async def test_set_background_svg_async_marks_dirty(self):
+        """set_background_svg_async should mark all cards dirty."""
+        ts = TouchStrip(panel_count=4, panel_width=200, panel_height=100)
+        for card in ts.cards:
+            card.mark_clean()
+        await ts.set_background_svg_async(self._make_svg())
+        assert ts.any_dirty is True
+
+    async def test_invalidate_background_async_rerasterizes(self):
+        """invalidate_background_async should re-slice the cached SVG."""
+        ts = TouchStrip(panel_count=2, panel_width=100, panel_height=50)
+        ts.set_background_svg(self._make_svg(width=200, height=50))
+        old_tiles = ts.bg_tiles
+        await ts.invalidate_background_async()
+        assert ts.bg_tiles is not None
+        assert ts.bg_tiles is not old_tiles
+
+    async def test_invalidate_background_async_noop_without_svg(self):
+        """invalidate_background_async is a no-op when no SVG is set."""
+        ts = TouchStrip(panel_count=2, panel_width=100, panel_height=50)
+        await ts.invalidate_background_async()
+        assert ts.bg_tiles is None
+
+    async def test_cancel_during_async_set_background(self):
+        """Cancelling during set_background_svg_async should not corrupt state."""
+        import asyncio
+
+        ts = TouchStrip(panel_count=2, panel_width=100, panel_height=50)
+        task = asyncio.create_task(
+            ts.set_background_svg_async(self._make_svg(width=200, height=50))
+        )
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Should not raise on subsequent calls
+        ts.invalidate_background()


### PR DESCRIPTION
## Summary

Wraps all CPU-bound SVG rasterisation, PIL encode/decode, and spinner frame generation in `asyncio.to_thread()` so they no longer block the event loop.

## Changes

### `src/deux/runtime/deck.py`
- `card.render_bytes()` and `card.render()` now run via `await asyncio.to_thread()`
- `compose_card_with_background()` in both the spinner push closure and the legacy card path now runs via `await asyncio.to_thread()`

### `src/deux/dui/key.py` / `src/deux/dui/card.py`
- `SpinnerFrames.frames` (lazy property that generates all rotation frames) is now accessed via `await asyncio.to_thread()` in `_start_spinner`

### `src/deux/ui/touch_strip.py`
- Added `set_background_svg_async()` and `invalidate_background_async()` — async variants that offload the CPU-bound `_rasterize_and_slice` to a thread
- Sync API preserved for backward compatibility

### Tests
- Added cancellation tests for card and key spinner start (`test_busy_guard.py`)
- Added async rasterisation tests and cancellation test for TouchStrip (`test_touch_strip.py`)

## Verification
- All 1668 tests pass
- Coverage: 96.90% (threshold: 95%)
- ruff: clean
- mypy: clean

Closes #185