### PR TITLE
refactor: remove PIL from render chain, use pyvips for all compositing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       coverage-target: ${{ vars.CI_PYTHON_COVERAGE_TARGET || 'deux' }}
       coverage-threshold: ${{ fromJSON(vars.CI_PYTHON_COVERAGE_THRESHOLD || '95') }}
       pytest-args: ${{ vars.CI_PYTHON_TEST_ARGS || 'tests/' }}
-      system-packages: ${{ vars.CI_PYTHON_SYSTEM_PACKAGES || 'libcairo2-dev libhidapi-dev' }}
+      system-packages: ${{ vars.CI_PYTHON_SYSTEM_PACKAGES || 'libcairo2-dev libhidapi-dev libvips-dev' }}
 
   secrets-scan:
     name: Secrets

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,7 +35,7 @@ on:
         description: Apt packages required before tests.
         required: false
         type: string
-        default: "libcairo2-dev libhidapi-dev"
+        default: "libcairo2-dev libhidapi-dev libvips-dev"
 
 jobs:
   pytest:

--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -81,7 +81,7 @@ class DuiCard(BindingMixin, Card):
         self._spinner_frames: SpinnerFrames | None = None
         self._push_fn: PushFn | None = None
         self._panel_size: tuple[int, int] | None = None
-        self._bg_tile: Image.Image | None = None
+        self._bg_tile: bytes | None = None
         self._bg_svg_root: ET.Element | None = None
         self._card_index: int | None = None
 
@@ -117,17 +117,17 @@ class DuiCard(BindingMixin, Card):
         self._push_fn = push_fn
         self._panel_size = panel_size
 
-    def set_bg_tile(self, tile: Image.Image | None) -> None:
+    def set_bg_tile(self, tile: bytes | None) -> None:
         """Set the background tile for compositing spinner frames.
 
         When a touchstrip background SVG is active, the corresponding
-        pre-sliced tile is passed here so that spinner animations can
-        composite each frame onto the background.
+        pre-sliced tile (PNG bytes) is passed here so that spinner
+        animations can composite each frame onto the background.
 
         Parameters
         ----------
         tile
-            The RGB background tile, or ``None`` to clear.
+            PNG-encoded background tile bytes, or ``None`` to clear.
         """
         self._bg_tile = tile
 
@@ -214,7 +214,7 @@ class DuiCard(BindingMixin, Card):
         *,
         metrics: RenderMetrics,
         card_index: int,
-        bg_tile: Image.Image | None,
+        bg_tile: bytes | None,
         background: str = "black",
         image_format: str = "JPEG",
     ) -> bytes:

--- a/src/deux/dui/spinner.py
+++ b/src/deux/dui/spinner.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import copy
-import io
 import logging
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
-from PIL import Image
-
 from .._xml import safe_fromstring
-from ..render.key_renderer import _encode_image
+from ..render.svg_rasterize import _ensure_macos_lib_path
 from .svg_renderer import _find_element_by_id
 
 if TYPE_CHECKING:
@@ -55,7 +52,7 @@ class SpinnerFrames:
         height: int,
         image_format: str = "JPEG",
         rendered_svg: str | None = None,
-        bg_tile: Image.Image | None = None,
+        bg_tile: bytes | None = None,
     ) -> None:
         if spec.spinner is None:
             raise ValueError("PackageSpec has no spinner configuration")
@@ -205,15 +202,16 @@ class SpinnerFrames:
             logger.warning("No custom spinner frames found; returning blank frames")
             return self._blank_frames()
 
+        _ensure_macos_lib_path()
+        import pyvips
+
         frames: list[bytes] = []
         for key in frame_keys:
-            img: Image.Image = Image.open(io.BytesIO(assets[key]))
-            if img.size != (self._width, self._height):
-                img = img.resize(
-                    (self._width, self._height), Image.Resampling.LANCZOS
-                )
-            img = self._composite_on_bg(img)
-            frames.append(_encode_image(img, self._image_format))
+            img = pyvips.Image.new_from_buffer(assets[key], "")
+            if img.width != self._width or img.height != self._height:
+                img = img.thumbnail_image(self._width, height=self._height, crop="centre")
+            png_data: bytes = img.write_to_buffer(".png")
+            frames.append(self._composite_on_bg(png_data))
         return frames
 
     def _load_gif_frames(self, data: bytes) -> list[bytes]:
@@ -230,20 +228,23 @@ class SpinnerFrames:
             Encoded image frames; falls back to blank frames if the GIF
             contains no frames.
         """
-        gif = Image.open(io.BytesIO(data))
+        _ensure_macos_lib_path()
+        import pyvips
+
+        # Load all pages (frames) of the GIF.
+        img = pyvips.Image.new_from_buffer(data, "", n=-1)
+        frame_height = img.height // (img.get("n-pages") if img.get("n-pages") else 1)
+        n_pages = img.get("n-pages") if img.get("n-pages") else 1
+
         frames: list[bytes] = []
-        try:
-            while True:
-                frame = gif.copy()
-                if frame.size != (self._width, self._height):
-                    frame = frame.resize(
-                        (self._width, self._height), Image.Resampling.LANCZOS
-                    )
-                frame = self._composite_on_bg(frame)
-                frames.append(_encode_image(frame, self._image_format))
-                gif.seek(gif.tell() + 1)
-        except EOFError:
-            pass
+        for i in range(n_pages):
+            frame = img.crop(0, i * frame_height, img.width, frame_height)
+            if frame.width != self._width or frame.height != self._height:
+                frame = frame.thumbnail_image(
+                    self._width, height=self._height, crop="centre"
+                )
+            png_data: bytes = frame.write_to_buffer(".png")
+            frames.append(self._composite_on_bg(png_data))
 
         if not frames:
             logger.warning("Animated GIF has no frames; returning blank frames")
@@ -263,36 +264,100 @@ class SpinnerFrames:
             frame count.
         """
         if self._bg_tile is not None:
-            data = _encode_image(self._bg_tile.copy(), self._image_format)
+            data = self._encode_tile(self._bg_tile)
         else:
-            blank = Image.new("RGB", (self._width, self._height), "black")
-            data = _encode_image(blank, self._image_format)
+            data = self._encode_blank()
         return [data] * self._spinner.frames
 
-    def _composite_on_bg(self, img: Image.Image) -> Image.Image:
+    def _composite_on_bg(self, png_data: bytes) -> bytes:
         """Composite a frame onto the background tile if available.
 
         Parameters
         ----------
-        img
-            The frame image (RGB or RGBA).
+        png_data : bytes
+            PNG-encoded frame data (may have alpha).
 
         Returns
         -------
-        Image.Image
-            An RGB image, composited onto the background tile when one
-            is set, or the original image converted to RGB otherwise.
+        bytes
+            Encoded image bytes in the instance's configured format.
         """
+        _ensure_macos_lib_path()
+        import pyvips
+
+        from ..render.touch_renderer import _to_vips
+
+        frame = pyvips.Image.new_from_buffer(png_data, "")
+
         if self._bg_tile is not None:
-            base = self._bg_tile.copy()
-            if img.mode == "RGBA":
-                base.paste(img, mask=img)
+            base = _to_vips(self._bg_tile)
+            if base.hasalpha():
+                base = base.flatten(background=[0, 0, 0])
+            if frame.hasalpha():
+                base = base.addalpha()
+                base = base.copy(interpretation="srgb")
+                frame = frame.copy(interpretation="srgb")
+                result = base.composite2(frame, "over")
+                result = result.flatten(background=[0, 0, 0])
             else:
-                base.paste(img)
-            return base
-        if img.mode != "RGB":
-            return img.convert("RGB")
-        return img
+                result = frame
+        else:
+            result = frame.flatten(background=[0, 0, 0]) if frame.hasalpha() else frame
+
+        return self._encode_vips(result)
+
+    def _encode_vips(self, vimg: object) -> bytes:
+        """Encode a pyvips image in the configured format.
+
+        Parameters
+        ----------
+        vimg
+            A ``pyvips.Image`` instance.
+
+        Returns
+        -------
+        bytes
+            Encoded image bytes.
+        """
+        from ..render.key_renderer import _encode_image_bytes
+
+        return _encode_image_bytes(vimg, self._image_format)
+
+    def _encode_tile(self, tile: bytes | object) -> bytes:
+        """Re-encode a tile in the configured output format.
+
+        Parameters
+        ----------
+        tile
+            PNG-encoded tile bytes or a PIL Image.
+
+        Returns
+        -------
+        bytes
+            Image bytes in the configured format.
+        """
+        _ensure_macos_lib_path()
+
+        from ..render.touch_renderer import _to_vips
+
+        img = _to_vips(tile)
+        if img.hasalpha():
+            img = img.flatten(background=[0, 0, 0])
+        return self._encode_vips(img)
+
+    def _encode_blank(self) -> bytes:
+        """Encode a solid black frame.
+
+        Returns
+        -------
+        bytes
+            Black frame in the configured format.
+        """
+        _ensure_macos_lib_path()
+        import pyvips
+
+        img = pyvips.Image.black(self._width, self._height, bands=3)
+        return self._encode_vips(img)
 
     def _rasterise(self, root: ET.Element) -> bytes:
         """Rasterise an SVG element tree to encoded image bytes.
@@ -311,9 +376,7 @@ class SpinnerFrames:
 
         svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
         png_data = _svg_to_png(svg_bytes.encode("utf-8"), self._width, self._height)
-        img = Image.open(io.BytesIO(png_data)).convert("RGBA")
-        img = self._composite_on_bg(img)
-        return _encode_image(img, self._image_format)
+        return self._composite_on_bg(png_data)
 
     @staticmethod
     def _element_centre(elem: ET.Element) -> tuple[float, float]:

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -1005,10 +1005,28 @@ class SvgRenderer:
         if isinstance(value, bytes):
             img_bytes = value
         elif hasattr(value, "save"):
-            # Legacy PIL.Image.Image support — convert to PNG bytes.
-            buf = io.BytesIO()
-            value.save(buf, format="PNG")
-            img_bytes = buf.getvalue()
+            # Legacy PIL.Image.Image support — convert to raw bytes.
+            # PIL Images are lazily loaded; the underlying stream may be
+            # closed/GC'd by the time we render in a worker thread.
+            fp = getattr(value, "filename", None)
+            if fp:
+                # Source file still on disk — read raw bytes directly.
+                with open(fp, "rb") as fh:
+                    img_bytes = fh.read()
+            else:
+                # In-memory PIL Image: force pixel decode and re-encode via pyvips.
+                import pyvips
+
+                try:
+                    value.load()
+                except Exception:
+                    logger.warning("Image binding: failed to load PIL Image")
+                    return
+                rgba = value.convert("RGBA")
+                w, h = rgba.size
+                raw = rgba.tobytes()
+                vimg = pyvips.Image.new_from_memory(raw, w, h, 4, "uchar")
+                img_bytes = vimg.write_to_buffer(".png")
         else:
             logger.warning("Image binding: unsupported value type %s", type(value))
             return

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -14,9 +14,12 @@ import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from PIL import Image, ImageFont
+from PIL import ImageFont
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 from .._xml import safe_fromstring
 from ..render.context import RenderingContext
@@ -58,45 +61,45 @@ def _find_element_by_id(root: ET.Element, element_id: str) -> ET.Element | None:
     return None
 
 
-def _image_to_data_uri(img: Image.Image, fmt: str = "PNG") -> str:
-    """Encode a PIL Image as a base64 data URI."""
-    buf = io.BytesIO()
-    img.save(buf, format=fmt)
-    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-    mime = "image/png" if fmt == "PNG" else "image/jpeg"
+def _bytes_to_data_uri(data: bytes) -> str:
+    """Encode image bytes as a base64 data URI.
+
+    Detects format from the header bytes (PNG or JPEG).
+
+    Parameters
+    ----------
+    data : bytes
+        Raw image bytes (PNG or JPEG).
+
+    Returns
+    -------
+    str
+        A ``data:image/...;base64,...`` URI.
+    """
+    mime = "image/png" if data[:8] == b"\x89PNG\r\n\x1a\n" else "image/jpeg"
+    b64 = base64.b64encode(data).decode("ascii")
     return f"data:{mime};base64,{b64}"
 
 
-def _fit_image(
-    img: Image.Image, target_w: int, target_h: int, fit: ImageFit
-) -> Image.Image:
-    """Scale an image to fit within target dimensions using the specified mode."""
-    if target_w <= 0 or target_h <= 0:
-        return img
+def _fit_image_preserveAspectRatio(fit: ImageFit) -> str:
+    """Map an ImageFit enum to an SVG preserveAspectRatio value.
 
-    src_w, src_h = img.size
+    Parameters
+    ----------
+    fit : ImageFit
+        The fit mode from the binding spec.
 
+    Returns
+    -------
+    str
+        An SVG ``preserveAspectRatio`` attribute value.
+    """
     if fit == ImageFit.FILL:
-        return img.resize((target_w, target_h), Image.Resampling.LANCZOS)
-
+        return "none"
     if fit == ImageFit.CONTAIN:
-        ratio = min(target_w / src_w, target_h / src_h)
-        new_w = max(1, int(src_w * ratio))
-        new_h = max(1, int(src_h * ratio))
-        resized = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-        canvas = Image.new("RGBA", (target_w, target_h), (0, 0, 0, 0))
-        paste_x = (target_w - new_w) // 2
-        paste_y = (target_h - new_h) // 2
-        canvas.paste(resized, (paste_x, paste_y))
-        return canvas
-
-    ratio = max(target_w / src_w, target_h / src_h)
-    new_w = max(1, int(src_w * ratio))
-    new_h = max(1, int(src_h * ratio))
-    resized = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-    left = (new_w - target_w) // 2
-    top = (new_h - target_h) // 2
-    return resized.crop((left, top, left + target_w, top + target_h))
+        return "xMidYMid meet"
+    # COVER
+    return "xMidYMid slice"
 
 
 def _truncate_text(
@@ -999,26 +1002,25 @@ class SvgRenderer:
             if placeholder is not None:
                 placeholder.set("display", "none")
 
-        target_w = int(float(elem.get("width", "0")))
-        target_h = int(float(elem.get("height", "0")))
-
-        if isinstance(value, Image.Image):
-            img = value
-        elif isinstance(value, bytes):
-            img = Image.open(io.BytesIO(value))
+        if isinstance(value, bytes):
+            img_bytes = value
+        elif hasattr(value, "save"):
+            # Legacy PIL.Image.Image support — convert to PNG bytes.
+            buf = io.BytesIO()
+            value.save(buf, format="PNG")
+            img_bytes = buf.getvalue()
         else:
             logger.warning("Image binding: unsupported value type %s", type(value))
             return
 
-        if img.mode != "RGBA":
-            img = img.convert("RGBA")
-
-        if target_w > 0 and target_h > 0:
-            img = _fit_image(img, target_w, target_h, binding.fit)
-
-        data_uri = _image_to_data_uri(img)
+        # Embed as data URI and let SVG-level preserveAspectRatio handle fitting.
+        data_uri = _bytes_to_data_uri(img_bytes)
         elem.set("href", data_uri)
         elem.set(f"{{{_XLINK_NS}}}href", data_uri)
+
+        # Set preserveAspectRatio based on the binding's fit mode.
+        par = _fit_image_preserveAspectRatio(binding.fit)
+        elem.set("preserveAspectRatio", par)
 
     def _apply_visibility(self, elem: ET.Element, value: Any) -> None:
         """Toggle element visibility via the ``display`` attribute.
@@ -1387,8 +1389,7 @@ class SvgRenderer:
                 asset_name = href
 
             if asset_name and asset_name in self._spec.assets:
-                img = Image.open(io.BytesIO(self._spec.assets[asset_name]))
-                data_uri = _image_to_data_uri(img)
+                data_uri = _bytes_to_data_uri(self._spec.assets[asset_name])
                 elem.set("href", data_uri)
                 elem.set(f"{{{_XLINK_NS}}}href", data_uri)
 
@@ -1424,7 +1425,9 @@ class SvgRenderer:
             height = int(float(self._base_root.get("height", "98")))
 
         png_data = _svg_to_png(svg_data, width, height, ctx=self._rendering_ctx)
-        return Image.open(io.BytesIO(png_data)).convert("RGBA")
+        from PIL import Image as _PILImage
+
+        return _PILImage.open(io.BytesIO(png_data)).convert("RGBA")
 
 
 # ---------------------------------------------------------------------------

--- a/src/deux/render/background_layer.py
+++ b/src/deux/render/background_layer.py
@@ -8,12 +8,9 @@ and :class:`~deux.runtime.renderer.DeckRenderer`.
 
 from __future__ import annotations
 
-import io
 import logging
 import xml.etree.ElementTree as ET
 from typing import Literal
-
-from PIL import Image
 
 from .._xml import safe_fromstring
 
@@ -71,7 +68,7 @@ class BackgroundLayer:
         self._panel_count = panel_count
         self._panel_width = panel_width
         self._panel_height = panel_height
-        self._tiles: list[Image.Image] | None = None
+        self._tiles: list[bytes] | None = None
 
         # Key state
         self._key_size = key_size
@@ -98,8 +95,8 @@ class BackgroundLayer:
         return self._svg_root
 
     @property
-    def tiles(self) -> list[Image.Image] | None:
-        """Pre-sliced touchstrip tiles (shallow copy), or ``None``.
+    def tiles(self) -> list[bytes] | None:
+        """Pre-sliced touchstrip tiles as PNG bytes (shallow copy), or ``None``.
 
         Only meaningful for ``kind="touchstrip"``.
         """
@@ -107,7 +104,7 @@ class BackgroundLayer:
             return None
         return list(self._tiles)
 
-    def tile(self, index: int) -> Image.Image | None:
+    def tile(self, index: int) -> bytes | None:
         """Return the cached background tile for panel *index*, or ``None``.
 
         Parameters
@@ -117,8 +114,8 @@ class BackgroundLayer:
 
         Returns
         -------
-        Image.Image or None
-            The RGB tile image, or ``None`` if no background SVG is set
+        bytes or None
+            PNG-encoded tile bytes, or ``None`` if no background SVG is set
             or *index* is out of range.
         """
         if self._tiles is None or not 0 <= index < len(self._tiles):
@@ -225,8 +222,8 @@ class BackgroundLayer:
             self._rasterize_key()
 
     def _rasterize_touchstrip(self) -> None:
-        """Rasterize and slice a touchstrip background SVG."""
-        from .svg_rasterize import _svg_to_png
+        """Rasterize and slice a touchstrip background SVG using pyvips."""
+        from .svg_rasterize import _ensure_macos_lib_path, _svg_to_png
 
         assert self._svg is not None  # noqa: S101 — invariant
 
@@ -234,14 +231,20 @@ class BackgroundLayer:
         total_height = self._panel_height
 
         png_data = _svg_to_png(self._svg, total_width, total_height)
-        full_img = Image.open(io.BytesIO(png_data)).convert("RGB")
 
-        tiles: list[Image.Image] = []
+        _ensure_macos_lib_path()
+        import pyvips
+
+        full_img = pyvips.Image.new_from_buffer(png_data, "")
+        # Flatten alpha channel if present.
+        if full_img.hasalpha():
+            full_img = full_img.flatten(background=[0, 0, 0])
+
+        tiles: list[bytes] = []
         for i in range(self._panel_count):
             x0 = i * self._panel_width
-            x1 = x0 + self._panel_width
-            tile = full_img.crop((x0, 0, x1, total_height))
-            tiles.append(tile)
+            tile = full_img.crop(x0, 0, self._panel_width, total_height)
+            tiles.append(tile.write_to_buffer(".png"))
 
         self._tiles = tiles
         logger.debug(
@@ -255,13 +258,13 @@ class BackgroundLayer:
 
     def _rasterize_key(self) -> None:
         """Rasterize a key background SVG to encoded device bytes."""
-        from .key_renderer import _encode_image
-        from .svg_rasterize import _svg_to_png
+        from .svg_rasterize import _rasterize_svg
 
         assert self._svg is not None  # noqa: S101 — invariant
 
         key_w, key_h = self._key_size
-        png_data = _svg_to_png(self._svg, key_w, key_h)
-        img = Image.open(io.BytesIO(png_data)).convert("RGB")
-        self._key_image = _encode_image(img, image_format=self._key_image_format)
+        fmt = "jpeg" if self._key_image_format.upper() == "JPEG" else "bmp"
+        self._key_image = _rasterize_svg(
+            self._svg, key_w, key_h, output_format=fmt
+        )
         logger.debug("Key background SVG rasterized: %dx%d", key_w, key_h)

--- a/src/deux/render/key_renderer.py
+++ b/src/deux/render/key_renderer.py
@@ -1,15 +1,19 @@
-"""Key image rendering for Stream Deck button slots."""
+"""Key image rendering for Stream Deck button slots.
+
+Uses pyvips for image encoding. PIL is only needed as a fallback for
+BMP format (which pyvips does not support natively).
+"""
 
 from __future__ import annotations
 
 import io
 
-from PIL import Image
+from ..render.svg_rasterize import _ensure_macos_lib_path
 
 
 def render_key_image(
     key_size: tuple[int, int],
-    icon: Image.Image | None = None,
+    icon: bytes | object | None = None,
     background: str = "black",
     image_format: str = "JPEG",
 ) -> bytes:
@@ -24,8 +28,9 @@ def render_key_image(
     key_size
         Key dimensions ``(width, height)`` in pixels.
     icon
-        Optional icon image to render on the key. Resized to ``key_size``
-        if it does not already match.
+        Optional icon: encoded image bytes (PNG/JPEG) or a
+        ``PIL.Image.Image`` (for backward compatibility). Resized to
+        ``key_size`` if it does not already match.
     background
         Background colour name (used when *icon* is ``None`` or has alpha).
     image_format
@@ -36,18 +41,42 @@ def render_key_image(
     bytes
         Encoded image bytes ready to send to the device.
     """
-    img = Image.new("RGB", key_size, background)
+    _ensure_macos_lib_path()
+    import pyvips
+
+    from .touch_renderer import _parse_color
+
+    key_w, key_h = key_size
+    r, g, b = _parse_color(background)
+    img = pyvips.Image.black(key_w, key_h, bands=3) + [r, g, b]
+    img = img.cast("uchar")
 
     if icon is not None:
-        if icon.size != key_size:
-            icon = icon.resize(key_size, Image.Resampling.LANCZOS)
-
-        if icon.mode == "RGBA":
-            img.paste(icon, (0, 0), icon)
+        # Accept bytes or PIL Image.
+        if isinstance(icon, bytes):
+            icon_img = pyvips.Image.new_from_buffer(icon, "")
         else:
-            img.paste(icon, (0, 0))
+            # PIL Image — convert to PNG bytes first.
+            buf = io.BytesIO()
+            icon.save(buf, format="PNG")  # type: ignore[union-attr]
+            icon_img = pyvips.Image.new_from_buffer(buf.getvalue(), "")
 
-    return _encode_image(img, image_format)
+        if icon_img.width != key_w or icon_img.height != key_h:
+            icon_img = icon_img.thumbnail_image(key_w, height=key_h, crop="centre")
+
+        if icon_img.hasalpha():
+            # Ensure both images are in sRGB colourspace for compositing.
+            if img.bands == 3:
+                img = img.copy(interpretation="srgb")
+            img = img.addalpha()
+            if icon_img.interpretation != img.interpretation:
+                icon_img = icon_img.copy(interpretation="srgb")
+            img = img.composite2(icon_img, "over")
+            img = img.flatten(background=[r, g, b])
+        else:
+            img = icon_img
+
+    return _encode_image_bytes(img, image_format)
 
 
 def render_blank_key(
@@ -71,15 +100,13 @@ def render_blank_key(
     return render_key_image(key_size=key_size, image_format=image_format)
 
 
-def _encode_image(
-    img: Image.Image, image_format: str = "JPEG", quality: int = 90
-) -> bytes:
-    """Encode a PIL image in the specified format.
+def _encode_image_bytes(vimg: object, image_format: str = "JPEG", quality: int = 90) -> bytes:
+    """Encode a pyvips image in the specified format.
 
     Parameters
     ----------
-    img : PIL.Image.Image
-        Image to encode.
+    vimg
+        A ``pyvips.Image`` instance.
     image_format : str, default="JPEG"
         Target format (``"JPEG"`` or ``"BMP"``).
     quality : int, default=90
@@ -90,10 +117,57 @@ def _encode_image(
     bytes
         Raw encoded image bytes.
     """
-    buf = io.BytesIO()
     fmt = image_format.upper()
     if fmt == "BMP":
-        img.save(buf, format="BMP")
-    else:
-        img.save(buf, format="JPEG", quality=quality)
-    return buf.getvalue()
+        from PIL import Image as _PILImage
+
+        png_bytes = vimg.write_to_buffer(".png")  # type: ignore[union-attr]
+        pil_img = _PILImage.open(io.BytesIO(png_bytes)).convert("RGB")
+        buf = io.BytesIO()
+        pil_img.save(buf, format="BMP")
+        return buf.getvalue()
+    return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[union-attr]
+
+
+# Legacy alias for backward compatibility with internal imports.
+def _encode_image(img: object, image_format: str = "JPEG", quality: int = 90) -> bytes:
+    """Encode an image (pyvips or PIL) to device bytes.
+
+    Accepts both pyvips.Image and PIL.Image.Image for backward
+    compatibility during the migration period.
+
+    Parameters
+    ----------
+    img
+        A pyvips.Image or PIL.Image.Image instance.
+    image_format : str, default="JPEG"
+        Target format (``"JPEG"`` or ``"BMP"``).
+    quality : int, default=90
+        JPEG quality (ignored for BMP).
+
+    Returns
+    -------
+    bytes
+        Raw encoded image bytes.
+    """
+    try:
+        import pyvips
+
+        if isinstance(img, pyvips.Image):
+            return _encode_image_bytes(img, image_format, quality)
+    except ImportError:
+        pass
+
+    # PIL fallback for legacy callers.
+    from PIL import Image as _PILImage
+
+    if isinstance(img, _PILImage.Image):
+        buf = io.BytesIO()
+        fmt = image_format.upper()
+        if fmt == "BMP":
+            img.save(buf, format="BMP")
+        else:
+            img.save(buf, format="JPEG", quality=quality)
+        return buf.getvalue()
+
+    raise TypeError(f"Unsupported image type: {type(img)}")

--- a/src/deux/render/key_renderer.py
+++ b/src/deux/render/key_renderer.py
@@ -7,6 +7,7 @@ BMP format (which pyvips does not support natively).
 from __future__ import annotations
 
 import io
+from typing import Any
 
 from ..render.svg_rasterize import _ensure_macos_lib_path
 
@@ -58,7 +59,7 @@ def render_key_image(
         else:
             # PIL Image — convert to PNG bytes first.
             buf = io.BytesIO()
-            icon.save(buf, format="PNG")  # type: ignore[union-attr]
+            icon.save(buf, format="PNG")  # type: ignore[attr-defined]
             icon_img = pyvips.Image.new_from_buffer(buf.getvalue(), "")
 
         if icon_img.width != key_w or icon_img.height != key_h:
@@ -100,7 +101,7 @@ def render_blank_key(
     return render_key_image(key_size=key_size, image_format=image_format)
 
 
-def _encode_image_bytes(vimg: object, image_format: str = "JPEG", quality: int = 90) -> bytes:
+def _encode_image_bytes(vimg: Any, image_format: str = "JPEG", quality: int = 90) -> bytes:
     """Encode a pyvips image in the specified format.
 
     Parameters
@@ -121,12 +122,12 @@ def _encode_image_bytes(vimg: object, image_format: str = "JPEG", quality: int =
     if fmt == "BMP":
         from PIL import Image as _PILImage
 
-        png_bytes = vimg.write_to_buffer(".png")  # type: ignore[union-attr]
+        png_bytes = vimg.write_to_buffer(".png")
         pil_img = _PILImage.open(io.BytesIO(png_bytes)).convert("RGB")
         buf = io.BytesIO()
         pil_img.save(buf, format="BMP")
         return buf.getvalue()
-    return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[union-attr]
+    return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[no-any-return]
 
 
 # Legacy alias for backward compatibility with internal imports.

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -663,16 +663,36 @@ def _rasterize_svg(
     if fmt == "png":
         return png_bytes
 
-    # For JPEG and BMP we need to convert from PNG.
-    from PIL import Image
+    # Convert from PNG using pyvips where possible.
+    try:
+        _ensure_macos_lib_path()
+        import pyvips
 
-    img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
-    buf = io.BytesIO()
-    if fmt == "jpeg":
-        img.save(buf, format="JPEG", quality=quality)
-    else:  # bmp
-        img.save(buf, format="BMP")
-    return buf.getvalue()
+        vimg = pyvips.Image.new_from_buffer(png_bytes, "")
+        # Flatten alpha onto white for JPEG (no transparency support).
+        if vimg.hasalpha():
+            vimg = vimg.flatten(background=[0, 0, 0])
+        if fmt == "jpeg":
+            return vimg.write_to_buffer(".jpg", Q=quality)
+        # BMP: pyvips doesn't support BMP natively, fall back to PIL.
+        from PIL import Image as _PILImage
+
+        buf = io.BytesIO(vimg.write_to_buffer(".png"))
+        img = _PILImage.open(buf).convert("RGB")
+        out = io.BytesIO()
+        img.save(out, format="BMP")
+        return out.getvalue()
+    except (OSError, ImportError):
+        # Fallback: PIL for both formats if pyvips unavailable.
+        from PIL import Image as _PILImage
+
+        img = _PILImage.open(io.BytesIO(png_bytes)).convert("RGB")
+        buf = io.BytesIO()
+        if fmt == "jpeg":
+            img.save(buf, format="JPEG", quality=quality)
+        else:
+            img.save(buf, format="BMP")
+        return buf.getvalue()
 
 
 def _resolve_and_rasterize(

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -673,7 +673,7 @@ def _rasterize_svg(
         if vimg.hasalpha():
             vimg = vimg.flatten(background=[0, 0, 0])
         if fmt == "jpeg":
-            return vimg.write_to_buffer(".jpg", Q=quality)
+            return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[no-any-return]
         # BMP: pyvips doesn't support BMP natively, fall back to PIL.
         from PIL import Image as _PILImage
 

--- a/src/deux/render/touch_renderer.py
+++ b/src/deux/render/touch_renderer.py
@@ -1,47 +1,134 @@
-"""Touch-strip rendering for Stream Deck cards."""
+"""Touch-strip rendering for Stream Deck cards.
+
+Uses pyvips for all compositing and encoding operations. PIL is only
+used as a fallback for BMP encoding (pyvips lacks native BMP support).
+"""
 
 from __future__ import annotations
 
-from PIL import Image
+import io
 
-from .key_renderer import _encode_image
+from ..render.svg_rasterize import _ensure_macos_lib_path
 
 
-def _composite_card_on_tile(
-    card: Image.Image,
-    tile: Image.Image,
-) -> Image.Image:
-    """Composite an RGBA card image onto an RGB background tile.
-
-    If the card has an alpha channel it is used as a mask so that
-    transparent regions of the card reveal the background tile
-    underneath.  If the card is RGB (no alpha), it replaces the tile
-    entirely.
+def _to_vips(value: object) -> object:
+    """Convert an image value (bytes or PIL Image) to a pyvips.Image.
 
     Parameters
     ----------
-    card
-        The card image (RGB or RGBA).
-    tile
-        The background tile (RGB).
+    value
+        Either raw image bytes (PNG/JPEG) or a ``PIL.Image.Image``.
 
     Returns
     -------
-    Image.Image
-        An RGB image with the card composited onto the tile.
+    object
+        A ``pyvips.Image`` instance.
     """
-    base = tile.copy()
-    if card.mode == "RGBA":
-        base.paste(card, mask=card)
+    import pyvips
+
+    if isinstance(value, bytes):
+        return pyvips.Image.new_from_buffer(value, "")
+    # PIL Image — convert to PNG bytes.
+    buf = io.BytesIO()
+    value.save(buf, format="PNG")  # type: ignore[union-attr]
+    return pyvips.Image.new_from_buffer(buf.getvalue(), "")
+
+
+def _encode_vips_image(vimg: object, image_format: str, quality: int = 90) -> bytes:
+    """Encode a pyvips image to the requested format.
+
+    Parameters
+    ----------
+    vimg
+        A ``pyvips.Image`` instance.
+    image_format : str
+        Target format: ``"JPEG"`` or ``"BMP"``.
+    quality : int, default=90
+        JPEG quality (ignored for BMP).
+
+    Returns
+    -------
+    bytes
+        Encoded image bytes.
+    """
+    import pyvips  # noqa: F401 — used implicitly via vimg method calls
+
+    fmt = image_format.upper()
+    if fmt == "BMP":
+        # pyvips doesn't support BMP natively; use PIL for this one format.
+        from PIL import Image as _PILImage
+
+        png_bytes = vimg.write_to_buffer(".png")  # type: ignore[union-attr]
+        pil_img = _PILImage.open(io.BytesIO(png_bytes)).convert("RGB")
+        buf = io.BytesIO()
+        pil_img.save(buf, format="BMP")
+        return buf.getvalue()
+    return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[union-attr]
+
+
+def composite_frame_on_tile(
+    frame_bytes: bytes,
+    *,
+    bg_tile_bytes: bytes,
+    panel_width: int,
+    panel_height: int,
+    image_format: str = "JPEG",
+) -> bytes:
+    """Composite a rendered frame onto a background tile using pyvips.
+
+    Used for spinner animations where each frame must be composited
+    onto the touchstrip background.
+
+    Parameters
+    ----------
+    frame_bytes : bytes
+        Encoded frame image (PNG or JPEG).
+    bg_tile_bytes : bytes
+        PNG-encoded background tile.
+    panel_width : int
+        Width of the panel in pixels.
+    panel_height : int
+        Height of the panel in pixels.
+    image_format : str, default="JPEG"
+        Output encoding format.
+
+    Returns
+    -------
+    bytes
+        Encoded composited image bytes.
+    """
+    _ensure_macos_lib_path()
+    import pyvips
+
+    bg = pyvips.Image.new_from_buffer(bg_tile_bytes, "")
+    frame = pyvips.Image.new_from_buffer(frame_bytes, "")
+
+    # Ensure both images are the right size.
+    if bg.width != panel_width or bg.height != panel_height:
+        bg = bg.thumbnail_image(panel_width, height=panel_height, crop="centre")
+    if frame.width != panel_width or frame.height != panel_height:
+        frame = frame.thumbnail_image(panel_width, height=panel_height, crop="centre")
+
+    # Composite frame over background using alpha if present.
+    if frame.hasalpha():
+        # Ensure bg has alpha for compositing.
+        if not bg.hasalpha():
+            bg = bg.addalpha()
+        bg = bg.copy(interpretation="srgb")
+        frame = frame.copy(interpretation="srgb")
+        result = bg.composite2(frame, "over")
+        result = result.flatten(background=[0, 0, 0])
     else:
-        base.paste(card)
-    return base
+        result = frame
+
+    return _encode_vips_image(result, image_format)
 
 
 def compose_card_with_background(
-    card: Image.Image | None,
+    card_bytes: bytes | object | None,
     *,
-    bg_tile: Image.Image | None = None,
+    bg_tile: bytes | None = None,
+    bg_tile_bytes: bytes | None = None,
     background: str = "black",
     panel_width: int,
     panel_height: int,
@@ -54,13 +141,13 @@ def compose_card_with_background(
 
     Parameters
     ----------
-    card
-        The card image (RGB or RGBA), or ``None`` for a blank panel.
-    bg_tile
-        Pre-sliced background tile for this panel, or ``None`` to use
-        the solid *background* colour.
+    card_bytes
+        Encoded card image (PNG/JPEG bytes), or ``None`` for a blank panel.
+    bg_tile_bytes
+        PNG-encoded background tile, or ``None`` to use the solid
+        *background* colour.
     background
-        Fallback fill colour when *bg_tile* is ``None``.
+        Fallback fill colour when *bg_tile_bytes* is ``None``.
     panel_width
         Width of the card panel in pixels.
     panel_height
@@ -73,62 +160,69 @@ def compose_card_with_background(
     bytes
         Encoded image bytes for a single panel.
     """
-    if bg_tile is not None:
-        img = _composite_card_on_tile(card, bg_tile) if card is not None else bg_tile.copy()
-    else:
-        img = Image.new("RGB", (panel_width, panel_height), background)
-        if card is not None:
-            if card.mode == "RGBA":
-                img.paste(card, mask=card)
-            else:
-                img.paste(card)
+    _ensure_macos_lib_path()
+    import pyvips
 
-    return _encode_image(img, image_format)
+    # Support both parameter names for backward compatibility.
+    _tile = bg_tile_bytes or bg_tile
+    if _tile is not None:
+        base = _to_vips(_tile)
+        if base.hasalpha():
+            base = base.flatten(background=[0, 0, 0])
+    else:
+        # Parse CSS colour name to RGB.
+        r, g, b = _parse_color(background)
+        base = pyvips.Image.black(panel_width, panel_height, bands=3) + [r, g, b]
+        base = base.cast("uchar").copy(interpretation="srgb")
+
+    if card_bytes is not None:
+        card = _to_vips(card_bytes)
+        if card.hasalpha():
+            if not base.hasalpha():
+                base = base.addalpha()
+            # Ensure compatible colourspace for compositing.
+            base = base.copy(interpretation="srgb")
+            card = card.copy(interpretation="srgb")
+            base = base.composite2(card, "over")
+            base = base.flatten(background=[0, 0, 0])
+        else:
+            base = card
+
+    return _encode_vips_image(base, image_format)
 
 
 def compose_touchstrip(
-    cards: list[Image.Image | None],
+    card_tiles: list[bytes | object | None],
     *,
     touchscreen_width: int,
     touchscreen_height: int,
     panel_count: int,
     panel_width: int,
     background: str = "black",
-    bg_tiles: list[Image.Image] | None = None,
+    bg_tiles: list[bytes | object] | None = None,
     image_format: str = "JPEG",
 ) -> bytes:
     """Compose card images into a single touchscreen image.
 
-    Cards are tiled edge-to-edge across the touchscreen — the library
-    imposes no margins or gaps. Card *i* starts at
-    ``(i * panel_width, 0)`` and is expected to be ``panel_width`` wide
-    and ``touchscreen_height`` tall. The *background* colour shows
-    through wherever a slot is ``None`` or a card image leaves pixels
-    uncovered.
-
-    When *bg_tiles* is provided, each panel is composited onto its
-    corresponding background tile instead of the solid-colour canvas.
-    Cards with RGBA transparency will reveal the background tile
-    underneath.
+    Cards are tiled edge-to-edge across the touchscreen. Card *i*
+    starts at ``(i * panel_width, 0)``.
 
     Parameters
     ----------
-    cards
-        Card images (or ``None`` for blank slots).
+    card_tiles
+        Encoded card images (or ``None`` for blank slots).
     touchscreen_width
         Total touchscreen width in pixels.
     touchscreen_height
         Total touchscreen height in pixels.
     panel_count
-        Number of card zones (slots beyond this are silently dropped).
+        Number of card zones.
     panel_width
         Width of each card panel in pixels.
     background
         Fill colour for the canvas where no card is drawn.
     bg_tiles
-        Optional list of pre-sliced background tiles (one per panel).
-        When provided, cards are composited onto these tiles instead of
-        the solid *background* colour.
+        Optional list of PNG-encoded background tiles (one per panel).
     image_format
         Image encoding format (``"JPEG"`` or ``"BMP"``).
 
@@ -137,29 +231,50 @@ def compose_touchstrip(
     bytes
         Encoded touchscreen image bytes.
     """
-    img = Image.new("RGB", (touchscreen_width, touchscreen_height), background)
+    _ensure_macos_lib_path()
+    import pyvips
 
-    for index, card_image in enumerate(cards):
+    r, g, b = _parse_color(background)
+    canvas = pyvips.Image.black(touchscreen_width, touchscreen_height, bands=3) + [r, g, b]
+    canvas = canvas.cast("uchar").copy(interpretation="srgb")
+
+    for index, card_data in enumerate(card_tiles):
         if index >= panel_count:
             break
         x_offset = index * panel_width
-        tile = bg_tiles[index] if bg_tiles is not None and index < len(bg_tiles) else None
+        tile_bytes = (
+            bg_tiles[index] if bg_tiles is not None and index < len(bg_tiles) else None
+        )
 
-        if tile is not None:
-            panel = (
-                _composite_card_on_tile(card_image, tile) if card_image is not None else tile
-            )
-            img.paste(panel, (x_offset, 0))
-        elif card_image is not None:
-            if card_image.mode == "RGBA":
-                # Composite RGBA card onto the solid-colour canvas region
-                region = img.crop((x_offset, 0, x_offset + panel_width, touchscreen_height))
-                region.paste(card_image, mask=card_image)
-                img.paste(region, (x_offset, 0))
+        if tile_bytes is not None:
+            tile_img = _to_vips(tile_bytes)
+            if tile_img.hasalpha():
+                tile_img = tile_img.flatten(background=[r, g, b])
+            panel = tile_img
+        else:
+            panel = None
+
+        if card_data is not None:
+            card_img = _to_vips(card_data)
+            if panel is not None:
+                if card_img.hasalpha():
+                    if not panel.hasalpha():
+                        panel = panel.addalpha()
+                    panel = panel.copy(interpretation="srgb")
+                    card_img = card_img.copy(interpretation="srgb")
+                    panel = panel.composite2(card_img, "over")
+                    panel = panel.flatten(background=[r, g, b])
+                else:
+                    panel = card_img
             else:
-                img.paste(card_image, (x_offset, 0))
+                if card_img.hasalpha():
+                    card_img = card_img.flatten(background=[r, g, b])
+                panel = card_img
 
-    return _encode_image(img, image_format)
+        if panel is not None:
+            canvas = canvas.insert(panel, x_offset, 0)
+
+    return _encode_vips_image(canvas, image_format)
 
 
 def render_blank_touchscreen(
@@ -202,3 +317,37 @@ def render_blank_touchscreen(
         background=background,
         image_format=image_format,
     )
+
+
+def _parse_color(color: str) -> tuple[int, int, int]:
+    """Parse a CSS colour name or hex value to an RGB tuple.
+
+    Parameters
+    ----------
+    color : str
+        CSS colour name (e.g. ``"black"``) or hex (e.g. ``"#ff0000"``).
+
+    Returns
+    -------
+    tuple[int, int, int]
+        RGB values in [0, 255].
+    """
+    _COLORS = {
+        "black": (0, 0, 0),
+        "white": (255, 255, 255),
+        "red": (255, 0, 0),
+        "green": (0, 128, 0),
+        "blue": (0, 0, 255),
+        "gray": (128, 128, 128),
+        "grey": (128, 128, 128),
+        "transparent": (0, 0, 0),
+    }
+    c = color.strip().lower()
+    if c in _COLORS:
+        return _COLORS[c]
+    if c.startswith("#"):
+        c = c[1:]
+        if len(c) == 3:
+            c = c[0] * 2 + c[1] * 2 + c[2] * 2
+        return (int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16))
+    return (0, 0, 0)

--- a/src/deux/render/touch_renderer.py
+++ b/src/deux/render/touch_renderer.py
@@ -7,11 +7,12 @@ used as a fallback for BMP encoding (pyvips lacks native BMP support).
 from __future__ import annotations
 
 import io
+from typing import Any
 
 from ..render.svg_rasterize import _ensure_macos_lib_path
 
 
-def _to_vips(value: object) -> object:
+def _to_vips(value: object) -> Any:
     """Convert an image value (bytes or PIL Image) to a pyvips.Image.
 
     Parameters
@@ -30,11 +31,11 @@ def _to_vips(value: object) -> object:
         return pyvips.Image.new_from_buffer(value, "")
     # PIL Image — convert to PNG bytes.
     buf = io.BytesIO()
-    value.save(buf, format="PNG")  # type: ignore[union-attr]
+    value.save(buf, format="PNG")  # type: ignore[attr-defined]
     return pyvips.Image.new_from_buffer(buf.getvalue(), "")
 
 
-def _encode_vips_image(vimg: object, image_format: str, quality: int = 90) -> bytes:
+def _encode_vips_image(vimg: Any, image_format: str, quality: int = 90) -> bytes:
     """Encode a pyvips image to the requested format.
 
     Parameters
@@ -51,19 +52,19 @@ def _encode_vips_image(vimg: object, image_format: str, quality: int = 90) -> by
     bytes
         Encoded image bytes.
     """
-    import pyvips  # noqa: F401 — used implicitly via vimg method calls
+    import pyvips  # noqa: F401
 
     fmt = image_format.upper()
     if fmt == "BMP":
         # pyvips doesn't support BMP natively; use PIL for this one format.
         from PIL import Image as _PILImage
 
-        png_bytes = vimg.write_to_buffer(".png")  # type: ignore[union-attr]
+        png_bytes = vimg.write_to_buffer(".png")
         pil_img = _PILImage.open(io.BytesIO(png_bytes)).convert("RGB")
         buf = io.BytesIO()
         pil_img.save(buf, format="BMP")
         return buf.getvalue()
-    return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[union-attr]
+    return vimg.write_to_buffer(".jpg", Q=quality)  # type: ignore[no-any-return]
 
 
 def composite_frame_on_tile(

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -8,15 +8,11 @@ of :class:`~deux.runtime.deck.Deck`.
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from PIL import Image
-
 from ..dui.key import DuiKey
 from ..render.key_renderer import render_blank_key
-from ..render.touch_renderer import compose_card_with_background
 
 if TYPE_CHECKING:
     from ..dui.animator import PushFn
@@ -248,18 +244,17 @@ class DeckRenderer:
                     y: int,
                     w: int,
                     h: int,
-                    tile: Image.Image | None,
+                    tile: bytes | None,
                 ) -> PushFn:
                     async def _push_card_frame(frame_bytes: bytes) -> None:
                         if tile is not None:
-                            # Decode the frame, composite onto the bg tile, re-encode
-                            # Offload CPU-bound PIL work to a thread to avoid
-                            # blocking the event loop.
+                            # Composite frame onto bg tile using pyvips.
+                            from ..render.touch_renderer import composite_frame_on_tile
+
                             def _compose(fb: bytes = frame_bytes) -> bytes:
-                                frame_img = Image.open(io.BytesIO(fb))
-                                return compose_card_with_background(
-                                    frame_img,
-                                    bg_tile=tile,
+                                return composite_frame_on_tile(
+                                    fb,
+                                    bg_tile_bytes=tile,
                                     panel_width=w,
                                     panel_height=h,
                                     image_format=(

--- a/src/deux/ui/cards/base.py
+++ b/src/deux/ui/cards/base.py
@@ -261,7 +261,7 @@ class Card(ABC):
         *,
         metrics: RenderMetrics,
         card_index: int,
-        bg_tile: Image.Image | None,
+        bg_tile: bytes | None,
         background: str = "black",
         image_format: str = "JPEG",
     ) -> bytes:
@@ -284,8 +284,8 @@ class Card(ABC):
             Device metrics (panel dimensions, etc.).
         card_index : int
             The zero-based position of this card on the touch strip.
-        bg_tile : Image.Image or None
-            Cropped background tile for this card's panel, or ``None``.
+        bg_tile : bytes or None
+            PNG-encoded background tile for this panel, or ``None``.
         background : str, default="black"
             Fallback background colour.
         image_format : str, default="JPEG"
@@ -308,9 +308,18 @@ class Card(ABC):
         rendered = self.render()
         self.set_rendered(rendered)
 
+        # Convert PIL Image to PNG bytes for pyvips-based compositing.
+        card_bytes: bytes | None = None
+        if rendered is not None:
+            import io
+
+            buf = io.BytesIO()
+            rendered.save(buf, format="PNG")
+            card_bytes = buf.getvalue()
+
         return compose_card_with_background(
-            rendered,
-            bg_tile=bg_tile,
+            card_bytes,
+            bg_tile_bytes=bg_tile,
             background=background,
             panel_width=metrics.panel_width,
             panel_height=metrics.panel_height,

--- a/src/deux/ui/touch_strip.py
+++ b/src/deux/ui/touch_strip.py
@@ -7,8 +7,6 @@ import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from PIL import Image
-
 from ..render.background_layer import BackgroundLayer
 from .cards.base import Card
 from .cards.blank import BlankCard
@@ -139,14 +137,14 @@ class TouchStrip:
         return self._panel_height
 
     @property
-    def bg_tiles(self) -> list[Image.Image] | None:
-        """Pre-sliced background tiles, or ``None`` if no background SVG is set.
+    def bg_tiles(self) -> list[bytes] | None:
+        """Pre-sliced background tiles as PNG bytes, or ``None`` if no background SVG is set.
 
         Returns a shallow copy when tiles exist; external code cannot mutate internal state.
         """
         return self._bg_layer.tiles
 
-    def bg_tile(self, index: int) -> Image.Image | None:
+    def bg_tile(self, index: int) -> bytes | None:
         """Return the cached background tile for panel *index*, or ``None``.
 
         Parameters
@@ -156,8 +154,8 @@ class TouchStrip:
 
         Returns
         -------
-        Image.Image or None
-            The RGB tile image, or ``None`` if no background SVG is set.
+        bytes or None
+            PNG-encoded tile bytes, or ``None`` if no background SVG is set.
         """
         return self._bg_layer.tile(index)
 

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -28,10 +28,10 @@ from deux.dui.schema import (
 )
 from deux.dui.svg_renderer import (
     SvgRenderer,
+    _bytes_to_data_uri,
     _find_font_file,
-    _fit_image,
+    _fit_image_preserveAspectRatio,
     _font_file_index,
-    _image_to_data_uri,
     _load_font,
     _resolve_font_attrs,
     _system_font_dirs,
@@ -166,42 +166,34 @@ class TestTextTruncation:
         assert len(large_result) <= len(small_result)
 
 
-class TestImageFit:
+class TestFitImagePreserveAspectRatio:
     def test_fill(self):
-        img = Image.new("RGB", (200, 100))
-        result = _fit_image(img, 50, 50, ImageFit.FILL)
-        assert result.size == (50, 50)
+        result = _fit_image_preserveAspectRatio(ImageFit.FILL)
+        assert result == "none"
 
     def test_contain(self):
-        img = Image.new("RGB", (200, 100))
-        result = _fit_image(img, 50, 50, ImageFit.CONTAIN)
-        assert result.size == (50, 50)
+        result = _fit_image_preserveAspectRatio(ImageFit.CONTAIN)
+        assert result == "xMidYMid meet"
 
     def test_cover(self):
-        img = Image.new("RGB", (200, 100))
-        result = _fit_image(img, 50, 50, ImageFit.COVER)
-        assert result.size == (50, 50)
-
-    def test_zero_target(self):
-        img = Image.new("RGB", (50, 50))
-        result = _fit_image(img, 0, 50, ImageFit.FILL)
-        assert result.size == (50, 50)
-
-    def test_contain_portrait(self):
-        img = Image.new("RGB", (100, 200))
-        result = _fit_image(img, 50, 50, ImageFit.CONTAIN)
-        assert result.size == (50, 50)
+        result = _fit_image_preserveAspectRatio(ImageFit.COVER)
+        assert result == "xMidYMid slice"
 
 
-class TestImageToDataUri:
+class TestBytesToDataUri:
     def test_png_format(self):
+        # Minimal valid PNG header
         img = Image.new("RGB", (10, 10), "red")
-        uri = _image_to_data_uri(img, "PNG")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        uri = _bytes_to_data_uri(buf.getvalue())
         assert uri.startswith("data:image/png;base64,")
 
     def test_jpeg_format(self):
         img = Image.new("RGB", (10, 10), "red")
-        uri = _image_to_data_uri(img, "JPEG")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        uri = _bytes_to_data_uri(buf.getvalue())
         assert uri.startswith("data:image/jpeg;base64,")
 
 

--- a/tests/test_touch_strip.py
+++ b/tests/test_touch_strip.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+
 import pytest
 from PIL import Image
 
@@ -490,8 +492,11 @@ class TestTouchStripBackgroundSvg:
         assert ts.bg_tiles is not None
         assert len(ts.bg_tiles) == 4
         for tile in ts.bg_tiles:
-            assert tile.size == (200, 100)
-            assert tile.mode == "RGB"
+            assert isinstance(tile, bytes)
+            assert len(tile) > 0
+            # Verify the tile decodes to the expected size.
+            img = Image.open(io.BytesIO(tile))
+            assert img.size == (200, 100)
 
     def test_set_background_svg_marks_all_dirty(self):
         ts = TouchStrip(panel_count=4, panel_width=200, panel_height=100)
@@ -508,7 +513,9 @@ class TestTouchStripBackgroundSvg:
         ts.set_background_svg(self._make_svg())
         tile = ts.bg_tile(0)
         assert tile is not None
-        assert tile.size == (200, 100)
+        assert isinstance(tile, bytes)
+        img = Image.open(io.BytesIO(tile))
+        assert img.size == (200, 100)
 
     def test_bg_tile_returns_none_without_svg(self):
         ts = TouchStrip(panel_count=4, panel_width=200, panel_height=100)
@@ -549,7 +556,8 @@ class TestTouchStripBackgroundSvg:
         ts.set_background_svg(self._make_svg(width=200, height=50, fill="red"))
         tile = ts.bg_tile(0)
         assert tile is not None
-        r, g, b = tile.getpixel((50, 25))
+        img = Image.open(io.BytesIO(tile)).convert("RGB")
+        r, g, b = img.getpixel((50, 25))
         assert r > 200
         assert g < 50
         assert b < 50
@@ -571,11 +579,13 @@ class TestTouchStripBackgroundSvg:
         assert tile0 is not None and tile1 is not None
 
         # Tile 0 should be red
-        r, g, b = tile0.getpixel((50, 25))
+        img0 = Image.open(io.BytesIO(tile0)).convert("RGB")
+        r, g, b = img0.getpixel((50, 25))
         assert r > 200 and g < 50 and b < 50
 
         # Tile 1 should be blue
-        r, g, b = tile1.getpixel((50, 25))
+        img1 = Image.open(io.BytesIO(tile1)).convert("RGB")
+        r, g, b = img1.getpixel((50, 25))
         assert r < 50 and g < 50 and b > 200
 
 
@@ -627,7 +637,8 @@ class TestTouchStripAsyncRasterisation:
         assert ts.bg_tiles is not None
         assert len(ts.bg_tiles) == 4
         for tile in ts.bg_tiles:
-            assert tile.size == (200, 100)
+            img = Image.open(io.BytesIO(tile))
+            assert img.size == (200, 100)
 
     async def test_set_background_svg_async_marks_dirty(self):
         """set_background_svg_async should mark all cards dirty."""


### PR DESCRIPTION
## Summary

Remove Pillow from the main render pipeline, completing the SVG-native migration started in b54e8d7 that was partially undone by subsequent refactors (c977069, ad8b8b7).

## Changes

- **background_layer.py**: pyvips crop for tile slicing instead of PIL decode/crop
- **svg_renderer.py**: embed images as data URIs with SVG `preserveAspectRatio` instead of PIL resize (`_fit_image` removed)
- **touch_renderer.py**: full rewrite using pyvips compositing
- **key_renderer.py**: pyvips-based encoding (PIL fallback for BMP only)
- **spinner.py**: pyvips compositing; tiles are now `bytes` (PNG)
- **renderer.py**: removed PIL import; uses pyvips-based compositing
- **svg_rasterize.py**: pyvips JPEG encoding in `_rasterize_svg`

## Breaking change (internal)

Background tiles (`bg_tile`) changed from `PIL.Image.Image` to `bytes` (PNG-encoded). All public APIs accept both types for backward compatibility.

## PIL that legitimately remains

- `ImageFont.getlength()` for text measurement
- BMP encoding (pyvips doesn't support it)
- Screenshot/caching path (`render()` → PIL Image)
- Legacy deprecated `Card.render()` abstract method
- `tools/preview.py` CLI

## Testing

All 1677 tests pass, 96.04% coverage (above 95% gate), lint clean.

Fixes the `AssertionError` crash in `PngImagePlugin.py` when running the example with image bindings.