### PR TITLE
fix: mark all controls dirty on screen switch

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -423,6 +423,11 @@ class Deck:
         # prior to the first paint, avoiding a flash of defaults.
         await self.on_screen_changed.emit(name, self._screens)
 
+        # Force a full repaint: mark every control on the incoming screen
+        # dirty so the renderer does not skip cards/keys that were already
+        # rendered on a previous visit or shared with another screen.
+        target.mark_all_dirty()
+
         await self._render_all_keys()
         if self._active_screen.touch_strip is not None:
             await self._render_touchscreen()


### PR DESCRIPTION
When switching screens via `set_screen()`, cards shared across screens (e.g. `dashboard.card` on both Main and Settings) were not re-rendered because they were already marked clean from a previous render pass.

**Root cause:** `render_touchscreen()` skips cards where `card.is_dirty` is `False` (renderer.py:349). On a screen switch, cards that had already been rendered on any screen remained clean, so the renderer silently skipped them — leaving stale or blank panels on the touchscreen.

**Fix:** Call `target.mark_all_dirty()` in `set_screen()` before rendering, ensuring every key, card, and info-screen on the incoming screen gets a full repaint.