### PR TITLE
chore: remove all Cairo/CairoSVG references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -40,7 +40,6 @@ body:
         macOS 15.4
         Stream Deck+
         hidapi 0.14
-        cairo 1.18
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,7 +35,7 @@ on:
         description: Apt packages required before tests.
         required: false
         type: string
-        default: "libcairo2-dev libhidapi-dev libvips-dev"
+        default: "libhidapi-dev libvips-dev"
 
 jobs:
   pytest:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Avoid feature sprawl that ties implementations to specific hardware quirks. Inst
 uv sync --extra test        # uses uv.lock; Python 3.11+ required
 ```
 
-System deps (CI uses `libcairo2-dev libhidapi-dev`; on macOS: `brew install cairo hidapi`).
+System deps (CI uses `libhidapi-dev`; on macOS: `brew install hidapi`).
 
 ## Mandatory workflow — read this FIRST
 
@@ -125,5 +125,5 @@ CI runs: lint, build, typecheck, tests (3.11/3.12/3.13), gitleaks. All must pass
 
 - Ruff: line length 100, target py311, rules: E/W/F/I/B/UP/C4/SIM (B008 ignored)
 - `tests/*` ignores B011
-- mypy strict with `ignore_missing_imports` for `StreamDeck.*` and `cairosvg`
+- mypy strict with `ignore_missing_imports` for `StreamDeck.*`
 - Wheel packages from `src/deux` (src layout)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ uv sync --extra test     # primary install — uses pinned uv.lock; Python 3.11+
 ```
 
 System libraries (required for HID + SVG rasterisation):
-- macOS: `brew install cairo hidapi`
-- Linux (Debian/Ubuntu): `sudo apt install libcairo2-dev libhidapi-dev`
+- macOS: `brew install hidapi`
+- Linux (Debian/Ubuntu): `sudo apt install libhidapi-dev`
 
 ## Quality gate (must pass before commit)
 
@@ -38,7 +38,7 @@ python examples/streamdeck.py
 - **Never commit directly to `main`.** Branch with prefix matching the change type: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`. Push and open a PR via `gh pr create`.
 - **NumPy-style docstrings** are mandatory on all public modules, classes, methods, functions (and non-obvious private helpers / complex test fixtures). Sections: Parameters, Returns, Raises (when relevant), Side effects (when relevant). The mkdocstrings docs build relies on this format — see `mkdocs.yml`.
 - Ruff config: line length 100, target py311, rules E/W/F/I/B/UP/C4/SIM with B008 ignored. `tests/*` ignores B011.
-- mypy is strict; `StreamDeck.*` and `cairosvg` are the only allowed `ignore_missing_imports` overrides.
+- mypy is strict; `StreamDeck.*` is the only allowed `ignore_missing_imports` override.
 
 ## Architecture
 
@@ -47,7 +47,7 @@ Single package `src/deux` (src layout, Hatchling build). Five subpackages with s
 - **`runtime/`** — device session: `DeckManager` is the **only public entry point**. It owns discovery (`discovery.py`), hot-plug polling, auto-reconnect, and creates `Deck` instances. `Deck` wraps one device, holds `DeviceCapabilities` (auto-detected from hardware), and uses `AsyncTransport` to bridge the synchronous `StreamDeck` library callbacks onto the asyncio loop. Events flow as typed `DeckEvent` subclasses (`KeyEvent`, `EncoderPressEvent`, `EncoderTurnEvent`, `TouchEvent`).
 - **`ui/`** — declarative layout primitives attached to a `Deck`: `Screen` is a named layout containing `KeySlot`s, `EncoderSlot`s, an optional `TouchStrip` of `Card`s, and an optional `InfoScreen`. Screens swap atomically via `deck.set_screen(name)`. Slots expose decorator-based handlers (`@key.on_press`, `@encoder.on_turn`, etc.). Available slots/zones are gated by `DeviceCapabilities` — accessing absent hardware raises `DeckError`.
 - **`dui/`** — the `.dui` package format: a directory containing `layout.svg` + `manifest.yaml`. `loader.load_package()` parses + validates into a `PackageSpec` (`schema.py`); `DuiCard` / `DuiKey` (`card.py`, `key.py`) wrap a spec to render via `SvgRenderer` and dispatch declared events through `EventMap`. Bindings are typed (text, image, visibility, color, range, slider, toggle, iconify) and drive SVG node attributes at render time. `animator.py` + `spinner.py` handle async spinner refresh; `iconify.py` fetches Iconify icons.
-- **`render/`** — pure-image layer: `key_renderer`, `screen_renderer`, `touch_renderer`, `svg_rasterize` (CairoSVG-backed), `image_fetch` (caching HTTP loader), and `metrics.py` which derives panel/touch-strip geometry from capabilities.
+- **`render/`** — pure-image layer: `key_renderer`, `screen_renderer`, `touch_renderer`, `svg_rasterize`, `image_fetch` (caching HTTP loader), and `metrics.py` which derives panel/touch-strip geometry from capabilities.
 - **`tools/`** — CLIs invoked as `python -m deux.tools.preview` and `python -m deux.tools.verify` (preview SVGs on a connected deck with optional `--watch`; verify a `.dui` package or a directory of packages with optional `--strict` / `--index`).
 
 Public surface is whatever `deux/__init__.py` re-exports — keep `__all__` accurate when you add or rename symbols.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ you need to get started.
 - **Python 3.11+**
 - **[uv](https://docs.astral.sh/uv/)** for dependency management
 - **System libraries:**
-  - macOS: `brew install vips cairo hidapi`
-  - Linux (Debian/Ubuntu): `sudo apt install libvips-dev libcairo2-dev libhidapi-dev`
+  - macOS: `brew install vips hidapi`
+  - Linux (Debian/Ubuntu): `sudo apt install libvips-dev libhidapi-dev`
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ A high-level, asyncio-native Python library for Elgato Stream Deck devices. Defi
 - Python 3.11+
 - [HIDAPI](https://github.com/libusb/hidapi) (For USB HID communication)
 - [libvips](https://github.com/libvips/libvips) (For SVG rendering)
-- [Cairo](https://www.cairographics.org/) (For 2D graphics rendering)
 
 ## Quick Start (macOS)
 
 Install system dependencies, clone the repo, and run the example:
 
 ```bash
-brew install hidapi vips cairo
+brew install hidapi vips
 
 git clone https://github.com/graphras-com/DeUX.git
 cd DeUX
@@ -52,7 +51,7 @@ python examples/streamdeck.py
 Install system dependencies, clone the repo, and run the example:
 
 ```bash
-apt-get install libhidapi-dev libvips-dev libcairo2-dev
+apt-get install libhidapi-dev libvips-dev
 
 git clone https://github.com/graphras-com/DeUX.git
 cd DeUX


### PR DESCRIPTION
Cairo has been removed from the library. This cleans up all remaining references across:

- **README.md** — removed Cairo from system requirements and install commands
- **CONTRIBUTING.md** — removed Cairo from prerequisites
- **CLAUDE.md** — removed Cairo from setup instructions, mypy notes, and render description
- **AGENTS.md** — removed Cairo from system deps and mypy notes
- **.github/workflows/python-tests.yml** — removed `libcairo2-dev` from CI system packages
- **.github/ISSUE_TEMPLATE/bug.yml** — removed Cairo from environment placeholder

All 1791 tests pass with 95.51% coverage.