### PR TITLE
feat: preload iconify icons and batch-render screens

### DIFF
--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -98,7 +98,6 @@ from deux import (
     DuiKey,
     Theme,
     add_dui_path,
-    set_active_theme,
 )
 
 log = logging.getLogger(__name__)
@@ -683,10 +682,7 @@ class DashboardController(CardController):
         """Generate and apply a random theme on encoder hold."""
         if self._deck is None:
             return
-        set_active_theme(Theme.from_random())
-        screen = self._deck.active_screen
-        if screen is not None:
-            screen.mark_all_dirty()
+        await self._deck.set_theme(Theme.from_random())
         log.info("Applied new random theme")
 
     async def _clock_loop(self) -> None:

--- a/src/deux/dui/__init__.py
+++ b/src/deux/dui/__init__.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from .animator import SpinnerAnimator
 from .card import DuiCard
 from .event_map import EventMap
-from .iconify import IconifyError, fetch_icon
+from .iconify import IconifyError, fetch_icon, prefetch_icons
 from .iconify import clear_cache as clear_iconify_cache
 from .key import DuiKey
 from .loader import PackageError, load_all_packages, load_package
@@ -110,6 +110,7 @@ __all__ = [
     "list_dui_packages",
     "load_all_packages",
     "load_package",
+    "prefetch_icons",
     "remove_dui_path",
     "resolve_dui",
 ]

--- a/src/deux/dui/iconify.py
+++ b/src/deux/dui/iconify.py
@@ -14,6 +14,7 @@ a process restart retries previously-failed icons.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -23,6 +24,7 @@ import tempfile
 import threading
 import urllib.error
 import urllib.request
+from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
 
@@ -249,6 +251,42 @@ def fetch_icon(name: str) -> str:
 
     logger.debug("Fetched Iconify icon '%s' (%d bytes)", key, len(body))
     return body
+
+
+async def prefetch_icons(names: Iterable[str]) -> dict[str, str | None]:
+    """Fetch multiple Iconify icons concurrently, warming the cache.
+
+    Each icon is fetched in a separate thread via
+    :func:`asyncio.to_thread`, so network I/O runs in parallel without
+    blocking the event loop.  Icons that are already cached (in memory
+    or on disk) return immediately.
+
+    Parameters
+    ----------
+    names : Iterable[str]
+        Icon identifiers in ``"prefix:icon"`` form (e.g.
+        ``"mdi:play"``).  Duplicates are deduplicated automatically.
+
+    Returns
+    -------
+    dict[str, str | None]
+        Mapping of icon name to SVG string on success, or ``None`` for
+        icons that failed to load (404, network error, malformed name).
+    """
+    unique = dict.fromkeys(names)  # deduplicate, preserve order
+    if not unique:
+        return {}
+
+    async def _fetch_one(name: str) -> tuple[str, str | None]:
+        try:
+            svg = await asyncio.to_thread(fetch_icon, name)
+            return (name, svg)
+        except (IconifyError, Exception):
+            logger.debug("Prefetch failed for icon '%s'", name, exc_info=True)
+            return (name, None)
+
+    results = await asyncio.gather(*[_fetch_one(n) for n in unique])
+    return dict(results)
 
 
 def clear_cache(*, persistent: bool = False) -> None:

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import builtins
 import copy
 import functools
 import io
@@ -627,6 +628,43 @@ class SvgRenderer:
             The rendering context to use, or ``None`` for defaults.
         """
         self._rendering_ctx = ctx
+
+    def collect_icon_names(self) -> builtins.set[str]:
+        """Return all Iconify icon identifiers needed by this renderer.
+
+        Scans bindings for :class:`IconifyBinding` defaults and current
+        values, as well as :class:`ListBinding` items prefixed with
+        ``icon:``.  The result includes both default and currently-bound
+        icon names so that a caller can prefetch everything before the
+        first render.
+
+        Returns
+        -------
+        set[str]
+            A set of ``"prefix:icon"`` strings.
+        """
+        icons: set[str] = set()
+        for name, binding in self._spec.bindings.items():
+            if isinstance(binding, IconifyBinding):
+                # Collect default
+                if binding.default:
+                    icons.add(str(binding.default))
+                # Collect current value
+                val = self._values.get(name)
+                if val and val != binding.default:
+                    icons.add(str(val))
+            elif isinstance(binding, ListBinding):
+                # Collect icon items from defaults
+                for item in binding.default_items:
+                    if isinstance(item, str) and item.startswith("icon:"):
+                        icons.add(item[5:])
+                # Collect icon items from current value
+                val = self._values.get(name)
+                if isinstance(val, dict):
+                    for item in val.get("items", []):
+                        if isinstance(item, str) and item.startswith("icon:"):
+                            icons.add(item[5:])
+        return icons
 
     def set_base_layer(
         self,

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -316,6 +316,44 @@ class Deck:
     def theme(self, value: Theme | None) -> None:
         self._theme = value
 
+    async def set_theme(self, theme: Theme | None) -> None:
+        """Apply a new deck-level theme and re-render the active screen.
+
+        Sets the deck theme, applies the CSS cascade to all renderers,
+        marks every control dirty, and performs a complete re-render
+        (icon prefetch, render all, push all) so the display updates
+        atomically.
+
+        Parameters
+        ----------
+        theme : Theme or None
+            The theme to apply, or ``None`` to revert to the system
+            theme.
+        """
+        self._theme = theme
+        if self._active_screen is None:
+            return
+
+        self._renderer.apply_theme()
+        self._active_screen.mark_all_dirty()
+        await self._renderer.render_screen_complete()
+
+    async def preload_icons(self) -> None:
+        """Prefetch Iconify icons for all registered screens.
+
+        Collects every icon identifier across all screens and fetches
+        them concurrently, warming the in-memory and disk caches.
+        Call this after all screens have been set up (keys and cards
+        installed) to avoid network latency on first render.
+        """
+        from ..dui.iconify import prefetch_icons
+
+        all_icons: set[str] = set()
+        for screen in self._screens.values():
+            all_icons.update(screen.collect_all_icons())
+        if all_icons:
+            await prefetch_icons(all_icons)
+
     def _resolve_stylesheet(self) -> str:
         """Resolve the effective CSS stylesheet for the active screen.
 
@@ -428,11 +466,7 @@ class Deck:
         # rendered on a previous visit or shared with another screen.
         target.mark_all_dirty()
 
-        await self._render_all_keys()
-        if self._active_screen.touch_strip is not None:
-            await self._render_touchscreen()
-        if self._active_screen.info_screen is not None:
-            await self._render_info_screen()
+        await self._renderer.render_screen_complete()
 
     def _wire_refresh_callbacks(self) -> None:
         """Register ``self.refresh`` on every key and card of the active screen.

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -462,6 +462,39 @@ class DeckRenderer:
     # Theme application
     # ------------------------------------------------------------------
 
+    async def render_screen_complete(self) -> None:
+        """Prefetch icons, render all controls, then push to device.
+
+        This is the single entry point for full-screen renders: initial
+        screen load, screen switch, and theme change.  It ensures the
+        complete screen (keys, cards, info screen) is rendered before
+        any images are sent to the device, avoiding partial displays.
+
+        The sequence is:
+
+        1. Prefetch all Iconify icons needed by the active screen.
+        2. Render all keys, cards, and the info screen concurrently.
+        3. Push all rendered images to the device.
+        """
+        deck = self._deck
+        screen = deck._current_screen()
+        if not screen or not deck._device:
+            return
+
+        # 1. Prefetch icons
+        icons = screen.collect_all_icons()
+        if icons:
+            from ..dui.iconify import prefetch_icons
+
+            await prefetch_icons(icons)
+
+        # 2–3. Render and push all controls
+        await self.render_all_keys()
+        if screen.touch_strip is not None:
+            await self.render_touchscreen()
+        if screen.info_screen is not None:
+            await self.render_info_screen()
+
     def apply_theme(self) -> None:
         """Apply the resolved theme cascade to all renderers on the active screen.
 

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -395,6 +395,32 @@ class Screen:
         if self._info_screen is not None:
             self._info_screen.mark_dirty()
 
+    def collect_all_icons(self) -> set[str]:
+        """Collect all Iconify icon identifiers needed by this screen.
+
+        Iterates all DuiKey and DuiCard instances on this screen and
+        aggregates their :meth:`~deux.dui.svg_renderer.SvgRenderer.collect_icon_names`
+        results.
+
+        Returns
+        -------
+        set[str]
+            A set of ``"prefix:icon"`` strings used across all
+            keys and cards on this screen.
+        """
+        from ..dui.card import DuiCard
+        from ..dui.key import DuiKey
+
+        icons: set[str] = set()
+        for key_slot in self._keys.values():
+            if isinstance(key_slot, DuiKey):
+                icons.update(key_slot._renderer.collect_icon_names())
+        if self._touch_strip is not None:
+            for card in self._touch_strip.cards:
+                if isinstance(card, DuiCard):
+                    icons.update(card._renderer.collect_icon_names())
+        return icons
+
     def screenshot(self, directory: str | Path) -> list[Path]:
         """Save the current screen state as individual PNG files.
 

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -178,21 +178,18 @@ class TestDeckSetPage:
 
     async def test_calls_render(self, deck):
         deck.screen("main")
-        deck._render_all_keys = AsyncMock()
-        deck._render_touchscreen = AsyncMock()
+        deck._renderer.render_screen_complete = AsyncMock()
 
         await deck.set_screen("main")
-        deck._render_all_keys.assert_awaited_once()
-        deck._render_touchscreen.assert_awaited_once()
+        deck._renderer.render_screen_complete.assert_awaited_once()
 
     async def test_emits_event_before_render(self, deck):
         """on_screen_changed fires before rendering so bind handlers can seed values."""
         deck.screen("main")
-        deck._render_all_keys = AsyncMock()
-        deck._render_touchscreen = AsyncMock()
+        deck._renderer.render_screen_complete = AsyncMock()
 
         order: list[str] = []
-        deck._render_all_keys.side_effect = lambda: order.append("rendered")
+        deck._renderer.render_screen_complete.side_effect = lambda: order.append("rendered")
 
         @deck.on_screen_changed
         async def _on(name: str, screens: dict) -> None:

--- a/tests/test_preload_batch_render.py
+++ b/tests/test_preload_batch_render.py
@@ -1,0 +1,523 @@
+"""Tests for icon preloading, collect_icon_names, and batch screen rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deux.dui import iconify as iconify_mod
+from deux.dui.iconify import (
+    clear_cache,
+    fetch_icon,
+    prefetch_icons,
+)
+from deux.dui.schema import (
+    IconifyBinding,
+    ListBinding,
+    PackageSpec,
+    PackageType,
+    TextBinding,
+)
+from deux.dui.svg_renderer import SvgRenderer
+from deux.render.metrics import RenderMetrics
+from deux.runtime.capabilities import STREAM_DECK_PLUS
+from deux.runtime.deck import Deck
+from deux.ui.screen import Screen
+
+_SAMPLE_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" '
+    'viewBox="0 0 24 24"><path fill="currentColor" d="M0 0"/></svg>'
+)
+
+_BASIC_SVG = (
+    '<svg id="test" xmlns="http://www.w3.org/2000/svg" width="100" height="50">'
+    '<rect id="bg" width="100" height="50" fill="#000000"/>'
+    '<text id="label" x="10" y="30" font-size="12" fill="#fff">Hi</text>'
+    '<g id="icon_group"></g>'
+    "</svg>"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_iconify_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Reset the iconify cache and redirect disk cache to tmp_path."""
+    clear_cache(persistent=True)
+    fake_dir = tmp_path / "iconify"
+    fake_dir.mkdir()
+
+    def _fake_get_dir() -> Path:
+        fake_dir.mkdir(parents=True, exist_ok=True)
+        return fake_dir
+
+    monkeypatch.setattr(iconify_mod, "_get_disk_cache_dir", _fake_get_dir)
+    monkeypatch.setattr(iconify_mod, "_disk_cache_dir", fake_dir)
+    yield
+    clear_cache(persistent=True)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_ssrf():
+    """Bypass SSRF checks."""
+    with patch("deux.dui.iconify.check_url"):
+        yield
+
+
+def _make_spec(
+    svg: str, bindings: dict | None = None, assets: dict | None = None
+) -> PackageSpec:
+    """Create a minimal PackageSpec for testing."""
+    return PackageSpec(
+        name="Test",
+        type=PackageType.TOUCH_STRIP_CARD,
+        version=1,
+        svg_source=svg,
+        bindings=bindings or {},
+        assets=assets or {},
+    )
+
+
+# -----------------------------------------------------------------------
+# prefetch_icons
+# -----------------------------------------------------------------------
+
+
+class TestPrefetchIcons:
+    """Tests for :func:`deux.dui.iconify.prefetch_icons`."""
+
+    async def test_prefetch_warms_cache(self):
+        """Prefetched icons are served from cache on subsequent fetch_icon calls."""
+        with patch.object(iconify_mod, "_http_get", return_value=_SAMPLE_SVG) as mock:
+            result = await prefetch_icons(["mdi:home", "mdi:settings"])
+
+        assert result["mdi:home"] == _SAMPLE_SVG
+        assert result["mdi:settings"] == _SAMPLE_SVG
+        assert mock.call_count == 2
+
+        # Now fetch_icon should hit cache
+        with patch.object(iconify_mod, "_http_get") as mock2:
+            svg = fetch_icon("mdi:home")
+        mock2.assert_not_called()
+        assert svg == _SAMPLE_SVG
+
+    async def test_prefetch_deduplicates(self):
+        """Duplicate icon names are fetched only once."""
+        with patch.object(iconify_mod, "_http_get", return_value=_SAMPLE_SVG) as mock:
+            result = await prefetch_icons(["mdi:home", "mdi:home", "mdi:home"])
+
+        assert mock.call_count == 1
+        assert len(result) == 1
+
+    async def test_prefetch_empty_iterable(self):
+        """Empty input returns empty dict without errors."""
+        result = await prefetch_icons([])
+        assert result == {}
+
+    async def test_prefetch_handles_failures_gracefully(self):
+        """Failed icons return None without raising."""
+
+        def _side_effect(url: str) -> str:
+            if "missing" in url:
+                return "404"
+            return _SAMPLE_SVG
+
+        with patch.object(iconify_mod, "_http_get", side_effect=_side_effect):
+            result = await prefetch_icons(["mdi:home", "mdi:missing"])
+
+        assert result["mdi:home"] == _SAMPLE_SVG
+        assert result["mdi:missing"] is None
+
+
+# -----------------------------------------------------------------------
+# SvgRenderer.collect_icon_names
+# -----------------------------------------------------------------------
+
+
+class TestCollectIconNames:
+    """Tests for :meth:`SvgRenderer.collect_icon_names`."""
+
+    def test_collects_iconify_defaults(self):
+        """IconifyBinding defaults are collected."""
+        spec = _make_spec(
+            _BASIC_SVG,
+            bindings={
+                "play_icon": IconifyBinding(
+                    node="icon_group", size=24, default="mdi:play"
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        assert renderer.collect_icon_names() == {"mdi:play"}
+
+    def test_collects_current_iconify_value(self):
+        """Changed iconify value is also collected."""
+        spec = _make_spec(
+            _BASIC_SVG,
+            bindings={
+                "play_icon": IconifyBinding(
+                    node="icon_group", size=24, default="mdi:play"
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        renderer.set("play_icon", "mdi:pause")
+        icons = renderer.collect_icon_names()
+        assert "mdi:play" in icons
+        assert "mdi:pause" in icons
+
+    def test_collects_list_icon_items(self):
+        """ListBinding items with 'icon:' prefix are collected."""
+        spec = _make_spec(
+            _BASIC_SVG,
+            bindings={
+                "menu": ListBinding(
+                    node="icon_group",
+                    child_tag="tspan",
+                    default_items=["icon:mdi:home", "Text", "icon:mdi:cog"],
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        icons = renderer.collect_icon_names()
+        assert "mdi:home" in icons
+        assert "mdi:cog" in icons
+        assert len(icons) == 2
+
+    def test_empty_when_no_icon_bindings(self):
+        """Spec with only text bindings returns empty set."""
+        spec = _make_spec(
+            _BASIC_SVG,
+            bindings={
+                "label": TextBinding(node="label", default="Hello"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        assert renderer.collect_icon_names() == set()
+
+    def test_collects_list_icon_from_current_value(self):
+        """ListBinding current value items with 'icon:' prefix are collected."""
+        spec = _make_spec(
+            _BASIC_SVG,
+            bindings={
+                "menu": ListBinding(
+                    node="icon_group",
+                    child_tag="tspan",
+                    default_items=["icon:mdi:home"],
+                ),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        renderer.set("menu", {"items": ["icon:mdi:star", "Text"], "index": 0})
+        icons = renderer.collect_icon_names()
+        assert "mdi:home" in icons
+        assert "mdi:star" in icons
+
+    def test_iconify_empty_default_skipped(self):
+        """IconifyBinding with empty default does not add empty string."""
+        spec = _make_spec(
+            _BASIC_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon_group", size=24, default=""),
+            },
+        )
+        renderer = SvgRenderer(spec)
+        assert renderer.collect_icon_names() == set()
+
+
+# -----------------------------------------------------------------------
+# Screen.collect_all_icons
+# -----------------------------------------------------------------------
+
+
+class TestScreenCollectAllIcons:
+    """Tests for :meth:`Screen.collect_all_icons`."""
+
+    def test_collects_from_dui_keys(self, key_dui_path: Path):
+        """Icons from DuiKey bindings are collected."""
+        from deux.dui.key import DuiKey
+
+        screen = Screen("test", STREAM_DECK_PLUS)
+
+        # Create a DuiKey with iconify bindings by modifying the manifest
+        svg = (
+            '<svg id="TestKey" xmlns="http://www.w3.org/2000/svg" '
+            'width="120" height="120">'
+            '<g id="icon_g"></g></svg>'
+        )
+        spec = PackageSpec(
+            name="IconKey",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=svg,
+            bindings={
+                "icon": IconifyBinding(node="icon_g", size=24, default="mdi:power"),
+            },
+        )
+        key = DuiKey(spec)
+        screen.set_key(0, key)
+
+        icons = screen.collect_all_icons()
+        assert "mdi:power" in icons
+
+    def test_collects_from_dui_cards(self):
+        """Icons from DuiCard bindings are collected."""
+        from deux.dui.card import DuiCard
+
+        screen = Screen("test", STREAM_DECK_PLUS)
+
+        svg = (
+            '<svg id="TestCard" xmlns="http://www.w3.org/2000/svg" '
+            'width="197" height="98">'
+            '<g id="icon_g"></g></svg>'
+        )
+        spec = PackageSpec(
+            name="IconCard",
+            type=PackageType.TOUCH_STRIP_CARD,
+            version=1,
+            svg_source=svg,
+            bindings={
+                "icon": IconifyBinding(node="icon_g", size=24, default="mdi:music"),
+            },
+        )
+        card = DuiCard(spec)
+        screen.set_card(0, card)
+
+        icons = screen.collect_all_icons()
+        assert "mdi:music" in icons
+
+    def test_empty_for_plain_keys(self):
+        """Screen with only plain KeySlots returns empty set."""
+        screen = Screen("test", STREAM_DECK_PLUS)
+        screen.key(0)
+        assert screen.collect_all_icons() == set()
+
+
+# -----------------------------------------------------------------------
+# DeckRenderer.render_screen_complete
+# -----------------------------------------------------------------------
+
+
+class TestRenderScreenComplete:
+    """Tests for :meth:`DeckRenderer.render_screen_complete`."""
+
+    def _make_deck_with_screen(self) -> Deck:
+        """Create a Deck with a mock device and active screen."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+        deck._device = MagicMock()
+        deck._device.set_key_image.return_value = None
+        deck._device.set_touchscreen_image.return_value = None
+        return deck
+
+    async def test_render_screen_complete_calls_prefetch(self):
+        """render_screen_complete prefetches icons before rendering."""
+        deck = self._make_deck_with_screen()
+        screen = deck.screen("main")
+        deck._active_screen = screen
+
+        with patch(
+            "deux.runtime.renderer.DeckRenderer.render_all_keys",
+            new_callable=AsyncMock,
+        ) as mock_keys, patch(
+            "deux.runtime.renderer.DeckRenderer.render_touchscreen",
+            new_callable=AsyncMock,
+        ), patch(
+            "deux.dui.iconify.prefetch_icons",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as mock_prefetch:
+            # Add a DuiKey with an icon to the screen
+            svg = (
+                '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">'
+                '<g id="icon_g"></g></svg>'
+            )
+            from deux.dui.key import DuiKey
+
+            spec = PackageSpec(
+                name="IK",
+                type=PackageType.KEY,
+                version=1,
+                svg_source=svg,
+                bindings={
+                    "icon": IconifyBinding(
+                        node="icon_g", size=24, default="mdi:play"
+                    ),
+                },
+            )
+            screen.set_key(0, DuiKey(spec))
+
+            await deck._renderer.render_screen_complete()
+
+            mock_prefetch.assert_awaited_once_with({"mdi:play"})
+            mock_keys.assert_awaited_once()
+
+    async def test_render_screen_complete_skips_when_no_screen(self):
+        """render_screen_complete is a no-op when no screen is active."""
+        deck = self._make_deck_with_screen()
+        # No active screen
+        await deck._renderer.render_screen_complete()
+        # Should not raise
+
+
+# -----------------------------------------------------------------------
+# Deck.set_screen uses render_screen_complete
+# -----------------------------------------------------------------------
+
+
+class TestDeckSetScreenIntegration:
+    """Tests for Deck.set_screen using render_screen_complete."""
+
+    async def test_set_screen_calls_render_screen_complete(self):
+        """set_screen delegates to render_screen_complete."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+        deck._device = MagicMock()
+        deck._device.set_key_image.return_value = None
+        deck._device.set_touchscreen_image.return_value = None
+        deck.screen("main")
+
+        with patch.object(
+            deck._renderer,
+            "render_screen_complete",
+            new_callable=AsyncMock,
+        ) as mock_complete:
+            await deck.set_screen("main")
+            mock_complete.assert_awaited_once()
+
+
+# -----------------------------------------------------------------------
+# Deck.set_theme
+# -----------------------------------------------------------------------
+
+
+class TestDeckSetTheme:
+    """Tests for :meth:`Deck.set_theme`."""
+
+    async def test_set_theme_triggers_full_render(self):
+        """set_theme applies theme and re-renders the entire screen."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+        deck._device = MagicMock()
+        deck._device.set_key_image.return_value = None
+        deck._device.set_touchscreen_image.return_value = None
+
+        deck.screen("main")
+        deck._active_screen = deck._screens["main"]
+
+        with patch.object(
+            deck._renderer,
+            "render_screen_complete",
+            new_callable=AsyncMock,
+        ) as mock_complete, patch.object(
+            deck._renderer, "apply_theme"
+        ) as mock_apply:
+            from deux.render.theme import Theme
+
+            theme = Theme(primary=(0, 0, 0))
+            await deck.set_theme(theme)
+
+            mock_apply.assert_called_once()
+            mock_complete.assert_awaited_once()
+            assert deck._theme is theme
+
+    async def test_set_theme_noop_when_no_screen(self):
+        """set_theme without an active screen only sets the property."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+
+        from deux.render.theme import Theme
+
+        theme = Theme(primary=(0, 0, 0))
+        await deck.set_theme(theme)
+
+        assert deck._theme is theme
+
+    async def test_set_theme_none_clears(self):
+        """Setting theme to None clears the deck theme."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+
+        from deux.render.theme import Theme
+
+        deck._theme = Theme(primary=(0, 0, 0))
+        await deck.set_theme(None)
+        assert deck._theme is None
+
+
+# -----------------------------------------------------------------------
+# Deck.preload_icons
+# -----------------------------------------------------------------------
+
+
+class TestDeckPreloadIcons:
+    """Tests for :meth:`Deck.preload_icons`."""
+
+    async def test_preload_icons_collects_all_screens(self):
+        """preload_icons aggregates icons from all registered screens."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+
+        from deux.dui.key import DuiKey
+
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">'
+            '<g id="icon_g"></g></svg>'
+        )
+
+        # Screen 1 with one icon
+        s1 = deck.screen("main")
+        spec1 = PackageSpec(
+            name="K1",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=svg,
+            bindings={
+                "icon": IconifyBinding(node="icon_g", size=24, default="mdi:home"),
+            },
+        )
+        s1.set_key(0, DuiKey(spec1))
+
+        # Screen 2 with a different icon
+        s2 = deck.screen("settings")
+        spec2 = PackageSpec(
+            name="K2",
+            type=PackageType.KEY,
+            version=1,
+            svg_source=svg,
+            bindings={
+                "icon": IconifyBinding(node="icon_g", size=24, default="mdi:cog"),
+            },
+        )
+        s2.set_key(0, DuiKey(spec2))
+
+        with patch(
+            "deux.dui.iconify.prefetch_icons",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as mock_prefetch:
+            await deck.preload_icons()
+
+            called_icons = mock_prefetch.call_args[0][0]
+            assert "mdi:home" in called_icons
+            assert "mdi:cog" in called_icons
+
+    async def test_preload_icons_noop_when_no_icons(self):
+        """preload_icons does not call prefetch when no icons exist."""
+        deck = Deck(serial_number="TEST123")
+        deck._caps = STREAM_DECK_PLUS
+        deck._metrics = RenderMetrics(STREAM_DECK_PLUS)
+        deck.screen("empty")
+
+        with patch(
+            "deux.dui.iconify.prefetch_icons",
+            new_callable=AsyncMock,
+        ) as mock_prefetch:
+            await deck.preload_icons()
+            mock_prefetch.assert_not_awaited()


### PR DESCRIPTION
## Summary

Preload all Iconify icons for all screens and render the complete screen (keys, cards, info screen) before sending to the display. This eliminates partial screen displays during initial load, screen switching, and theme changes.

## Changes

### Icon Preloading
- **`prefetch_icons()`** in `iconify.py`: async batch fetcher that fetches multiple icons concurrently via `asyncio.to_thread`, warming both in-memory and disk caches before render
- **`SvgRenderer.collect_icon_names()`**: scans all bindings for IconifyBinding defaults/values and ListBinding `icon:` items
- **`Screen.collect_all_icons()`**: aggregates icon names across all DuiKeys and DuiCards on a screen
- **`Deck.preload_icons()`**: prefetches icons for all registered screens in one batch

### Batch Screen Rendering
- **`DeckRenderer.render_screen_complete()`**: single entry point that prefetches icons → renders all controls concurrently → pushes all to device. Used by:
  - `Deck.set_screen()` — initial load and screen switching
  - `Deck.set_theme()` — theme changes

### New API
- **`Deck.set_theme(theme)`**: async method that applies a theme and re-renders the entire active screen atomically

## Tests
- 21 new tests covering prefetch_icons, collect_icon_names, collect_all_icons, render_screen_complete, set_screen integration, set_theme, and preload_icons
- All 1671 tests pass, coverage at 95.84%