### PR TITLE
perf: reduce encoder-turn-to-display latency

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -249,9 +249,7 @@ class DuiCard(BindingMixin, Card):
             background=background,
         )
 
-        # Also render a PIL image for caching (used by screenshot).
-        img = self.render()
-        self.set_rendered(img)
+        self.mark_clean()
 
         return panel_bytes
 

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -16,7 +16,7 @@ from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
 from .device_info import DeviceInfo
 from .event_router import DeckEventRouter
-from .events import DeckEvent
+from .events import DeckEvent, EncoderTurnEvent
 from .renderer import DeckRenderer
 from .transport import AsyncTransport
 
@@ -500,9 +500,14 @@ class Deck:
         if not screen:
             return
 
-        await asyncio.gather(
-            *(self._drain_card_callbacks(card) for card in screen.cards)
-        )
+        # Only drain cards that actually have pending callbacks.
+        cards_with_pending = [
+            card for card in screen.cards if card._pending_callbacks
+        ]
+        if cards_with_pending:
+            await asyncio.gather(
+                *(self._drain_card_callbacks(card) for card in cards_with_pending)
+            )
 
         dirty_keys = [
             (key_index, key_slot)
@@ -562,7 +567,15 @@ class Deck:
             pass
 
     async def _event_loop(self) -> None:
-        """Dispatch transport events to the active screen handlers."""
+        """Dispatch transport events to the active screen handlers.
+
+        Encoder turn events are coalesced: when a turn event is
+        dequeued, any additional turn events for the same encoder
+        already waiting in the queue are merged into a single
+        dispatched event.  This prevents a backlog of redundant
+        renders when the user turns the encoder faster than the
+        render pipeline can keep up.
+        """
         if not self._transport:
             return
 
@@ -576,6 +589,12 @@ class Deck:
 
                 if not self._current_screen():
                     continue
+
+                # Coalesce consecutive encoder turn events for the
+                # same encoder so fast turns don't queue up behind
+                # slow renders.
+                if isinstance(event, EncoderTurnEvent):
+                    event = self._coalesce_encoder_turns(event)
 
                 try:
                     await self._dispatch(event)
@@ -596,6 +615,54 @@ class Deck:
     async def _drain_card_callbacks(self, card: Any) -> None:
         """Drain and await all pending callbacks queued on a card."""
         await self._renderer.drain_card_callbacks(card)
+
+    def _coalesce_encoder_turns(self, event: EncoderTurnEvent) -> EncoderTurnEvent:
+        """Merge queued encoder turn events for the same encoder.
+
+        Drains all pending :class:`EncoderTurnEvent` items from the
+        transport queue that target the same encoder as *event*,
+        summing their directions.  Non-matching events are re-queued
+        in their original order.
+
+        Parameters
+        ----------
+        event : EncoderTurnEvent
+            The initial encoder turn event just dequeued.
+
+        Returns
+        -------
+        EncoderTurnEvent
+            A single event whose ``direction`` is the sum of all
+            coalesced turns.  If no additional events were pending,
+            the original event is returned unchanged.
+        """
+        if self._transport is None:
+            return event
+
+        queue = self._transport.queue
+        direction = event.direction
+        requeue: list[DeckEvent] = []
+
+        while not queue.empty():
+            try:
+                pending = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if (
+                isinstance(pending, EncoderTurnEvent)
+                and pending.encoder == event.encoder
+            ):
+                direction += pending.direction
+            else:
+                requeue.append(pending)
+
+        # Put back non-matching events in order.
+        for item in requeue:
+            queue.put_nowait(item)
+
+        if direction == event.direction:
+            return event
+        return EncoderTurnEvent(encoder=event.encoder, direction=direction)
 
     async def _dispatch(self, event: DeckEvent) -> None:
         """Dispatch a single event to the appropriate handler on the active screen."""

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -345,6 +345,10 @@ class DeckRenderer:
                 if self.is_animating(card):
                     continue
 
+            # Only render cards that actually need updating.
+            if not card.is_dirty:
+                continue
+
             cards_to_render.append((card_idx, card, bg_tile))
 
         # Phase 2: prepare assets and render all cards concurrently
@@ -367,12 +371,19 @@ class DeckRenderer:
             return (cidx, panel_bytes)
 
         if cards_to_render:
-            results = await asyncio.gather(
-                *[_render_card(cidx, crd, tile) for cidx, crd, tile in cards_to_render]
-            )
-
-            # Phase 3: push all panels to device sequentially
-            for cidx, panel_bytes in sorted(results, key=lambda r: r[0]):
+            if len(cards_to_render) == 1:
+                # Fast path: render and push a single dirty card without
+                # the overhead of asyncio.gather.
+                cidx, crd, tile = cards_to_render[0]
+                await crd.prepare_assets()
+                panel_bytes = await asyncio.to_thread(
+                    crd.render_panel_bytes,
+                    metrics=metrics,
+                    card_index=cidx,
+                    bg_tile=tile,
+                    background=touch_strip.background_color,
+                    image_format=image_fmt,
+                )
                 x_pos = cidx * metrics.panel_width
                 y_pos = 0
                 async with deck._device_lock:
@@ -384,6 +395,24 @@ class DeckRenderer:
                         metrics.panel_width,
                         metrics.panel_height,
                     )
+            else:
+                results = await asyncio.gather(
+                    *[_render_card(cidx, crd, tile) for cidx, crd, tile in cards_to_render]
+                )
+
+                # Phase 3: push all panels to device sequentially
+                for cidx, panel_bytes in sorted(results, key=lambda r: r[0]):
+                    x_pos = cidx * metrics.panel_width
+                    y_pos = 0
+                    async with deck._device_lock:
+                        await deck._exec_device_io(
+                            deck._device.set_touchscreen_image,
+                            panel_bytes,
+                            x_pos,
+                            y_pos,
+                            metrics.panel_width,
+                            metrics.panel_height,
+                        )
 
     # ------------------------------------------------------------------
     # Info-screen rendering

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -445,7 +445,9 @@ class Screen:
         # Touch-strip cards
         if self._touch_strip is not None:
             for index, card in enumerate(self._touch_strip.cards):
-                card_img = card.rendered
+                # Render on demand; fall back to the last cached image
+                # when the card does not support on-demand rendering.
+                card_img = card.render() or card.rendered
                 if card_img is None:
                     continue
                 buf = io.BytesIO()


### PR DESCRIPTION
## Problem

Encoder turns on the Stream Deck+ have become noticeably slower and laggier after recent refactors. The GaugeCard example (with `accumulate: false`) exhibits a visible delay between turning the encoder and seeing the display update.

## Root Cause

Multiple latency sources were identified in the encoder-turn → display-update pipeline:

1. **All cards re-rendered on every turn** — `render_touchscreen()` had no dirty check, so turning one encoder re-rasterised all 4 panels
2. **Double SVG rasterisation** — `DuiCard.render_panel_bytes()` ran the full SVG pipeline twice: once for device bytes, once for a screenshot cache that is rarely used
3. **Gather overhead for single card** — `asyncio.gather` was used even when only one card needed rendering
4. **Event backlog** — sequential event processing meant fast encoder turns queued up behind slow renders
5. **Blanket callback drain** — `refresh()` drained callbacks for all cards, not just those with pending work

## Changes

| Fix | File | Impact |
|-----|------|--------|
| Only render dirty cards | `renderer.py` | Eliminates 3/4 of rasterisation work per turn |
| Remove screenshot pre-cache | `card.py`, `screen.py` | Halves rasterisation per dirty card |
| Single-card fast path | `renderer.py` | Removes gather overhead for the common case |
| Coalesce encoder turns | `deck.py` | Prevents render backlog during fast turning |
| Targeted callback drain | `deck.py` | Skips no-op drains on unaffected cards |

## Testing

All 1690 tests pass, coverage 95.17% (threshold: 95%). Lint (ruff) and typecheck (mypy strict) clean.