### PR TITLE
refactor: extract rendering logic from Deck into DeckRenderer (#195)

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -15,13 +15,8 @@ from ._executor import get_executor, shutdown_executor
 from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .device_info import DeviceInfo
-from .events import (
-    DeckEvent,
-    EncoderPressEvent,
-    EncoderTurnEvent,
-    KeyEvent,
-    TouchEvent,
-)
+from .event_router import DeckEventRouter
+from .events import DeckEvent
 from .renderer import DeckRenderer
 from .transport import AsyncTransport
 
@@ -102,6 +97,7 @@ class Deck:
         self.on_screen_changed = AsyncEvent()
 
         self._renderer = DeckRenderer(self)
+        self._event_router = DeckEventRouter(self)
 
     async def start(self) -> None:
         """Discover the device by serial, open it, and start the event loop."""
@@ -588,44 +584,4 @@ class Deck:
 
     async def _dispatch(self, event: DeckEvent) -> None:
         """Dispatch a single event to the appropriate handler on the active screen."""
-        screen = self._current_screen()
-        if not screen:
-            return
-
-        if isinstance(event, KeyEvent):
-            key_slot = screen.keys.get(event.key)
-            if key_slot:
-                await key_slot.dispatch(event.pressed)
-                if key_slot.is_dirty:
-                    await self.refresh()
-
-        elif isinstance(event, EncoderTurnEvent):
-            encoder = screen.encoders.get(event.encoder)
-            if encoder:
-                await encoder.dispatch_turn(event.direction)
-            if screen.touch_strip is not None:
-                card = screen.touch_strip.card(event.encoder)
-                await card.dispatch_encoder_turn(event.direction)
-                await self._drain_card_callbacks(card)
-                if card.is_dirty:
-                    await self.refresh()
-
-        elif isinstance(event, EncoderPressEvent):
-            encoder = screen.encoders.get(event.encoder)
-            if encoder:
-                await encoder.dispatch_press(event.pressed)
-            if screen.touch_strip is not None:
-                card = screen.touch_strip.card(event.encoder)
-                if event.pressed:
-                    await card.dispatch_encoder_press()
-                else:
-                    await card.dispatch_encoder_release()
-                await self._drain_card_callbacks(card)
-                if card.is_dirty:
-                    await self.refresh()
-
-        elif isinstance(event, TouchEvent):
-            if screen.touch_strip is not None and self._metrics is not None:
-                zone = event.compute_zone(self._metrics)
-                card = screen.touch_strip.card(zone)
-                await card.dispatch_touch(event)
+        await self._event_router.dispatch(event)

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -3,19 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
-from PIL import Image
 from StreamDeck.DeviceManager import DeviceManager
 
 from .._errors import DeuxError
-from ..dui.key import DuiKey
-from ..render.key_renderer import render_blank_key
 from ..render.metrics import RenderMetrics
-from ..render.touch_renderer import compose_card_with_background
 from ._executor import get_executor, shutdown_executor
 from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
@@ -27,13 +22,11 @@ from .events import (
     KeyEvent,
     TouchEvent,
 )
+from .renderer import DeckRenderer
 from .transport import AsyncTransport
 
 if TYPE_CHECKING:
-    from ..dui.animator import PushFn
     from ..render.theme import Theme
-    from ..ui.cards.base import Card
-    from ..ui.controls.key_slot import KeySlot
     from ..ui.screen import Screen
 
 logger = logging.getLogger(__name__)
@@ -107,6 +100,8 @@ class Deck:
 
         self.on_brightness_changed = AsyncEvent()
         self.on_screen_changed = AsyncEvent()
+
+        self._renderer = DeckRenderer(self)
 
     async def start(self) -> None:
         """Discover the device by serial, open it, and start the event loop."""
@@ -330,14 +325,7 @@ class Deck:
         str
             CSS stylesheet string from the most specific theme.
         """
-        from ..render.theme import get_active_theme
-
-        screen = self._active_screen
-        if screen is not None and screen.theme is not None:
-            return screen.theme.css
-        if self._theme is not None:
-            return self._theme.css
-        return get_active_theme().css
+        return self._renderer._resolve_stylesheet()
 
     async def set_brightness(self, percent: int) -> None:
         """Set screen brightness.
@@ -425,9 +413,7 @@ class Deck:
         logger.info("Switching to screen: %s", name)
 
         # Apply the resolved theme cascade for this screen.
-        from ..render.svg_rasterize import set_svg_stylesheet
-
-        set_svg_stylesheet(self._resolve_stylesheet())
+        self._renderer.apply_theme()
 
         self._wire_refresh_callbacks()
 
@@ -466,50 +452,19 @@ class Deck:
 
     async def _render_all_keys(self) -> None:
         """Render and push all key images for the active screen."""
-        screen = self._current_screen()
-        if not self._device or not screen:
-            return
-
-        caps = self._caps
-        if caps is None:
-            return
-
-        metrics = self._metrics
-
-        if metrics is None:
-            return
-
-        for key_index in range(caps.key_count):
-            key_slot = screen.keys.get(key_index)
-            if key_slot and self._is_dui_key(key_slot):
-                await self._render_dui_key(key_slot, key_index)
-            else:
-                bg_image = screen.key_bg_image
-                if bg_image is not None:
-                    image_bytes = bg_image
-                else:
-                    image_bytes = render_blank_key(
-                        key_size=metrics.key_size,
-                        image_format=caps.key_image_format,
-                    )
-                async with self._device_lock:
-                    await self._exec_device_io(
-                        self._device.set_key_image,
-                        key_index,
-                        image_bytes,
-                    )
+        await self._renderer.render_all_keys()
 
     @staticmethod
-    def _is_dui_key(key_slot: KeySlot) -> bool:
+    def _is_dui_key(key_slot: Any) -> bool:
         """Check whether a key slot is a DuiKey."""
-        return isinstance(key_slot, DuiKey)
+        return DeckRenderer.is_dui_key(key_slot)
 
     @staticmethod
     def _is_animating(obj: Any) -> bool:
         """Check whether a card or key has an active spinner animation."""
-        return getattr(obj, "is_animating", False)
+        return DeckRenderer.is_animating(obj)
 
-    async def _render_dui_key(self, key_slot: KeySlot, key_index: int) -> None:
+    async def _render_dui_key(self, key_slot: Any, key_index: int) -> None:
         """Render a DuiKey and push to the device.
 
         Parameters
@@ -517,222 +472,17 @@ class Deck:
         key_slot
             The DuiKey to render.
         key_index
-            The screen slot the key is currently installed at.  This is
-            authoritative for routing (a single DuiKey may live on
-            multiple screens at different slots), so the spinner
-            ``push_fn`` is rewired on every render to capture the active
-            slot.
+            The screen slot the key is currently installed at.
         """
-        if not self._device:
-            return
-
-        dui_key = cast("DuiKey", key_slot)
-
-        # Skip rendering if a spinner animation is active
-        if self._is_animating(dui_key):
-            return
-
-        # Re-wire push_fn every render so a DuiKey reused across screens
-        # always animates at the slot of the currently active screen.
-        async def _push_key_frame(frame_bytes: bytes) -> None:
-            async with self._device_lock:
-                await self._exec_device_io(
-                    self._device.set_key_image,
-                    key_index,
-                    frame_bytes,
-                )
-
-        if self._caps is None:
-            return
-
-        dui_key.set_push_fn(_push_key_frame, key_size=self._caps.key_size)
-
-        image_bytes = dui_key.render_image(
-            key_size=self._caps.key_size,
-            image_format=self._caps.key_image_format,
-        )
-        dui_key.set_rendered_image(image_bytes)
-
-        async with self._device_lock:
-            await self._exec_device_io(
-                self._device.set_key_image,
-                key_index,
-                image_bytes,
-            )
+        await self._renderer.render_dui_key(key_slot, key_index)
 
     async def _render_touchscreen(self) -> None:
-        """Render and push each card panel individually to the device.
-
-        Uses the SVG-native pipeline for DuiCards: background
-        compositing happens at the SVG level, and each panel is
-        rasterised directly to device-ready bytes and pushed as a
-        per-panel update.
-
-        Non-DUI cards fall back to the legacy Pillow compositing path.
-        """
-        screen = self._current_screen()
-        if not self._device or not screen or not self._metrics:
-            return
-
-        if screen.touch_strip is None:
-            return
-
-        metrics = self._metrics
-        touch_strip = screen.touch_strip
-
-        from ..dui.card import DuiCard
-
-        bg_svg_root = touch_strip.bg_svg_root
-
-        for card_idx, card in enumerate(screen.cards):
-            x_pos = card_idx * metrics.panel_width
-            y_pos = 0
-
-            if isinstance(card, DuiCard):
-                # Set up background layer for SVG-level compositing
-                bg_tile = touch_strip.bg_tile(card_idx)
-                card.set_bg_tile(bg_tile)
-
-                if bg_svg_root is not None:
-                    card.set_background_layer(
-                        bg_svg_root,
-                        card_idx,
-                        metrics.panel_width,
-                        metrics.panel_height,
-                    )
-                else:
-                    card.clear_background_layer()
-
-                # Wire push_fn for spinner animations (per-panel update)
-                async def _make_push(
-                    x: int,
-                    y: int,
-                    w: int,
-                    h: int,
-                    tile: Image.Image | None,
-                ) -> PushFn:
-                    async def _push_card_frame(frame_bytes: bytes) -> None:
-                        if tile is not None:
-                            # Decode the frame, composite onto the bg tile, re-encode
-                            # Offload CPU-bound PIL work to a thread to avoid
-                            # blocking the event loop.
-                            def _compose(fb: bytes = frame_bytes) -> bytes:
-                                frame_img = Image.open(io.BytesIO(fb))
-                                return compose_card_with_background(
-                                    frame_img,
-                                    bg_tile=tile,
-                                    panel_width=w,
-                                    panel_height=h,
-                                    image_format=(
-                                        self._caps.touchscreen_image_format
-                                        if self._caps
-                                        else "JPEG"
-                                    ),
-                                )
-
-                            out_bytes = await asyncio.to_thread(_compose)
-                        else:
-                            out_bytes = frame_bytes
-                        async with self._device_lock:
-                            await self._exec_device_io(
-                                self._device.set_touchscreen_image,
-                                out_bytes,
-                                x,
-                                y,
-                                w,
-                                h,
-                            )
-
-                    return _push_card_frame
-
-                push_fn = await _make_push(
-                    x_pos,
-                    y_pos,
-                    metrics.panel_width,
-                    metrics.panel_height,
-                    bg_tile,
-                )
-                card.set_push_fn(
-                    push_fn, panel_size=(metrics.panel_width, metrics.panel_height)
-                )
-
-                # Skip re-rendering cards with active spinner animations
-                if self._is_animating(card):
-                    continue
-
-                await card.prepare_assets()
-
-                # SVG-native pipeline: render directly to device bytes.
-                # Offload CPU-bound rasterisation to a thread so the
-                # event loop stays responsive.
-                image_fmt = (
-                    self._caps.touchscreen_image_format if self._caps else "JPEG"
-                )
-                panel_bytes = await asyncio.to_thread(
-                    card.render_bytes,
-                    panel_width=metrics.panel_width,
-                    panel_height=metrics.panel_height,
-                    image_format=image_fmt,
-                    background=touch_strip.background_color,
-                )
-
-                # Also render a PIL image for caching (used by screenshot).
-                # Likewise offloaded because it involves SVG rasterisation.
-                img = await asyncio.to_thread(card.render)
-                card.set_rendered(img)
-
-            else:
-                # Non-DUI card: legacy path with Pillow compositing
-                await card.prepare_assets()
-                rendered = await asyncio.to_thread(card.render)
-                card.set_rendered(rendered)
-
-                bg_tile = touch_strip.bg_tile(card_idx)
-                panel_bytes = await asyncio.to_thread(
-                    compose_card_with_background,
-                    rendered,
-                    bg_tile=bg_tile,
-                    background=touch_strip.background_color,
-                    panel_width=metrics.panel_width,
-                    panel_height=metrics.panel_height,
-                    image_format=(
-                        self._caps.touchscreen_image_format if self._caps else "JPEG"
-                    ),
-                )
-
-            # Push per-panel update
-            async with self._device_lock:
-                await self._exec_device_io(
-                    self._device.set_touchscreen_image,
-                    panel_bytes,
-                    x_pos,
-                    y_pos,
-                    metrics.panel_width,
-                    metrics.panel_height,
-                )
+        """Render and push each card panel individually to the device."""
+        await self._renderer.render_touchscreen()
 
     async def _render_info_screen(self) -> None:
         """Render and push the info screen image (e.g. Neo)."""
-        screen = self._current_screen()
-        if not self._device or not screen:
-            return
-
-        info = screen.info_screen
-        if info is None:
-            return
-
-        image_bytes = info.render_bytes()
-
-        async with self._device_lock:
-            await self._exec_device_io(
-                self._device.set_screen_image,
-                image_bytes,
-                0,
-                0,
-                info.width,
-                info.height,
-            )
-        info.mark_clean()
+        await self._renderer.render_info_screen()
 
     async def refresh(self) -> None:
         """Re-render and push all dirty controls on the active screen.
@@ -832,10 +582,9 @@ class Deck:
                     await self._timeout_task
             self._closed_event.set()
 
-    async def _drain_card_callbacks(self, card: Card) -> None:
+    async def _drain_card_callbacks(self, card: Any) -> None:
         """Drain and await all pending callbacks queued on a card."""
-        for handler, args in card.drain_pending_callbacks():
-            await handler(*args)
+        await self._renderer.drain_card_callbacks(card)
 
     async def _dispatch(self, event: DeckEvent) -> None:
         """Dispatch a single event to the appropriate handler on the active screen."""

--- a/src/deux/runtime/event_router.py
+++ b/src/deux/runtime/event_router.py
@@ -1,0 +1,145 @@
+"""DeckEventRouter: extracted event dispatch logic for Stream Deck devices.
+
+Routes transport events (key presses, encoder turns/presses, touch
+events) to the appropriate screen handlers, separated from the
+lifecycle and rendering responsibilities of
+:class:`~deux.runtime.deck.Deck`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .events import (
+    DeckEvent,
+    EncoderPressEvent,
+    EncoderTurnEvent,
+    KeyEvent,
+    TouchEvent,
+)
+
+if TYPE_CHECKING:
+    from .deck import Deck
+
+logger = logging.getLogger(__name__)
+
+
+class DeckEventRouter:
+    """Routes transport events to the active screen's handlers.
+
+    This class owns the event dispatch logic that was previously
+    embedded in ``Deck._dispatch``.  It operates on the deck's active
+    screen, metrics, and refresh/drain helpers via a back-reference to
+    the parent ``Deck`` instance.
+
+    Parameters
+    ----------
+    deck : Deck
+        The parent deck instance whose state is used for routing.
+    """
+
+    def __init__(self, deck: Deck) -> None:
+        self._deck = deck
+
+    async def dispatch(self, event: DeckEvent) -> None:
+        """Dispatch a single event to the appropriate handler on the active screen.
+
+        Parameters
+        ----------
+        event : DeckEvent
+            The transport event to route.  Supported types are
+            :class:`KeyEvent`, :class:`EncoderTurnEvent`,
+            :class:`EncoderPressEvent`, and :class:`TouchEvent`.
+        """
+        deck = self._deck
+        screen = deck._current_screen()
+        if not screen:
+            return
+
+        if isinstance(event, KeyEvent):
+            await self._dispatch_key(screen, event)
+        elif isinstance(event, EncoderTurnEvent):
+            await self._dispatch_encoder_turn(screen, event)
+        elif isinstance(event, EncoderPressEvent):
+            await self._dispatch_encoder_press(screen, event)
+        elif isinstance(event, TouchEvent):
+            await self._dispatch_touch(screen, event)
+
+    async def _dispatch_key(self, screen: Any, event: KeyEvent) -> None:
+        """Dispatch a key press/release event.
+
+        Parameters
+        ----------
+        screen : Screen
+            The currently active screen.
+        event : KeyEvent
+            The key event to dispatch.
+        """
+        key_slot = screen.keys.get(event.key)
+        if key_slot:
+            await key_slot.dispatch(event.pressed)
+            if key_slot.is_dirty:
+                await self._deck.refresh()
+
+    async def _dispatch_encoder_turn(
+        self, screen: Any, event: EncoderTurnEvent
+    ) -> None:
+        """Dispatch an encoder turn event.
+
+        Parameters
+        ----------
+        screen : Screen
+            The currently active screen.
+        event : EncoderTurnEvent
+            The encoder turn event to dispatch.
+        """
+        encoder = screen.encoders.get(event.encoder)
+        if encoder:
+            await encoder.dispatch_turn(event.direction)
+        if screen.touch_strip is not None:
+            card = screen.touch_strip.card(event.encoder)
+            await card.dispatch_encoder_turn(event.direction)
+            await self._deck._drain_card_callbacks(card)
+            if card.is_dirty:
+                await self._deck.refresh()
+
+    async def _dispatch_encoder_press(
+        self, screen: Any, event: EncoderPressEvent
+    ) -> None:
+        """Dispatch an encoder press/release event.
+
+        Parameters
+        ----------
+        screen : Screen
+            The currently active screen.
+        event : EncoderPressEvent
+            The encoder press event to dispatch.
+        """
+        encoder = screen.encoders.get(event.encoder)
+        if encoder:
+            await encoder.dispatch_press(event.pressed)
+        if screen.touch_strip is not None:
+            card = screen.touch_strip.card(event.encoder)
+            if event.pressed:
+                await card.dispatch_encoder_press()
+            else:
+                await card.dispatch_encoder_release()
+            await self._deck._drain_card_callbacks(card)
+            if card.is_dirty:
+                await self._deck.refresh()
+
+    async def _dispatch_touch(self, screen: Any, event: TouchEvent) -> None:
+        """Dispatch a touchscreen event.
+
+        Parameters
+        ----------
+        screen : Screen
+            The currently active screen.
+        event : TouchEvent
+            The touch event to dispatch.
+        """
+        if screen.touch_strip is not None and self._deck._metrics is not None:
+            zone = event.compute_zone(self._deck._metrics)
+            card = screen.touch_strip.card(zone)
+            await card.dispatch_touch(event)

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -1,0 +1,405 @@
+"""DeckRenderer: extracted rendering logic for Stream Deck devices.
+
+Handles key, touchscreen, and info-screen rendering pipelines,
+separated from the lifecycle and event-dispatch responsibilities
+of :class:`~deux.runtime.deck.Deck`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from PIL import Image
+
+from ..dui.key import DuiKey
+from ..render.key_renderer import render_blank_key
+from ..render.touch_renderer import compose_card_with_background
+
+if TYPE_CHECKING:
+    from ..dui.animator import PushFn
+    from ..render.metrics import RenderMetrics
+    from ..ui.cards.base import Card
+    from ..ui.controls.key_slot import KeySlot
+    from .capabilities import DeviceCapabilities
+    from .deck import Deck
+
+logger = logging.getLogger(__name__)
+
+
+class DeckRenderer:
+    """Encapsulates all rendering pipelines for a single :class:`Deck`.
+
+    This class owns the key, touchscreen, and info-screen render methods
+    that were previously embedded in ``Deck``.  It operates on the deck's
+    device, capabilities, metrics, and active screen via a back-reference
+    to the parent ``Deck`` instance.
+
+    Parameters
+    ----------
+    deck : Deck
+        The parent deck instance whose device and state are used for
+        rendering.
+    """
+
+    def __init__(self, deck: Deck) -> None:
+        self._deck = deck
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_dui_key(key_slot: KeySlot) -> bool:
+        """Check whether a key slot is a DuiKey.
+
+        Parameters
+        ----------
+        key_slot : KeySlot
+            The key slot to inspect.
+
+        Returns
+        -------
+        bool
+            ``True`` if *key_slot* is a :class:`DuiKey`.
+        """
+        return isinstance(key_slot, DuiKey)
+
+    @staticmethod
+    def is_animating(obj: Any) -> bool:
+        """Check whether a card or key has an active spinner animation.
+
+        Parameters
+        ----------
+        obj : Any
+            Object to inspect (typically a :class:`DuiKey` or
+            :class:`Card`).
+
+        Returns
+        -------
+        bool
+            ``True`` if *obj* has ``is_animating`` set to ``True``.
+        """
+        return getattr(obj, "is_animating", False)
+
+    def _resolve_stylesheet(self) -> str:
+        """Resolve the effective CSS stylesheet for the active screen.
+
+        The cascade is: screen theme > deck theme > system theme.
+
+        Returns
+        -------
+        str
+            CSS stylesheet string from the most specific theme.
+        """
+        from ..render.theme import get_active_theme
+
+        screen = self._deck._active_screen
+        if screen is not None and screen.theme is not None:
+            return screen.theme.css
+        if self._deck._theme is not None:
+            return self._deck._theme.css
+        return get_active_theme().css
+
+    # ------------------------------------------------------------------
+    # Key rendering
+    # ------------------------------------------------------------------
+
+    async def render_all_keys(self) -> None:
+        """Render and push all key images for the active screen."""
+        deck = self._deck
+        screen = deck._current_screen()
+        if not deck._device or not screen:
+            return
+
+        caps: DeviceCapabilities | None = deck._caps
+        if caps is None:
+            return
+
+        metrics: RenderMetrics | None = deck._metrics
+        if metrics is None:
+            return
+
+        for key_index in range(caps.key_count):
+            key_slot = screen.keys.get(key_index)
+            if key_slot and self.is_dui_key(key_slot):
+                await self.render_dui_key(key_slot, key_index)
+            else:
+                bg_image = screen.key_bg_image
+                if bg_image is not None:
+                    image_bytes = bg_image
+                else:
+                    image_bytes = render_blank_key(
+                        key_size=metrics.key_size,
+                        image_format=caps.key_image_format,
+                    )
+                async with deck._device_lock:
+                    await deck._exec_device_io(
+                        deck._device.set_key_image,
+                        key_index,
+                        image_bytes,
+                    )
+
+    async def render_dui_key(self, key_slot: KeySlot, key_index: int) -> None:
+        """Render a DuiKey and push to the device.
+
+        Parameters
+        ----------
+        key_slot : KeySlot
+            The DuiKey to render.
+        key_index : int
+            The screen slot the key is currently installed at.  This is
+            authoritative for routing (a single DuiKey may live on
+            multiple screens at different slots), so the spinner
+            ``push_fn`` is rewired on every render to capture the active
+            slot.
+        """
+        deck = self._deck
+        if not deck._device:
+            return
+
+        dui_key = cast("DuiKey", key_slot)
+
+        # Skip rendering if a spinner animation is active
+        if self.is_animating(dui_key):
+            return
+
+        # Re-wire push_fn every render so a DuiKey reused across screens
+        # always animates at the slot of the currently active screen.
+        async def _push_key_frame(frame_bytes: bytes) -> None:
+            async with deck._device_lock:
+                await deck._exec_device_io(
+                    deck._device.set_key_image,
+                    key_index,
+                    frame_bytes,
+                )
+
+        if deck._caps is None:
+            return
+
+        dui_key.set_push_fn(_push_key_frame, key_size=deck._caps.key_size)
+
+        image_bytes = dui_key.render_image(
+            key_size=deck._caps.key_size,
+            image_format=deck._caps.key_image_format,
+        )
+        dui_key.set_rendered_image(image_bytes)
+
+        async with deck._device_lock:
+            await deck._exec_device_io(
+                deck._device.set_key_image,
+                key_index,
+                image_bytes,
+            )
+
+    # ------------------------------------------------------------------
+    # Touchscreen rendering
+    # ------------------------------------------------------------------
+
+    async def render_touchscreen(self) -> None:
+        """Render and push each card panel individually to the device.
+
+        Uses the SVG-native pipeline for DuiCards: background
+        compositing happens at the SVG level, and each panel is
+        rasterised directly to device-ready bytes and pushed as a
+        per-panel update.
+
+        Non-DUI cards fall back to the legacy Pillow compositing path.
+        """
+        deck = self._deck
+        screen = deck._current_screen()
+        if not deck._device or not screen or not deck._metrics:
+            return
+
+        if screen.touch_strip is None:
+            return
+
+        metrics = deck._metrics
+        touch_strip = screen.touch_strip
+
+        from ..dui.card import DuiCard
+
+        bg_svg_root = touch_strip.bg_svg_root
+
+        for card_idx, card in enumerate(screen.cards):
+            x_pos = card_idx * metrics.panel_width
+            y_pos = 0
+
+            if isinstance(card, DuiCard):
+                # Set up background layer for SVG-level compositing
+                bg_tile = touch_strip.bg_tile(card_idx)
+                card.set_bg_tile(bg_tile)
+
+                if bg_svg_root is not None:
+                    card.set_background_layer(
+                        bg_svg_root,
+                        card_idx,
+                        metrics.panel_width,
+                        metrics.panel_height,
+                    )
+                else:
+                    card.clear_background_layer()
+
+                # Wire push_fn for spinner animations (per-panel update)
+                async def _make_push(
+                    x: int,
+                    y: int,
+                    w: int,
+                    h: int,
+                    tile: Image.Image | None,
+                ) -> PushFn:
+                    async def _push_card_frame(frame_bytes: bytes) -> None:
+                        if tile is not None:
+                            # Decode the frame, composite onto the bg tile, re-encode
+                            # Offload CPU-bound PIL work to a thread to avoid
+                            # blocking the event loop.
+                            def _compose(fb: bytes = frame_bytes) -> bytes:
+                                frame_img = Image.open(io.BytesIO(fb))
+                                return compose_card_with_background(
+                                    frame_img,
+                                    bg_tile=tile,
+                                    panel_width=w,
+                                    panel_height=h,
+                                    image_format=(
+                                        deck._caps.touchscreen_image_format
+                                        if deck._caps
+                                        else "JPEG"
+                                    ),
+                                )
+
+                            out_bytes = await asyncio.to_thread(_compose)
+                        else:
+                            out_bytes = frame_bytes
+                        async with deck._device_lock:
+                            await deck._exec_device_io(
+                                deck._device.set_touchscreen_image,
+                                out_bytes,
+                                x,
+                                y,
+                                w,
+                                h,
+                            )
+
+                    return _push_card_frame
+
+                push_fn = await _make_push(
+                    x_pos,
+                    y_pos,
+                    metrics.panel_width,
+                    metrics.panel_height,
+                    bg_tile,
+                )
+                card.set_push_fn(
+                    push_fn, panel_size=(metrics.panel_width, metrics.panel_height)
+                )
+
+                # Skip re-rendering cards with active spinner animations
+                if self.is_animating(card):
+                    continue
+
+                await card.prepare_assets()
+
+                # SVG-native pipeline: render directly to device bytes.
+                # Offload CPU-bound rasterisation to a thread so the
+                # event loop stays responsive.
+                image_fmt = (
+                    deck._caps.touchscreen_image_format if deck._caps else "JPEG"
+                )
+                panel_bytes = await asyncio.to_thread(
+                    card.render_bytes,
+                    panel_width=metrics.panel_width,
+                    panel_height=metrics.panel_height,
+                    image_format=image_fmt,
+                    background=touch_strip.background_color,
+                )
+
+                # Also render a PIL image for caching (used by screenshot).
+                # Likewise offloaded because it involves SVG rasterisation.
+                img = await asyncio.to_thread(card.render)
+                card.set_rendered(img)
+
+            else:
+                # Non-DUI card: legacy path with Pillow compositing
+                await card.prepare_assets()
+                rendered = await asyncio.to_thread(card.render)
+                card.set_rendered(rendered)
+
+                bg_tile = touch_strip.bg_tile(card_idx)
+                panel_bytes = await asyncio.to_thread(
+                    compose_card_with_background,
+                    rendered,
+                    bg_tile=bg_tile,
+                    background=touch_strip.background_color,
+                    panel_width=metrics.panel_width,
+                    panel_height=metrics.panel_height,
+                    image_format=(
+                        deck._caps.touchscreen_image_format if deck._caps else "JPEG"
+                    ),
+                )
+
+            # Push per-panel update
+            async with deck._device_lock:
+                await deck._exec_device_io(
+                    deck._device.set_touchscreen_image,
+                    panel_bytes,
+                    x_pos,
+                    y_pos,
+                    metrics.panel_width,
+                    metrics.panel_height,
+                )
+
+    # ------------------------------------------------------------------
+    # Info-screen rendering
+    # ------------------------------------------------------------------
+
+    async def render_info_screen(self) -> None:
+        """Render and push the info screen image (e.g. Neo)."""
+        deck = self._deck
+        screen = deck._current_screen()
+        if not deck._device or not screen:
+            return
+
+        info = screen.info_screen
+        if info is None:
+            return
+
+        image_bytes = info.render_bytes()
+
+        async with deck._device_lock:
+            await deck._exec_device_io(
+                deck._device.set_screen_image,
+                image_bytes,
+                0,
+                0,
+                info.width,
+                info.height,
+            )
+        info.mark_clean()
+
+    # ------------------------------------------------------------------
+    # Card callback drain
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def drain_card_callbacks(card: Card) -> None:
+        """Drain and await all pending callbacks queued on a card.
+
+        Parameters
+        ----------
+        card : Card
+            The card whose pending callbacks should be drained.
+        """
+        for handler, args in card.drain_pending_callbacks():
+            await handler(*args)
+
+    # ------------------------------------------------------------------
+    # Theme application
+    # ------------------------------------------------------------------
+
+    def apply_theme(self) -> None:
+        """Apply the resolved theme cascade to the SVG stylesheet."""
+        from ..render.svg_rasterize import set_svg_stylesheet
+
+        set_svg_stylesheet(self._resolve_stylesheet())


### PR DESCRIPTION
## Summary

Splits `runtime/deck.py` into three focused modules, addressing all acceptance criteria in issue #195.

### New modules

**`runtime/renderer.py` — DeckRenderer (405 lines)**
- `render_all_keys` / `render_dui_key` — key rendering pipeline
- `render_touchscreen` — touchscreen panel rendering (DUI + legacy paths)
- `render_info_screen` — info screen rendering
- `drain_card_callbacks` — card callback drain helper
- `is_dui_key` / `is_animating` — static helpers
- `_resolve_stylesheet` / `apply_theme` — theme cascade resolution

**`runtime/event_router.py` — DeckEventRouter (145 lines, 100% coverage)**
- `dispatch` — top-level event routing
- `_dispatch_key` — key press/release handling
- `_dispatch_encoder_turn` / `_dispatch_encoder_press` — encoder events
- `_dispatch_touch` — touchscreen events

### What stays in `Deck` (587 lines)
- Lifecycle management (`start`/`stop`)
- Screen management, brightness, properties
- Timeout polling (`_timeout_loop`, `_check_timeouts`)
- Refresh coordination
- Thin delegation wrappers for backward compatibility

### Results
- `deck.py`: 882 → 587 lines (33% reduction)
- All 1668 tests pass
- Coverage: 96.85% (above 95% threshold)
- Ruff + mypy: clean
- No public API changes

Closes #195