### PR TITLE
fix: limit encoder data parsing to payload_len bytes

### DIFF
--- a/src/deux/runtime/hid/protocol.py
+++ b/src/deux/runtime/hid/protocol.py
@@ -334,7 +334,7 @@ def parse_input_report(data: bytes) -> InputEvent | None:
         if len(payload) < 2:
             return None
         content_type = payload[0]
-        encoder_data = payload[1:]
+        encoder_data = payload[1:payload_len]
         if content_type == EncoderEventType.BUTTON:
             states = tuple(b != 0 for b in encoder_data)
             return EncoderButtonEvent(states=states)

--- a/tests/test_hid_protocol.py
+++ b/tests/test_hid_protocol.py
@@ -177,6 +177,32 @@ class TestParseInputReportEncoder:
         data = _build_input(InputCommand.ENCODER, b"\x00")
         assert parse_input_report(data) is None
 
+    def test_button_event_ignores_trailing_padding(self) -> None:
+        """EncoderButtonEvent only uses payload_len bytes, ignoring HID padding."""
+        encoder_payload = bytes([EncoderEventType.BUTTON, 0x01, 0x00, 0x00, 0x01])
+        padding = b"\x00" * 50
+        data = _build_input(
+            InputCommand.ENCODER,
+            encoder_payload + padding,
+            payload_len=len(encoder_payload),
+        )
+        evt = parse_input_report(data)
+        assert isinstance(evt, EncoderButtonEvent)
+        assert evt.states == (True, False, False, True)
+
+    def test_rotate_event_ignores_trailing_padding(self) -> None:
+        """EncoderRotateEvent only uses payload_len bytes, ignoring HID padding."""
+        encoder_payload = bytes([EncoderEventType.ROTATE]) + struct.pack("bb", 1, -1)
+        padding = b"\x00" * 50
+        data = _build_input(
+            InputCommand.ENCODER,
+            encoder_payload + padding,
+            payload_len=len(encoder_payload),
+        )
+        evt = parse_input_report(data)
+        assert isinstance(evt, EncoderRotateEvent)
+        assert evt.ticks == (1, -1)
+
     def test_unknown_encoder_type_returns_none(self) -> None:
         """Unknown encoder content_type returns None."""
         payload = bytes([0xFF, 0x00, 0x00])


### PR DESCRIPTION
## Problem

Pressing any encoder on a real Stream Deck+ produced a flood of `IndexError: Card index must be 0-3, got 443` errors with monotonically increasing indices.

## Root Cause

`parse_input_report` in `protocol.py` sliced encoder data as `payload[1:]`, which included all trailing HID report padding bytes (up to ~500 bytes of zeros). This caused `EncoderButtonEvent.states` to contain hundreds of entries instead of the expected 4, and the transport layer then emitted `EncoderPressEvent` with encoder indices far exceeding the valid 0-3 range.

`KeyStateEvent` parsing already correctly used `payload[:payload_len]` to limit the data.

## Fix

Changed `encoder_data = payload[1:]` to `encoder_data = payload[1:payload_len]`, limiting both button and rotate encoder data to the declared payload length.

## Tests

Added two regression tests that verify encoder button and rotate events ignore trailing padding bytes.