### PR TITLE
chore: remove all pyvips/libvips references

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,7 +35,7 @@ on:
         description: Apt packages required before tests.
         required: false
         type: string
-        default: "libhidapi-dev libvips-dev"
+        default: "libhidapi-dev"
 
 jobs:
   pytest:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ you need to get started.
 - **Python 3.11+**
 - **[uv](https://docs.astral.sh/uv/)** for dependency management
 - **System libraries:**
-  - macOS: `brew install vips hidapi`
-  - Linux (Debian/Ubuntu): `sudo apt install libvips-dev libhidapi-dev`
+  - macOS: `brew install hidapi`
+  - Linux (Debian/Ubuntu): `sudo apt install libhidapi-dev`
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@ A high-level, asyncio-native Python library for Elgato Stream Deck devices. Defi
 
 - Python 3.11+
 - [HIDAPI](https://github.com/libusb/hidapi) (For USB HID communication)
-- [libvips](https://github.com/libvips/libvips) (For SVG rendering)
 
 ## Quick Start (macOS)
 
 Install system dependencies, clone the repo, and run the example:
 
 ```bash
-brew install hidapi vips
+brew install hidapi
 
 git clone https://github.com/graphras-com/DeUX.git
 cd DeUX
@@ -51,7 +50,7 @@ python examples/streamdeck.py
 Install system dependencies, clone the repo, and run the example:
 
 ```bash
-apt-get install libhidapi-dev libvips-dev
+apt-get install libhidapi-dev
 
 git clone https://github.com/graphras-com/DeUX.git
 cd DeUX


### PR DESCRIPTION
pyvips/libvips is no longer used. This PR removes all remaining references from:

- README.md (system requirements, install commands)
- CONTRIBUTING.md (system library install commands)
- .github/workflows/python-tests.yml (default apt packages)