### PR TITLE
fix: emit on_screen_changed before render to eliminate default-value flash

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -153,6 +153,11 @@ class Deck:
         self._running = True
         self._closed_event.clear()
 
+        # Publish the initial brightness so that any later bind_range()
+        # call can seed from the event's last_value without waiting for
+        # an explicit set_brightness().
+        await self.on_brightness_changed.emit(self._brightness)
+
         self._event_task = asyncio.create_task(
             self._event_loop(), name="deux-events"
         )
@@ -413,13 +418,16 @@ class Deck:
 
         self._wire_refresh_callbacks()
 
+        # Emit *before* rendering so that bind() handlers listening to
+        # on_screen_changed can seed card values (e.g. the nav pager)
+        # prior to the first paint, avoiding a flash of defaults.
+        await self.on_screen_changed.emit(name, self._screens)
+
         await self._render_all_keys()
         if self._active_screen.touch_strip is not None:
             await self._render_touchscreen()
         if self._active_screen.info_screen is not None:
             await self._render_info_screen()
-
-        await self.on_screen_changed.emit(name, self._screens)
 
     def _wire_refresh_callbacks(self) -> None:
         """Register ``self.refresh`` on every key and card of the active screen.

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -185,8 +185,8 @@ class TestDeckSetPage:
         deck._render_all_keys.assert_awaited_once()
         deck._render_touchscreen.assert_awaited_once()
 
-    async def test_emits_event_after_render(self, deck):
-        """on_screen_changed fires after the new screen has rendered."""
+    async def test_emits_event_before_render(self, deck):
+        """on_screen_changed fires before rendering so bind handlers can seed values."""
         deck.screen("main")
         deck._render_all_keys = AsyncMock()
         deck._render_touchscreen = AsyncMock()
@@ -199,7 +199,7 @@ class TestDeckSetPage:
             order.append(f"event:{name}")
 
         await deck.set_screen("main")
-        assert order == ["rendered", "event:main"]
+        assert order == ["event:main", "rendered"]
 
     async def test_idempotent_does_not_emit_or_re_render(self, deck):
         """Re-setting the same screen emits nothing and re-renders nothing."""


### PR DESCRIPTION
## Problem

DashboardCard (and any card with bindings driven by `on_screen_changed` or `on_brightness_changed`) flashes manifest defaults on first paint, then re-renders with real values.

The prior PR (#278) added `last_value` seeding to `bind()`, but two ordering issues remained:

1. **`set_screen()` emitted `on_screen_changed` *after* rendering** — the nav pager handler couldn't seed values before the first paint.
2. **`Deck.start()` never emitted the initial brightness** — `set_brightness()` no-ops when the requested value matches the constructor default, so `on_brightness_changed` never fired and `bind_range()` couldn't seed from `last_value`.

## Fix

1. **`set_screen()`**: moved `on_screen_changed.emit()` before the render calls. The screen state has already changed at that point (line 408), so the event name remains accurate. Bind handlers now seed card values before the first paint.

2. **`Deck.start()`**: emits `on_brightness_changed` with the initial brightness after hardware setup, ensuring the event always has a `last_value` for later `bind_range()` calls.

## Test changes

- Renamed `test_emits_event_after_render` → `test_emits_event_before_render` with updated assertion order.
- All 1690 tests pass, coverage 95.97%.