### PR TITLE
refactor: unify KeySlot/DuiKey handler dispatch (#194)

### DIFF
--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -328,12 +328,7 @@ class DuiKey(BindingMixin, KeySlot):
             background="black",
         )
 
-    @property
-    def has_dui_content(self) -> bool:
-        """Always ``True`` — this key is backed by a .dui package."""
-        return True
-
-    async def dispatch(self, pressed: bool) -> None:
+    async def _dispatch_event(self, pressed: bool) -> None:
         """Dispatch a key press/release through the event map.
 
         All matching handlers (simple and compound) are called.
@@ -350,7 +345,7 @@ class DuiKey(BindingMixin, KeySlot):
             for handler in handlers:
                 await handler()
         else:
-            await super().dispatch(pressed)
+            await super()._dispatch_event(pressed)
 
     async def start_busy(self) -> None:
         """Enter the busy state and start the spinner animation.

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -12,6 +12,7 @@ from PIL import Image
 from StreamDeck.DeviceManager import DeviceManager
 
 from .._errors import DeuxError
+from ..dui.key import DuiKey
 from ..render.key_renderer import render_blank_key
 from ..render.metrics import RenderMetrics
 from ..render.touch_renderer import compose_card_with_background
@@ -30,7 +31,6 @@ from .transport import AsyncTransport
 
 if TYPE_CHECKING:
     from ..dui.animator import PushFn
-    from ..dui.key import DuiKey
     from ..render.theme import Theme
     from ..ui.cards.base import Card
     from ..ui.controls.key_slot import KeySlot
@@ -502,7 +502,7 @@ class Deck:
     @staticmethod
     def _is_dui_key(key_slot: KeySlot) -> bool:
         """Check whether a key slot is a DuiKey."""
-        return getattr(key_slot, "has_dui_content", False)
+        return isinstance(key_slot, DuiKey)
 
     @staticmethod
     def _is_animating(obj: Any) -> bool:

--- a/src/deux/ui/controls/key_slot.py
+++ b/src/deux/ui/controls/key_slot.py
@@ -102,7 +102,23 @@ class KeySlot:
         return handler
 
     async def dispatch(self, pressed: bool) -> None:
-        """Dispatch a press or release event through the registered handlers."""
+        """Dispatch a press or release event through the internal hook.
+
+        Subclasses should override :meth:`_dispatch_event` to customise
+        event handling without replacing the public entry point.
+        """
+        await self._dispatch_event(pressed)
+
+    async def _dispatch_event(self, pressed: bool) -> None:
+        """Internal dispatch hook — override in subclasses.
+
+        The default implementation calls the registered press/release handler.
+
+        Parameters
+        ----------
+        pressed : bool
+            ``True`` for a press event, ``False`` for a release event.
+        """
         handler = self._press_handler if pressed else self._release_handler
         if handler is not None:
             await handler()

--- a/tests/test_dui_key.py
+++ b/tests/test_dui_key.py
@@ -65,10 +65,10 @@ class TestDuiKeyIsKeySlot:
         key = DuiKey(spec)
         assert key.spec is spec
 
-    def test_has_dui_content(self):
+    def test_is_dui_key_instance(self):
         spec = _make_key_spec()
         key = DuiKey(spec)
-        assert key.has_dui_content is True
+        assert isinstance(key, DuiKey)
 
 
 class TestDuiKeyDataBinding:


### PR DESCRIPTION
## Summary

Unifies the KeySlot and DuiKey handler dispatch into a single internal mechanism, addressing issue #194.

## Changes

- **KeySlot**: Added `_dispatch_event()` internal hook method. The public `dispatch()` now delegates to this hook, giving subclasses a clean override point.
- **DuiKey**: Overrides `_dispatch_event()` instead of `dispatch()` directly. Removed the `has_dui_content` property.
- **Deck**: Replaced `getattr(key_slot, 'has_dui_content', False)` with `isinstance(key_slot, DuiKey)` — a proper type check.

## Acceptance Criteria

- [x] Single internal event dispatch mechanism on KeySlot that DuiKey overrides
- [x] `getattr(..., 'has_dui_content', ...)` hack removed
- [x] `Deck._is_dui_key` uses proper isinstance check
- [x] No change to public handler registration API
- [x] All 1668 tests pass, coverage 96.9% (>95%), ruff clean, mypy clean

Closes #194
Absorbs #32, #52