### PR TITLE
Consolidate background-rasterisation logic into BackgroundLayer abstraction

### DIFF
--- a/src/deux/render/__init__.py
+++ b/src/deux/render/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .background_layer import BackgroundLayer
 from .context import RenderingContext
 from .defaults import (
     SurfaceBackgrounds,
@@ -40,6 +41,7 @@ from .touch_renderer import (
 _apply_default_theme()
 
 __all__ = [
+    "BackgroundLayer",
     "RenderingContext",
     "SurfaceBackgrounds",
     "Theme",

--- a/src/deux/render/background_layer.py
+++ b/src/deux/render/background_layer.py
@@ -1,0 +1,267 @@
+"""Unified background-layer abstraction for Stream Deck surfaces.
+
+Consolidates background SVG parsing, rasterisation, and tile slicing
+that was previously scattered across :class:`~deux.ui.touch_strip.TouchStrip`,
+:class:`~deux.ui.screen.Screen`, :class:`~deux.dui.svg_renderer.SvgRenderer`,
+and :class:`~deux.runtime.renderer.DeckRenderer`.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import xml.etree.ElementTree as ET
+from typing import Literal
+
+from PIL import Image
+
+from .._xml import safe_fromstring
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundLayer:
+    """Own the SVG source, parsed XML root, and rasterised outputs for a background.
+
+    A single ``BackgroundLayer`` encapsulates one background SVG and its
+    derived artefacts: the parsed element tree, rasterised full image,
+    and (for touchstrip backgrounds) per-panel tiles.  Two *kinds* are
+    supported:
+
+    ``"touchstrip"``
+        A full-width SVG that is rasterised and sliced into per-panel
+        tiles.  Requires *panel_count*, *panel_width*, and
+        *panel_height*.
+
+    ``"key"``
+        A single-key SVG that is rasterised and encoded to device image
+        bytes.  Requires *key_size* and *key_image_format*.
+
+    Parameters
+    ----------
+    kind : ``"touchstrip"`` or ``"key"``
+        Which surface this background belongs to.
+    panel_count : int, optional
+        Number of panels (touchstrip only).
+    panel_width : int, optional
+        Width of each panel in pixels (touchstrip only).
+    panel_height : int, optional
+        Height of each panel in pixels (touchstrip only).
+    key_size : tuple[int, int], optional
+        ``(width, height)`` of a key (key only).
+    key_image_format : str, optional
+        Device image format for key encoding (key only).
+    """
+
+    def __init__(
+        self,
+        kind: Literal["touchstrip", "key"],
+        *,
+        panel_count: int = 0,
+        panel_width: int = 0,
+        panel_height: int = 0,
+        key_size: tuple[int, int] = (0, 0),
+        key_image_format: str = "JPEG",
+    ) -> None:
+        self._kind = kind
+        self._svg: bytes | None = None
+        self._svg_root: ET.Element | None = None
+
+        # Touchstrip state
+        self._panel_count = panel_count
+        self._panel_width = panel_width
+        self._panel_height = panel_height
+        self._tiles: list[Image.Image] | None = None
+
+        # Key state
+        self._key_size = key_size
+        self._key_image_format = key_image_format
+        self._key_image: bytes | None = None
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def kind(self) -> Literal["touchstrip", "key"]:
+        """The surface kind this layer targets."""
+        return self._kind
+
+    @property
+    def svg(self) -> bytes | None:
+        """Raw SVG source bytes, or ``None`` if unset."""
+        return self._svg
+
+    @property
+    def svg_root(self) -> ET.Element | None:
+        """Parsed SVG root element, or ``None`` if unset."""
+        return self._svg_root
+
+    @property
+    def tiles(self) -> list[Image.Image] | None:
+        """Pre-sliced touchstrip tiles (shallow copy), or ``None``.
+
+        Only meaningful for ``kind="touchstrip"``.
+        """
+        if self._tiles is None:
+            return None
+        return list(self._tiles)
+
+    def tile(self, index: int) -> Image.Image | None:
+        """Return the cached background tile for panel *index*, or ``None``.
+
+        Parameters
+        ----------
+        index : int
+            Panel index (0-based).
+
+        Returns
+        -------
+        Image.Image or None
+            The RGB tile image, or ``None`` if no background SVG is set
+            or *index* is out of range.
+        """
+        if self._tiles is None or not 0 <= index < len(self._tiles):
+            return None
+        return self._tiles[index]
+
+    @property
+    def key_image(self) -> bytes | None:
+        """Pre-rendered key background image bytes, or ``None``.
+
+        Only meaningful for ``kind="key"``.
+        """
+        return self._key_image
+
+    @property
+    def has_svg(self) -> bool:
+        """Whether a background SVG is currently set."""
+        return self._svg is not None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def set_svg(self, svg_data: bytes, *, trusted: bool = False) -> None:
+        """Set the background SVG and rasterise immediately.
+
+        Parameters
+        ----------
+        svg_data : bytes
+            Raw SVG content as UTF-8 bytes.
+        trusted : bool, default=False
+            When ``True``, uses stdlib ``ET.fromstring`` (suitable for
+            bundled/trusted SVGs).  When ``False``, uses the safe parser
+            that strips potentially dangerous elements.
+        """
+        self._svg = svg_data
+        if trusted:
+            self._svg_root = ET.fromstring(svg_data)  # noqa: S314 — trusted
+        else:
+            self._svg_root = safe_fromstring(svg_data)
+        self._rasterize()
+
+    def set_svg_deferred(self, svg_data: bytes, *, trusted: bool = False) -> None:
+        """Parse the SVG without rasterising (for async workflows).
+
+        Call :meth:`rasterize` separately (e.g. via ``asyncio.to_thread``)
+        to perform the CPU-bound rasterisation step.
+
+        Parameters
+        ----------
+        svg_data : bytes
+            Raw SVG content as UTF-8 bytes.
+        trusted : bool, default=False
+            When ``True``, uses stdlib ``ET.fromstring``.
+        """
+        self._svg = svg_data
+        if trusted:
+            self._svg_root = ET.fromstring(svg_data)  # noqa: S314 — trusted
+        else:
+            self._svg_root = safe_fromstring(svg_data)
+
+    def rasterize(self) -> None:
+        """Public entry point for rasterisation.
+
+        Useful for offloading to a thread via ``asyncio.to_thread``.
+        No-op if no SVG is set.
+        """
+        self._rasterize()
+
+    def clear(self) -> None:
+        """Remove the background SVG and all derived artefacts."""
+        self._svg = None
+        self._svg_root = None
+        self._tiles = None
+        self._key_image = None
+
+    def invalidate(self) -> None:
+        """Re-rasterize the current SVG (e.g. after stylesheet changes).
+
+        No-op if no SVG is set.
+        """
+        if self._svg is not None:
+            self._rasterize()
+
+    # ------------------------------------------------------------------
+    # Internal rasterisation
+    # ------------------------------------------------------------------
+
+    def _rasterize(self) -> None:
+        """Rasterize the SVG according to the layer's *kind*.
+
+        For ``"touchstrip"``, produces a full-width image and slices it
+        into per-panel tiles.  For ``"key"``, produces an encoded key
+        image ready to push to the device.
+        """
+        if self._svg is None:
+            self._tiles = None
+            self._key_image = None
+            return
+
+        if self._kind == "touchstrip":
+            self._rasterize_touchstrip()
+        else:
+            self._rasterize_key()
+
+    def _rasterize_touchstrip(self) -> None:
+        """Rasterize and slice a touchstrip background SVG."""
+        from .svg_rasterize import _svg_to_png
+
+        assert self._svg is not None  # noqa: S101 — invariant
+
+        total_width = self._panel_width * self._panel_count
+        total_height = self._panel_height
+
+        png_data = _svg_to_png(self._svg, total_width, total_height)
+        full_img = Image.open(io.BytesIO(png_data)).convert("RGB")
+
+        tiles: list[Image.Image] = []
+        for i in range(self._panel_count):
+            x0 = i * self._panel_width
+            x1 = x0 + self._panel_width
+            tile = full_img.crop((x0, 0, x1, total_height))
+            tiles.append(tile)
+
+        self._tiles = tiles
+        logger.debug(
+            "Background SVG rasterized: %dx%d -> %d tiles of %dx%d",
+            total_width,
+            total_height,
+            self._panel_count,
+            self._panel_width,
+            self._panel_height,
+        )
+
+    def _rasterize_key(self) -> None:
+        """Rasterize a key background SVG to encoded device bytes."""
+        from .key_renderer import _encode_image
+        from .svg_rasterize import _svg_to_png
+
+        assert self._svg is not None  # noqa: S101 — invariant
+
+        key_w, key_h = self._key_size
+        png_data = _svg_to_png(self._svg, key_w, key_h)
+        img = Image.open(io.BytesIO(png_data)).convert("RGB")
+        self._key_image = _encode_image(img, image_format=self._key_image_format)
+        logger.debug("Key background SVG rasterized: %dx%d", key_w, key_h)

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+from ..render.background_layer import BackgroundLayer
 from .controls.encoder_slot import EncoderSlot
 from .controls.key_slot import KeySlot
 from .info_screen import InfoScreen
@@ -51,8 +52,11 @@ class Screen:
         self._keys: dict[int, KeySlot] = {}
         self._encoders: dict[int, EncoderSlot] = {}
         self._theme: Theme | None = None
-        self._key_bg_svg: bytes | None = None
-        self._key_bg_image: bytes | None = None
+        self._key_bg_layer = BackgroundLayer(
+            "key",
+            key_size=self._caps.key_size,
+            key_image_format=self._caps.key_image_format,
+        )
         self._key_bg_dirty: bool = False
 
         if self._caps.has_touchscreen and self._caps.dial_count > 0:
@@ -88,14 +92,9 @@ class Screen:
 
         Looks up the device's VID:PID in the bundled manifest and sets
         the touchscreen background SVG if one is available and no
-        background has been explicitly configured.  Only the SVG source
-        and parsed XML root are stored; PIL rasterisation is deferred
-        until the first render pass to avoid unnecessary work during
-        construction.  Failures are logged but never raised — defaults
-        are best-effort.
+        background has been explicitly configured.  Failures are logged
+        but never raised — defaults are best-effort.
         """
-        import xml.etree.ElementTree as ET  # noqa: N817
-
         from ..render.defaults import get_default_backgrounds
 
         try:
@@ -109,42 +108,23 @@ class Screen:
         if "touchscreen" in backgrounds and self._touch_strip is not None:
             try:
                 svg_data = backgrounds["touchscreen"]
-                self._touch_strip._bg_svg = svg_data
-                self._touch_strip._bg_svg_root = ET.fromstring(svg_data)  # noqa: S314 — trusted: bundled default backgrounds
-                self._touch_strip._rasterize_and_slice()
+                self._touch_strip.bg_layer.set_svg(svg_data, trusted=True)
             except Exception:
                 logger.debug("Failed to apply default touchscreen background", exc_info=True)
 
         if "key" in backgrounds:
             try:
-                self._key_bg_svg = backgrounds["key"]
-                self._rasterize_key_background()
+                svg_data = backgrounds["key"]
+                self._key_bg_layer.set_svg(svg_data, trusted=True)
             except Exception:
                 logger.debug("Failed to apply default key background", exc_info=True)
 
     def _rasterize_key_background(self) -> None:
-        """Rasterize the key background SVG into encoded image bytes.
+        """Re-rasterize the key background via the BackgroundLayer.
 
-        Uses the device's key size and image format to produce a ready-to-send
-        blank key image with the default background applied.  If no key
-        background SVG is set, clears the cached image.
+        If no key background SVG is set, this is a no-op.
         """
-        if self._key_bg_svg is None:
-            self._key_bg_image = None
-            return
-
-        from PIL import Image as PILImage
-
-        from ..render.key_renderer import _encode_image
-        from ..render.svg_rasterize import _svg_to_png
-
-        key_w, key_h = self._caps.key_size
-        png_data = _svg_to_png(self._key_bg_svg, key_w, key_h)
-        img = PILImage.open(io.BytesIO(png_data)).convert("RGB")
-        self._key_bg_image = _encode_image(
-            img, image_format=self._caps.key_image_format
-        )
-        logger.debug("Key background SVG rasterized: %dx%d", key_w, key_h)
+        self._key_bg_layer.invalidate()
 
     @property
     def key_bg_image(self) -> bytes | None:
@@ -156,7 +136,7 @@ class Screen:
             Encoded image bytes ready to push to the device, or ``None``
             if no default key background is configured.
         """
-        return self._key_bg_image
+        return self._key_bg_layer.key_image
 
     @property
     def key_bg_dirty(self) -> bool:
@@ -405,8 +385,8 @@ class Screen:
         """
         for key_slot in self._keys.values():
             key_slot.mark_dirty()
-        if self._key_bg_svg is not None:
-            self._rasterize_key_background()
+        if self._key_bg_layer.has_svg:
+            self._key_bg_layer.invalidate()
             self._key_bg_dirty = True
         if self._touch_strip is not None:
             self._touch_strip.invalidate_background()

--- a/src/deux/ui/touch_strip.py
+++ b/src/deux/ui/touch_strip.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from PIL import Image
 
-from .._xml import safe_fromstring
+from ..render.background_layer import BackgroundLayer
 from .cards.base import Card
 from .cards.blank import BlankCard
 
@@ -58,9 +57,12 @@ class TouchStrip:
         self._panel_height = panel_height
         self._cards: list[Card] = [BlankCard() for _ in range(panel_count)]
         self._background_color = background_color
-        self._bg_svg: bytes | None = None
-        self._bg_svg_root: ET.Element | None = None
-        self._bg_tiles: list[Image.Image] | None = None
+        self._bg_layer = BackgroundLayer(
+            "touchstrip",
+            panel_count=panel_count,
+            panel_width=panel_width,
+            panel_height=panel_height,
+        )
 
     @property
     def panel_count(self) -> int:
@@ -142,9 +144,7 @@ class TouchStrip:
 
         Returns a shallow copy when tiles exist; external code cannot mutate internal state.
         """
-        if self._bg_tiles is None:
-            return None
-        return list(self._bg_tiles)
+        return self._bg_layer.tiles
 
     def bg_tile(self, index: int) -> Image.Image | None:
         """Return the cached background tile for panel *index*, or ``None``.
@@ -159,9 +159,7 @@ class TouchStrip:
         Image.Image or None
             The RGB tile image, or ``None`` if no background SVG is set.
         """
-        if self._bg_tiles is None or not 0 <= index < len(self._bg_tiles):
-            return None
-        return self._bg_tiles[index]
+        return self._bg_layer.tile(index)
 
     @property
     def bg_svg_root(self) -> ET.Element | None:
@@ -170,7 +168,12 @@ class TouchStrip:
         Used by the SVG-native pipeline to compose background layers
         with card SVGs at the vector level before rasterisation.
         """
-        return self._bg_svg_root
+        return self._bg_layer.svg_root
+
+    @property
+    def bg_layer(self) -> BackgroundLayer:
+        """The background layer managing SVG, tiles, and rasterisation."""
+        return self._bg_layer
 
     def set_background_svg(self, svg_data: bytes) -> None:
         """Set a background SVG for the entire touchstrip.
@@ -187,9 +190,7 @@ class TouchStrip:
         svg_data
             Raw SVG content as UTF-8 bytes.
         """
-        self._bg_svg = svg_data
-        self._bg_svg_root = safe_fromstring(svg_data)  # untrusted: user-supplied SVG
-        self._rasterize_and_slice()
+        self._bg_layer.set_svg(svg_data)
         for card in self._cards:
             card.mark_dirty()
 
@@ -217,9 +218,7 @@ class TouchStrip:
         All cards are marked dirty so they re-render without the
         background tiles.
         """
-        self._bg_svg = None
-        self._bg_svg_root = None
-        self._bg_tiles = None
+        self._bg_layer.clear()
         for card in self._cards:
             card.mark_dirty()
 
@@ -230,8 +229,8 @@ class TouchStrip:
         (such as the active stylesheet) has changed.  If no background
         SVG is set this is a no-op.
         """
-        if self._bg_svg is not None:
-            self._rasterize_and_slice()
+        if self._bg_layer.has_svg:
+            self._bg_layer.invalidate()
 
     async def set_background_svg_async(self, svg_data: bytes) -> None:
         """Async variant of :meth:`set_background_svg`.
@@ -244,9 +243,8 @@ class TouchStrip:
         svg_data
             Raw SVG content as UTF-8 bytes.
         """
-        self._bg_svg = svg_data
-        self._bg_svg_root = safe_fromstring(svg_data)
-        await asyncio.to_thread(self._rasterize_and_slice)
+        self._bg_layer.set_svg_deferred(svg_data)
+        await asyncio.to_thread(self._bg_layer.rasterize)
         for card in self._cards:
             card.mark_dirty()
 
@@ -256,43 +254,8 @@ class TouchStrip:
         Offloads the CPU-bound SVG rasterisation to a worker thread
         so the event loop stays responsive.
         """
-        if self._bg_svg is not None:
-            await asyncio.to_thread(self._rasterize_and_slice)
-
-    def _rasterize_and_slice(self) -> None:
-        """Rasterize the background SVG and slice into per-panel tiles.
-
-        The full-width image is cropped into ``panel_count`` tiles of
-        ``panel_width x panel_height`` each.
-        """
-        if self._bg_svg is None:
-            self._bg_tiles = None
-            return
-
-        from ..render.svg_rasterize import _svg_to_png
-
-        total_width = self._panel_width * self._panel_count
-        total_height = self._panel_height
-
-        png_data = _svg_to_png(self._bg_svg, total_width, total_height)
-        full_img = Image.open(io.BytesIO(png_data)).convert("RGB")
-
-        tiles: list[Image.Image] = []
-        for i in range(self._panel_count):
-            x0 = i * self._panel_width
-            x1 = x0 + self._panel_width
-            tile = full_img.crop((x0, 0, x1, total_height))
-            tiles.append(tile)
-
-        self._bg_tiles = tiles
-        logger.debug(
-            "Background SVG rasterized: %dx%d -> %d tiles of %dx%d",
-            total_width,
-            total_height,
-            self._panel_count,
-            self._panel_width,
-            self._panel_height,
-        )
+        if self._bg_layer.has_svg:
+            await asyncio.to_thread(self._bg_layer.rasterize)
 
     @property
     def any_dirty(self) -> bool:


### PR DESCRIPTION
## Summary

Introduces a single `BackgroundLayer` abstraction that owns the background SVG source, parsed XML root, sliced tiles, and rasterised key images — consolidating logic previously scattered across four locations.

## Changes

- **New** `src/deux/render/background_layer.py` — `BackgroundLayer` class supporting both `"touchstrip"` (rasterise + slice into per-panel tiles) and `"key"` (rasterise + encode to device format) kinds.
- **Refactored** `TouchStrip` — delegates all background state (`_bg_svg`, `_bg_svg_root`, `_bg_tiles`) to its `BackgroundLayer` instance. Exposes `bg_layer` property. Removed `_rasterize_and_slice` method.
- **Refactored** `Screen` — uses `BackgroundLayer` for key backgrounds (replaces `_key_bg_svg`/`_key_bg_image` privates). `_apply_default_backgrounds` now calls `touch_strip.bg_layer.set_svg(trusted=True)` instead of reaching into TouchStrip privates.
- **Updated** `render/__init__.py` — exports `BackgroundLayer`.

## Acceptance Criteria

- [x] Single `BackgroundLayer` abstraction owns background SVG, parsed tree, sliced tiles, and rasterised images
- [x] Four current touch points consolidated
- [x] Existing tests pass (1679 passed, 96.72% coverage)
- [x] No change to public API
- [x] Absorbs #18 (Screen no longer accesses TouchStrip privates)

## Verification

- `ruff check .` — all checks passed
- `mypy src/deux` — no issues found
- `pytest tests/ --cov=deux --cov-fail-under=95` — 1679 passed, 96.72% coverage

Closes #201
Absorbs #18