### PR TITLE
refactor: unify DUI vs non-DUI rendering in _render_touchscreen

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -18,6 +18,7 @@ from .svg_renderer import SvgRenderer
 if TYPE_CHECKING:
     from PIL import Image
 
+    from ..render.metrics import RenderMetrics
     from ..runtime.async_event import AsyncEvent
     from ..runtime.events import AsyncHandler, TouchEvent
 
@@ -207,6 +208,52 @@ class DuiCard(BindingMixin, Card):
             output_format=out_fmt,
             background=bg,
         )
+
+    def render_panel_bytes(
+        self,
+        *,
+        metrics: RenderMetrics,
+        card_index: int,
+        bg_tile: Image.Image | None,
+        background: str = "black",
+        image_format: str = "JPEG",
+    ) -> bytes:
+        """Render the card to encoded image bytes using the SVG-native pipeline.
+
+        Overrides the base :meth:`Card.render_panel_bytes` to use
+        SVG-level background compositing and direct rasterisation,
+        avoiding the legacy Pillow compositing path entirely.
+
+        Parameters
+        ----------
+        metrics : RenderMetrics
+            Device metrics (panel dimensions, etc.).
+        card_index : int
+            The zero-based position of this card on the touch strip.
+        bg_tile : Image.Image or None
+            Cropped background tile for this card's panel, or ``None``.
+        background : str, default="black"
+            Fallback background colour.
+        image_format : str, default="JPEG"
+            Image encoding format (``"JPEG"`` or ``"BMP"``).
+
+        Returns
+        -------
+        bytes
+            Encoded image bytes ready to send to the device.
+        """
+        panel_bytes = self.render_bytes(
+            panel_width=metrics.panel_width,
+            panel_height=metrics.panel_height,
+            image_format=image_format,
+            background=background,
+        )
+
+        # Also render a PIL image for caching (used by screenshot).
+        img = self.render()
+        self.set_rendered(img)
+
+        return panel_bytes
 
     def set(self, name: str, value: Any) -> DuiCard:
         """Set a binding value.  Marks the card dirty if changed.

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -202,12 +202,11 @@ class DeckRenderer:
     async def render_touchscreen(self) -> None:
         """Render and push each card panel individually to the device.
 
-        Uses the SVG-native pipeline for DuiCards: background
-        compositing happens at the SVG level, and each panel is
-        rasterised directly to device-ready bytes and pushed as a
-        per-panel update.
-
-        Non-DUI cards fall back to the legacy Pillow compositing path.
+        Delegates panel rendering to the card's
+        :meth:`~deux.ui.cards.base.Card.render_panel_bytes` method,
+        which is overridden by :class:`~deux.dui.card.DuiCard` to use
+        the SVG-native pipeline.  Non-DUI cards fall back to the
+        legacy Pillow compositing path (with a deprecation warning).
         """
         deck = self._deck
         screen = deck._current_screen()
@@ -227,10 +226,10 @@ class DeckRenderer:
         for card_idx, card in enumerate(screen.cards):
             x_pos = card_idx * metrics.panel_width
             y_pos = 0
+            bg_tile = touch_strip.bg_tile(card_idx)
 
             if isinstance(card, DuiCard):
                 # Set up background layer for SVG-level compositing
-                bg_tile = touch_strip.bg_tile(card_idx)
                 card.set_bg_tile(bg_tile)
 
                 if bg_svg_root is not None:
@@ -300,45 +299,21 @@ class DeckRenderer:
                 if self.is_animating(card):
                     continue
 
-                await card.prepare_assets()
+            await card.prepare_assets()
 
-                # SVG-native pipeline: render directly to device bytes.
-                # Offload CPU-bound rasterisation to a thread so the
-                # event loop stays responsive.
-                image_fmt = (
-                    deck._caps.touchscreen_image_format if deck._caps else "JPEG"
-                )
-                panel_bytes = await asyncio.to_thread(
-                    card.render_bytes,
-                    panel_width=metrics.panel_width,
-                    panel_height=metrics.panel_height,
-                    image_format=image_fmt,
-                    background=touch_strip.background_color,
-                )
+            image_fmt = (
+                deck._caps.touchscreen_image_format if deck._caps else "JPEG"
+            )
 
-                # Also render a PIL image for caching (used by screenshot).
-                # Likewise offloaded because it involves SVG rasterisation.
-                img = await asyncio.to_thread(card.render)
-                card.set_rendered(img)
-
-            else:
-                # Non-DUI card: legacy path with Pillow compositing
-                await card.prepare_assets()
-                rendered = await asyncio.to_thread(card.render)
-                card.set_rendered(rendered)
-
-                bg_tile = touch_strip.bg_tile(card_idx)
-                panel_bytes = await asyncio.to_thread(
-                    compose_card_with_background,
-                    rendered,
-                    bg_tile=bg_tile,
-                    background=touch_strip.background_color,
-                    panel_width=metrics.panel_width,
-                    panel_height=metrics.panel_height,
-                    image_format=(
-                        deck._caps.touchscreen_image_format if deck._caps else "JPEG"
-                    ),
-                )
+            # Unified rendering: each card type implements render_panel_bytes
+            panel_bytes = await asyncio.to_thread(
+                card.render_panel_bytes,
+                metrics=metrics,
+                card_index=card_idx,
+                bg_tile=bg_tile,
+                background=touch_strip.background_color,
+                image_format=image_fmt,
+            )
 
             # Push per-panel update
             async with deck._device_lock:

--- a/src/deux/ui/cards/base.py
+++ b/src/deux/ui/cards/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,8 @@ from ...runtime.events import AsyncHandler, EventType, TouchEvent
 
 if TYPE_CHECKING:
     from PIL import Image
+
+    from ...render.metrics import RenderMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -252,6 +255,67 @@ class Card(ABC):
     async def prepare_assets(self) -> None:
         """Prepare external assets needed for rendering this card."""
         return None
+
+    def render_panel_bytes(
+        self,
+        *,
+        metrics: RenderMetrics,
+        card_index: int,
+        bg_tile: Image.Image | None,
+        background: str = "black",
+        image_format: str = "JPEG",
+    ) -> bytes:
+        """Render the card to encoded image bytes for a touchscreen panel.
+
+        The base implementation uses the legacy Pillow compositing path:
+        it calls :meth:`render` and composites the result onto the
+        background tile.  Subclasses (e.g.
+        :class:`~deux.dui.card.DuiCard`) override this to use their
+        native rendering pipeline.
+
+        .. deprecated::
+            Non-DUI cards using this legacy rendering path are
+            deprecated.  Migrate to :class:`~deux.dui.card.DuiCard`
+            for SVG-native rendering.
+
+        Parameters
+        ----------
+        metrics : RenderMetrics
+            Device metrics (panel dimensions, etc.).
+        card_index : int
+            The zero-based position of this card on the touch strip.
+        bg_tile : Image.Image or None
+            Cropped background tile for this card's panel, or ``None``.
+        background : str, default="black"
+            Fallback background colour.
+        image_format : str, default="JPEG"
+            Image encoding format (``"JPEG"`` or ``"BMP"``).
+
+        Returns
+        -------
+        bytes
+            Encoded image bytes ready to send to the device.
+        """
+        from ...render.touch_renderer import compose_card_with_background
+
+        warnings.warn(
+            f"{type(self).__name__} uses the legacy Pillow rendering path. "
+            "Migrate to DuiCard for SVG-native rendering.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        rendered = self.render()
+        self.set_rendered(rendered)
+
+        return compose_card_with_background(
+            rendered,
+            bg_tile=bg_tile,
+            background=background,
+            panel_width=metrics.panel_width,
+            panel_height=metrics.panel_height,
+            image_format=image_format,
+        )
 
     async def dispatch_encoder_turn(self, direction: int) -> None:
         """Dispatch an encoder-turn event to the card."""


### PR DESCRIPTION
## Summary

Removes the duplicated DUI vs non-DUI rendering pipeline in `render_touchscreen` by introducing a polymorphic `render_panel_bytes()` method on the `Card` base class.

## Changes

- **`src/deux/ui/cards/base.py`**: Added `render_panel_bytes()` method that encapsulates the legacy Pillow compositing path with a `DeprecationWarning` directing users to migrate to `DuiCard`.
- **`src/deux/dui/card.py`**: Overrides `render_panel_bytes()` to use the SVG-native pipeline (`render_bytes()` + PIL cache for screenshots).
- **`src/deux/runtime/renderer.py`**: Simplified `render_touchscreen()` to a single code path that delegates to each card's `render_panel_bytes()`, eliminating the `if isinstance(card, DuiCard) ... else ...` branching for the rendering step.

## Acceptance Criteria

- [x] `render_touchscreen` has a single rendering code path
- [x] Legacy path deprecated with `DeprecationWarning`
- [x] All 1679 tests pass, 96.74% coverage (above 95% threshold)
- [x] Ruff lint clean, mypy strict clean

Closes #200