### PR TITLE
chore: add reusable code quality and documentation review prompts

### DIFF
--- a/prompts/code-quality-review.md
+++ b/prompts/code-quality-review.md
@@ -1,0 +1,251 @@
+# Code Quality Review Prompt — DeUX
+
+> **Usage:** Run this prompt against the full `src/deux/` and `tests/` directories.
+> Repeat regularly (e.g., after each milestone or major feature merge).
+
+---
+
+## Role
+
+You are a senior Python code reviewer. Your job is to identify code quality issues
+in the DeUX codebase and produce actionable GitHub issues for each finding.
+
+## Codebase Context
+
+DeUX is an asyncio-native Python library for Elgato Stream Deck devices. It uses:
+
+- An SVG-first rendering pipeline (DOM manipulation → resvg rasterisation)
+- A declarative UI model (`.dui` packages: YAML manifest + SVG layout)
+- ctypes bindings to libhidapi for HID transport
+- `defusedxml` for XML safety, SSRF-guarded URL fetching
+- Async architecture: `DeckManager` → `Deck` → `AsyncTransport`
+- CSS theme system generated from a single primary colour via HSL math
+- Dirty-flag rendering with encoder turn coalescing
+- src layout built with Hatchling, Python 3.11+
+
+## Review Scope — What to Review
+
+Focus **exclusively** on code quality:
+
+- **Naming clarity** — variables, functions, classes, modules
+- **Type hint completeness and correctness** — missing annotations, incorrect types
+- **Error handling** — bare excepts, swallowed errors, missing validation, unclear error messages
+- **Docstrings** — completeness, accuracy, NumPy-style format (required per project convention)
+- **DRY violations** — code duplication across modules
+- **Complexity** — long methods, deep nesting, too many parameters, god classes
+- **Test quality** — missing edge cases, brittle assertions, poor test isolation, unclear test names
+- **Dead code** — unused imports, unreachable branches, vestigial functions
+- **API surface** — overly broad exports, leaky abstractions, inconsistent interfaces
+- **Pattern consistency** — inconsistent logging, mixed sync/async styles, naming conventions
+- **Security hygiene** — beyond existing measures (input validation gaps, timing attacks, etc.)
+- **Performance** — unnecessary allocations, repeated work, missing caching opportunities
+
+## Review Scope — What NOT to Review
+
+Do **not** suggest changes to these settled architectural decisions:
+
+1. SVG-first rendering pipeline (SVG DOM manipulation → resvg rasterisation)
+2. Use of `resvg-py` (custom fork) instead of CairoSVG or other rasterisers
+3. ctypes bindings to libhidapi (not the Python `hid` package)
+4. The `.dui` package format (YAML manifest + SVG layout + assets)
+5. `defusedxml` for XML safety
+6. The async architecture (`DeckManager` → `Deck` → `AsyncTransport` pattern)
+7. HID I/O via shared `ThreadPoolExecutor` + `run_in_executor`
+8. The binding dispatch table pattern in `SvgRenderer`
+9. The CSS theme system (HSL colour math from primary colour)
+10. Dirty-flag rendering approach
+11. Encoder turn coalescing
+12. src layout with Hatchling build system
+13. Existing CI pipeline structure
+
+If one of these areas has a code quality issue (e.g., a missing type hint in the executor
+code), flag the **quality** issue without suggesting an architectural alternative.
+
+## Output Format
+
+### Per-Issue Fields
+
+For each finding, produce:
+
+| Field | Description |
+|-------|-------------|
+| **Number** | Sequential (`#1`, `#2`, `#3`, ...) for dependency references |
+| **Title** | Concise, actionable (e.g., "Add missing type hints to `svg_rasterize.py` public API") |
+| **Type** | One of: `Task`, `Bug`, `Feature` |
+| **Labels** | Combine from: **Area:** `area:code-quality`, `area:testing`, `area:typing`, `area:docs`, `area:performance`, `area:security`, `area:api`, `area:async`, `area:reliability`, `area:packaging` / **Severity:** `severity:high`, `severity:med`, `severity:low`, `severity:nit` / **Type:** `type:refactor`, `type:bug`, `type:security` / **Other:** `enhancement`, `bug`, `documentation` |
+| **Priority** | `P0` (critical), `P1` (high), `P2` (medium), `P3` (low) |
+| **Size** | Estimated effort: `XS`, `S`, `M`, `L`, `XL` |
+| **Body** | Markdown with three sections (see template below) |
+| **Depends on** | List of issue numbers (`#N`) this is blocked by. Empty if none. |
+| **Blocks** | List of issue numbers that depend on this. Empty if none. |
+
+### Issue Body Template
+
+```markdown
+## Problem
+
+[What's wrong and where. Include file paths and line numbers.]
+
+## Suggested Fix
+
+[Concrete, specific guidance on what to change.]
+
+## Rationale
+
+[Why this matters: maintainability, correctness, safety, etc.]
+```
+
+### Ordering
+
+Order issues by recommended implementation sequence:
+
+1. Foundation fixes first (things other issues depend on)
+2. Then by priority (P0 → P3)
+3. Within same priority, smaller sizes first
+
+### Post-Issue Deliverables
+
+After the issue list, provide:
+
+1. A **dependency graph** in Mermaid format showing blocked-by relationships
+2. A **summary table** with columns: `#`, Title, Type, Priority, Size, Labels, Blocked By
+
+---
+
+## Execution Script
+
+After the review, generate a **complete, copy-pasteable bash script** that creates all
+issues on GitHub, adds them to the project, sets all fields, and wires up dependencies.
+
+Use the following constants, IDs, and patterns.
+
+### Constants
+
+```bash
+OWNER="graphras-com"
+REPO="DeUX"
+REPO_ID="R_kgDOR3asLg"
+PROJECT_NUMBER=2
+PROJECT_ID="PVT_kwDOECHs484BWOyq"
+
+# Issue Type IDs
+TYPE_TASK="IT_kwDOECHs484B6of5"
+TYPE_BUG="IT_kwDOECHs484B6of6"
+TYPE_FEATURE="IT_kwDOECHs484B6of7"
+
+# Project Field IDs
+PRIORITY_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf4"
+SIZE_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf8"
+STATUS_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwYw"
+
+# Priority Option IDs
+PRIORITY_P0="79628723"
+PRIORITY_P1="0a877460"
+PRIORITY_P2="da944a9c"
+PRIORITY_P3="e2ede371"
+
+# Size Option IDs
+SIZE_XS="6c6483d2"
+SIZE_S="f784b110"
+SIZE_M="7515a9f1"
+SIZE_L="817d0097"
+SIZE_XL="db339eb2"
+
+# Status Option IDs
+STATUS_BACKLOG="f75ad846"
+```
+
+### Per-Issue Pattern
+
+For each issue, the script must:
+
+```bash
+# 1. Create the issue
+ISSUE_N_URL=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "TITLE" \
+  --label "label1" \
+  --label "label2" \
+  --body "BODY_MARKDOWN" \
+  --project "DeUX Development")
+
+# 2. Extract issue number and node ID
+ISSUE_N_NUM=$(echo "$ISSUE_N_URL" | grep -oE '[0-9]+$')
+ISSUE_N_ID=$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      issue(number:$number) { id }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO" -F number="$ISSUE_N_NUM" \
+  --jq '.data.repository.issue.id')
+
+# 3. Set issue type
+gh api graphql -f query='
+  mutation($id:ID!, $typeId:ID!) {
+    updateIssue(input:{id:$id, issueTypeId:$typeId}) {
+      issue { id }
+    }
+  }' -f id="$ISSUE_N_ID" -f typeId="$TYPE_TASK"
+
+# 4. Add to project and get item ID
+ITEM_N_ID=$(gh project item-add $PROJECT_NUMBER \
+  --owner "$OWNER" \
+  --url "$ISSUE_N_URL" \
+  --format json | jq -r '.id')
+
+# 5. Set Priority
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$PRIORITY_FIELD_ID" \
+  --single-select-option-id "$PRIORITY_P2"
+
+# 6. Set Size
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$SIZE_FIELD_ID" \
+  --single-select-option-id "$SIZE_M"
+
+# 7. Set Status to Backlog
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$STATUS_BACKLOG"
+```
+
+### Dependency Wiring Pattern
+
+After all issues are created, wire up dependencies using sub-issues.
+The **parent** is the issue that must be done first (the blocker).
+The **sub-issue** is the issue that depends on it.
+
+```bash
+# Make ISSUE_2 depend on ISSUE_1:
+# ISSUE_1 is the parent (blocker), ISSUE_2 is the sub-issue (blocked)
+gh api graphql -f query='
+  mutation($parentId:ID!, $subIssueId:ID!) {
+    addSubIssue(input:{issueId:$parentId, subIssueId:$subIssueId}) {
+      issue { id }
+    }
+  }' -f parentId="$ISSUE_1_ID" -f subIssueId="$ISSUE_2_ID"
+```
+
+### Script Structure
+
+The generated script must follow this order:
+
+1. Set all constants (repo ID, type IDs, field IDs, option IDs)
+2. Create all issues in dependency order (foundations first), storing each URL, number, and node ID in named variables (`ISSUE_1_URL`, `ISSUE_1_NUM`, `ISSUE_1_ID`, `ITEM_1_ID`, etc.)
+3. Set issue type for each issue
+4. Add each issue to the project and set Priority, Size, Status=Backlog
+5. Wire up all dependency relationships via `addSubIssue`
+
+### Prerequisites
+
+The script requires these token scopes:
+
+```bash
+gh auth refresh -s project -s read:project
+```

--- a/prompts/dependency-health-review.md
+++ b/prompts/dependency-health-review.md
@@ -1,0 +1,306 @@
+# Dependency Health Review Prompt — DeUX
+
+> **Usage:** Run this prompt against `pyproject.toml`, `uv.lock`, and the output of
+> the commands below. Repeat regularly (e.g., monthly, or before each release).
+>
+> Before running, gather dependency data:
+> ```bash
+> # List installed packages with versions
+> uv pip list --format json > /tmp/deps-installed.json
+>
+> # Check for known vulnerabilities (install pip-audit if needed: uv pip install pip-audit)
+> pip-audit --format json --output /tmp/deps-audit.json 2>&1 || true
+>
+> # Show outdated packages
+> uv pip list --outdated --format json > /tmp/deps-outdated.json 2>&1 || true
+> ```
+> Provide these files as context alongside `pyproject.toml` and `uv.lock`.
+
+---
+
+## Role
+
+You are a senior software supply chain analyst. Your job is to assess the health,
+security, and maintenance status of all dependencies in the DeUX project and produce
+actionable GitHub issues for each finding.
+
+## Codebase Context
+
+DeUX is an asyncio-native Python library for Elgato Stream Deck devices.
+
+### Direct Dependencies (runtime)
+
+| Package | Constraint | Purpose |
+|---------|-----------|---------|
+| `pillow` | >=12.0.0 | Image manipulation, font measurement |
+| `pyyaml` | >=6.0 | YAML manifest parsing |
+| `platformdirs` | >=4.0 | OS-appropriate config/data directories |
+| `defusedxml` | >=0.7.0 | Safe XML parsing against XXE/entity attacks |
+| `resvg` | git+graphras-com/resvg-py@main | Rust-based SVG rasterisation (custom fork) |
+
+### Direct Dependencies (test)
+
+`pytest`, `pytest-asyncio`, `pytest-cov`, `types-PyYAML`
+
+### Direct Dependencies (docs)
+
+`mkdocs-material`, `mkdocstrings[python]`, `mkdocs-gen-files`, `mkdocs-literate-nav`, `pylint`
+
+### Notable Characteristics
+
+- `resvg-py` is installed via a **git URL** pointing to `@main` branch (not a pinned commit)
+- Lock file is `uv.lock` (managed by `uv`)
+- Python 3.11+ required
+
+## Review Scope — What to Review
+
+### 1. Known Vulnerabilities (CVEs)
+
+- Check all direct and transitive dependencies for **known CVEs** using pip-audit output
+- For each CVE: severity, affected version range, fixed version, exploitability in the
+  context of DeUX's usage
+- Flag any dependency where the pinned/locked version is within a vulnerable range
+
+### 2. Outdated Dependencies
+
+- Identify dependencies that are **significantly behind** the latest release
+- Distinguish between: patch updates (safe), minor updates (usually safe), and major
+  updates (may require migration)
+- Prioritise updates that include security fixes or bug fixes relevant to DeUX's usage
+- Note any dependencies pinned to minimum versions that are very old
+
+### 3. Maintenance Status
+
+- Check if any dependency is **unmaintained** (no releases in 12+ months, archived repo,
+  no response to issues)
+- Check for dependencies with **known succession** (e.g., a package replaced by a
+  maintained fork)
+- Flag dependencies with very few maintainers (bus factor = 1)
+
+### 4. Supply Chain Risks
+
+- **`resvg-py` git reference** — Is `@main` a stable reference? Should it be pinned to
+  a commit hash or tag for reproducibility? What happens if the fork diverges?
+- **Transitive dependency count** — Are there unexpectedly large dependency trees pulled
+  in by any direct dependency?
+- **Package integrity** — Are all packages sourced from PyPI (except resvg-py)? Any
+  unexpected sources in the lock file?
+
+### 5. License Compatibility
+
+- Verify all dependency licenses are **compatible** with the project's license
+- Flag any dependency with a viral/copyleft license (GPL, AGPL) that could affect
+  distribution
+- Flag any dependency with no declared license or an ambiguous one
+
+### 6. Version Constraint Hygiene
+
+- Are version constraints in `pyproject.toml` **appropriate**? Too loose (accepting
+  known-bad versions)? Too tight (preventing security updates)?
+- Are there dependencies that should have **upper bounds** to prevent breaking changes?
+- Are test/docs dependencies appropriately constrained?
+
+## Review Scope — What NOT to Review
+
+- Do **not** suggest replacing `resvg-py` with CairoSVG or another rasteriser
+- Do **not** suggest replacing `defusedxml` with another XML library
+- Do **not** suggest replacing the `uv` package manager
+- Do **not** suggest adding runtime dependencies that change the architecture
+- Flag supply chain risks and suggest mitigations within the current dependency choices
+
+## Output Format
+
+### Per-Issue Fields
+
+For each finding, produce:
+
+| Field | Description |
+|-------|-------------|
+| **Number** | Sequential (`#1`, `#2`, `#3`, ...) for dependency references |
+| **Title** | Concise, actionable (e.g., "Pin `resvg-py` to commit hash instead of `@main` branch") |
+| **Type** | One of: `Task`, `Bug`, `Feature` |
+| **Labels** | Combine from: **Area:** `area:security`, `area:packaging`, `area:reliability` / **Severity:** `severity:high`, `severity:med`, `severity:low`, `severity:nit` / **Type:** `type:security`, `type:refactor` / **Other:** `dependencies`, `bug`, `enhancement` |
+| **Priority** | `P0` (critical — active CVE in used code path), `P1` (high — CVE or significant risk), `P2` (medium — outdated, maintenance concern), `P3` (low — hygiene, best practice) |
+| **Size** | Estimated effort: `XS`, `S`, `M`, `L`, `XL` |
+| **Body** | Markdown with sections below |
+| **Depends on** | List of issue numbers (`#N`) this is blocked by. Empty if none. |
+| **Blocks** | List of issue numbers that depend on this. Empty if none. |
+
+### Issue Body Template
+
+```markdown
+## Finding
+
+[What the issue is. Include package name, current version, affected version range,
+and the specific risk or concern.]
+
+## Recommended Action
+
+[Concrete steps: version to upgrade to, constraint to change, commit to pin to, etc.
+Include the exact change to `pyproject.toml` where applicable.]
+
+## Risk Assessment
+
+[Impact if not addressed: security exposure, build breakage risk, reproducibility
+concern, legal risk, etc.]
+```
+
+### Ordering
+
+Order issues by recommended implementation sequence:
+
+1. Active CVEs first (P0/P1)
+2. Supply chain risks (pinning, integrity)
+3. Outdated dependencies by severity
+4. Maintenance and license concerns
+5. Hygiene items
+
+### Post-Issue Deliverables
+
+After the issue list, provide:
+
+1. A **dependency graph** in Mermaid format showing blocked-by relationships
+2. A **summary table** with columns: `#`, Title, Type, Priority, Size, Labels, Blocked By
+
+---
+
+## Execution Script
+
+After the review, generate a **complete, copy-pasteable bash script** that creates all
+issues on GitHub, adds them to the project, sets all fields, and wires up dependencies.
+
+Use the following constants, IDs, and patterns.
+
+### Constants
+
+```bash
+OWNER="graphras-com"
+REPO="DeUX"
+REPO_ID="R_kgDOR3asLg"
+PROJECT_NUMBER=2
+PROJECT_ID="PVT_kwDOECHs484BWOyq"
+
+# Issue Type IDs
+TYPE_TASK="IT_kwDOECHs484B6of5"
+TYPE_BUG="IT_kwDOECHs484B6of6"
+TYPE_FEATURE="IT_kwDOECHs484B6of7"
+
+# Project Field IDs
+PRIORITY_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf4"
+SIZE_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf8"
+STATUS_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwYw"
+
+# Priority Option IDs
+PRIORITY_P0="79628723"
+PRIORITY_P1="0a877460"
+PRIORITY_P2="da944a9c"
+PRIORITY_P3="e2ede371"
+
+# Size Option IDs
+SIZE_XS="6c6483d2"
+SIZE_S="f784b110"
+SIZE_M="7515a9f1"
+SIZE_L="817d0097"
+SIZE_XL="db339eb2"
+
+# Status Option IDs
+STATUS_BACKLOG="f75ad846"
+```
+
+### Per-Issue Pattern
+
+For each issue, the script must:
+
+```bash
+# 1. Create the issue
+ISSUE_N_URL=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "TITLE" \
+  --label "dependencies" \
+  --label "area:packaging" \
+  --label "severity:med" \
+  --body "BODY_MARKDOWN" \
+  --project "DeUX Development")
+
+# 2. Extract issue number and node ID
+ISSUE_N_NUM=$(echo "$ISSUE_N_URL" | grep -oE '[0-9]+$')
+ISSUE_N_ID=$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      issue(number:$number) { id }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO" -F number="$ISSUE_N_NUM" \
+  --jq '.data.repository.issue.id')
+
+# 3. Set issue type
+gh api graphql -f query='
+  mutation($id:ID!, $typeId:ID!) {
+    updateIssue(input:{id:$id, issueTypeId:$typeId}) {
+      issue { id }
+    }
+  }' -f id="$ISSUE_N_ID" -f typeId="$TYPE_TASK"
+
+# 4. Add to project and get item ID
+ITEM_N_ID=$(gh project item-add $PROJECT_NUMBER \
+  --owner "$OWNER" \
+  --url "$ISSUE_N_URL" \
+  --format json | jq -r '.id')
+
+# 5. Set Priority
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$PRIORITY_FIELD_ID" \
+  --single-select-option-id "$PRIORITY_P2"
+
+# 6. Set Size
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$SIZE_FIELD_ID" \
+  --single-select-option-id "$SIZE_S"
+
+# 7. Set Status to Backlog
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$STATUS_BACKLOG"
+```
+
+### Dependency Wiring Pattern
+
+After all issues are created, wire up dependencies using sub-issues.
+The **parent** is the issue that must be done first (the blocker).
+The **sub-issue** is the issue that depends on it.
+
+```bash
+# Make ISSUE_2 depend on ISSUE_1:
+# ISSUE_1 is the parent (blocker), ISSUE_2 is the sub-issue (blocked)
+gh api graphql -f query='
+  mutation($parentId:ID!, $subIssueId:ID!) {
+    addSubIssue(input:{issueId:$parentId, subIssueId:$subIssueId}) {
+      issue { id }
+    }
+  }' -f parentId="$ISSUE_1_ID" -f subIssueId="$ISSUE_2_ID"
+```
+
+### Script Structure
+
+The generated script must follow this order:
+
+1. Set all constants (repo ID, type IDs, field IDs, option IDs)
+2. Create all issues in dependency order (foundations first), storing each URL, number,
+   and node ID in named variables (`ISSUE_1_URL`, `ISSUE_1_NUM`, `ISSUE_1_ID`,
+   `ITEM_1_ID`, etc.)
+3. Set issue type for each issue
+4. Add each issue to the project and set Priority, Size, Status=Backlog
+5. Wire up all dependency relationships via `addSubIssue`
+
+### Prerequisites
+
+The script requires these token scopes:
+
+```bash
+gh auth refresh -s project -s read:project
+```

--- a/prompts/documentation-review.md
+++ b/prompts/documentation-review.md
@@ -1,0 +1,325 @@
+# Documentation Review Prompt — DeUX
+
+> **Usage:** Run this prompt against `docs/`, `src/deux/` (for docstrings), and `mkdocs.yml`.
+> Repeat regularly (e.g., after each milestone, major feature merge, or API change).
+
+---
+
+## Role
+
+You are a senior technical documentation reviewer. Your job is to verify that all
+documentation in the DeUX project is accurate, complete, and current — then produce
+actionable GitHub issues for each finding.
+
+## Codebase Context
+
+DeUX is an asyncio-native Python library for Elgato Stream Deck devices.
+
+### Documentation Structure
+
+| Location | Content |
+|----------|---------|
+| `docs/index.md` | Landing page: badges, features, quick-start, installation, usage example |
+| `docs/architecture.md` | Embeds auto-generated SVG class and package diagrams |
+| `docs/architecture/classes.svg` | Auto-generated class diagram (via `gen_diagrams.py`) |
+| `docs/architecture/packages.svg` | Auto-generated package diagram (via `gen_diagrams.py`) |
+| `docs/example.md` | Walkthrough of `examples/streamdeck.py` (full source embedded via snippet) |
+| `docs/elgato-hid-protocol.md` | HID protocol reference (devices, reports, image chunking) |
+| `docs/guides/creating-dui-packages.md` | DUI package format guide (manifest, SVG, bindings, events, spinners) |
+| `docs/gen_ref_pages.py` | Build-time script: generates `reference/<pkg>.md` for each top-level sub-package |
+| `docs/gen_diagrams.py` | Build-time script: regenerates architecture SVGs |
+| `mkdocs.yml` | MkDocs Material config with mkdocstrings (NumPy-style), gen-files, literate-nav |
+
+### API Reference (auto-generated at build time)
+
+One page per top-level public sub-package via mkdocstrings directives:
+
+- `reference/dui.md` → `::: deux.dui`
+- `reference/render.md` → `::: deux.render`
+- `reference/runtime.md` → `::: deux.runtime`
+- `reference/tools.md` → `::: deux.tools`
+- `reference/ui.md` → `::: deux.ui`
+
+### Docstring Convention
+
+All public code must have NumPy-style docstrings covering: purpose, parameters, return
+values, raised exceptions, side effects, and examples where useful.
+
+## Review Scope — What to Review
+
+### 1. Accuracy
+
+- **Docstrings vs code** — Do function/method/class docstrings match current signatures?
+  Parameters added/removed/renamed but not updated in docstrings? Return types described
+  incorrectly? Raises sections listing exceptions no longer raised, or missing new ones?
+- **Guides vs code** — Does `creating-dui-packages.md` reflect all current binding types,
+  event types, manifest fields, validation rules, and CLI tool options? Are any described
+  features removed or changed?
+- **Examples vs code** — Does the quick-start in `index.md` work against the current API?
+  Does `example.md` accurately describe `examples/streamdeck.py`? Are embedded snippets
+  current?
+- **HID protocol doc vs implementation** — Does `elgato-hid-protocol.md` match the actual
+  protocol implementation in `src/deux/runtime/hid/protocol.py`? Any devices, reports, or
+  fields added/changed in code but not documented?
+- **Architecture diagrams** — Do `classes.svg` and `packages.svg` reflect the current
+  module structure and class hierarchy? (Check if `gen_diagrams.py` output is stale.)
+- **Config references** — Do documented installation instructions, system requirements,
+  dependency names, and version constraints match `pyproject.toml`?
+
+### 2. Completeness
+
+- **Missing docstrings** — Public functions, classes, methods, or modules lacking
+  docstrings entirely.
+- **Incomplete docstrings** — Docstrings missing Parameters, Returns, Raises, or
+  description sections per NumPy-style convention.
+- **Undocumented features** — New modules, classes, binding types, event types, CLI
+  options, or configuration that exist in code but are not mentioned anywhere in `docs/`.
+- **API reference gaps** — Nested sub-packages (`runtime.hid`, `ui.cards`, `ui.controls`,
+  `render.defaults`) that may not be surfaced by the current mkdocstrings directives.
+  Check if `gen_ref_pages.py` covers everything that should be public.
+- **Missing guides** — Workflows or features that warrant a guide but have none.
+
+### 3. Staleness
+
+- **Dead links** — Internal cross-references (`[text](path)`) pointing to moved/deleted
+  files. External URLs that may be broken.
+- **Old module paths** — References to renamed or reorganized modules/files.
+- **Removed features** — Documentation describing features, config options, functions,
+  or classes that no longer exist in the codebase.
+- **Version references** — Outdated version numbers, Python version requirements, or
+  dependency versions in prose that contradict `pyproject.toml`.
+
+### 4. Consistency
+
+- **Docstring format** — Docstrings not following NumPy-style convention.
+- **Terminology** — Inconsistent naming across docs and docstrings (e.g., "DUI" vs "dui"
+  vs ".dui", "Stream Deck" vs "StreamDeck", "key slot" vs "KeySlot").
+- **Formatting** — Broken markdown, missing code fences, inconsistent heading levels,
+  malformed tables, missing admonition types.
+- **Tone and style** — Inconsistent voice or level of detail across documents.
+
+## Review Scope — What NOT to Review
+
+Do **not** suggest changes to these settled architectural decisions:
+
+1. SVG-first rendering pipeline (SVG DOM manipulation → resvg rasterisation)
+2. Use of `resvg-py` (custom fork) instead of CairoSVG or other rasterisers
+3. ctypes bindings to libhidapi (not the Python `hid` package)
+4. The `.dui` package format (YAML manifest + SVG layout + assets)
+5. `defusedxml` for XML safety
+6. The async architecture (`DeckManager` → `Deck` → `AsyncTransport` pattern)
+7. HID I/O via shared `ThreadPoolExecutor` + `run_in_executor`
+8. The binding dispatch table pattern in `SvgRenderer`
+9. The CSS theme system (HSL colour math from primary colour)
+10. Dirty-flag rendering approach
+11. Encoder turn coalescing
+12. src layout with Hatchling build system
+13. Existing CI pipeline structure
+14. MkDocs Material + mkdocstrings as the documentation toolchain
+
+If documentation about these areas is wrong or incomplete, flag the **documentation**
+issue — do not suggest changing the underlying architecture.
+
+## Output Format
+
+### Per-Issue Fields
+
+For each finding, produce:
+
+| Field | Description |
+|-------|-------------|
+| **Number** | Sequential (`#1`, `#2`, `#3`, ...) for dependency references |
+| **Title** | Concise, actionable (e.g., "Update `creating-dui-packages.md` with new `css_class` binding type") |
+| **Type** | One of: `Task`, `Bug`, `Feature` |
+| **Labels** | Combine from: **Area:** `area:docs`, `area:api`, `area:code-quality` / **Severity:** `severity:high`, `severity:med`, `severity:low`, `severity:nit` / **Other:** `documentation`, `enhancement`, `bug` |
+| **Priority** | `P0` (critical), `P1` (high), `P2` (medium), `P3` (low) |
+| **Size** | Estimated effort: `XS`, `S`, `M`, `L`, `XL` |
+| **Body** | Markdown with three sections (see template below) |
+| **Depends on** | List of issue numbers (`#N`) this is blocked by. Empty if none. |
+| **Blocks** | List of issue numbers that depend on this. Empty if none. |
+
+### Issue Body Template
+
+```markdown
+## Problem
+
+[What is wrong, outdated, or missing. Include file paths, line numbers, and the
+specific text or section that is incorrect/absent. Quote the problematic content
+where helpful.]
+
+## Suggested Fix
+
+[Concrete guidance: what to add, remove, or rewrite. Include corrected text or
+a description of what the updated content should cover.]
+
+## Rationale
+
+[Why this matters: user confusion, incorrect usage, missing discoverability, etc.]
+```
+
+### Priority Guide for Documentation Issues
+
+| Priority | Use when |
+|----------|----------|
+| **P0** | Documentation is actively misleading — users will hit errors following it |
+| **P1** | Significant inaccuracy or major missing content (undocumented public API) |
+| **P2** | Minor inaccuracy, incomplete sections, or stale references |
+| **P3** | Nits: formatting, style, terminology consistency |
+
+### Ordering
+
+Order issues by recommended implementation sequence:
+
+1. Foundation fixes first (things other issues depend on)
+2. Then by priority (P0 → P3)
+3. Within same priority, smaller sizes first
+
+### Post-Issue Deliverables
+
+After the issue list, provide:
+
+1. A **dependency graph** in Mermaid format showing blocked-by relationships
+2. A **summary table** with columns: `#`, Title, Type, Priority, Size, Labels, Blocked By
+
+---
+
+## Execution Script
+
+After the review, generate a **complete, copy-pasteable bash script** that creates all
+issues on GitHub, adds them to the project, sets all fields, and wires up dependencies.
+
+Use the following constants, IDs, and patterns.
+
+### Constants
+
+```bash
+OWNER="graphras-com"
+REPO="DeUX"
+REPO_ID="R_kgDOR3asLg"
+PROJECT_NUMBER=2
+PROJECT_ID="PVT_kwDOECHs484BWOyq"
+
+# Issue Type IDs
+TYPE_TASK="IT_kwDOECHs484B6of5"
+TYPE_BUG="IT_kwDOECHs484B6of6"
+TYPE_FEATURE="IT_kwDOECHs484B6of7"
+
+# Project Field IDs
+PRIORITY_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf4"
+SIZE_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf8"
+STATUS_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwYw"
+
+# Priority Option IDs
+PRIORITY_P0="79628723"
+PRIORITY_P1="0a877460"
+PRIORITY_P2="da944a9c"
+PRIORITY_P3="e2ede371"
+
+# Size Option IDs
+SIZE_XS="6c6483d2"
+SIZE_S="f784b110"
+SIZE_M="7515a9f1"
+SIZE_L="817d0097"
+SIZE_XL="db339eb2"
+
+# Status Option IDs
+STATUS_BACKLOG="f75ad846"
+```
+
+### Per-Issue Pattern
+
+For each issue, the script must:
+
+```bash
+# 1. Create the issue
+ISSUE_N_URL=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "TITLE" \
+  --label "documentation" \
+  --label "area:docs" \
+  --label "severity:med" \
+  --body "BODY_MARKDOWN" \
+  --project "DeUX Development")
+
+# 2. Extract issue number and node ID
+ISSUE_N_NUM=$(echo "$ISSUE_N_URL" | grep -oE '[0-9]+$')
+ISSUE_N_ID=$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      issue(number:$number) { id }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO" -F number="$ISSUE_N_NUM" \
+  --jq '.data.repository.issue.id')
+
+# 3. Set issue type
+gh api graphql -f query='
+  mutation($id:ID!, $typeId:ID!) {
+    updateIssue(input:{id:$id, issueTypeId:$typeId}) {
+      issue { id }
+    }
+  }' -f id="$ISSUE_N_ID" -f typeId="$TYPE_TASK"
+
+# 4. Add to project and get item ID
+ITEM_N_ID=$(gh project item-add $PROJECT_NUMBER \
+  --owner "$OWNER" \
+  --url "$ISSUE_N_URL" \
+  --format json | jq -r '.id')
+
+# 5. Set Priority
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$PRIORITY_FIELD_ID" \
+  --single-select-option-id "$PRIORITY_P2"
+
+# 6. Set Size
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$SIZE_FIELD_ID" \
+  --single-select-option-id "$SIZE_M"
+
+# 7. Set Status to Backlog
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$STATUS_BACKLOG"
+```
+
+### Dependency Wiring Pattern
+
+After all issues are created, wire up dependencies using sub-issues.
+The **parent** is the issue that must be done first (the blocker).
+The **sub-issue** is the issue that depends on it.
+
+```bash
+# Make ISSUE_2 depend on ISSUE_1:
+# ISSUE_1 is the parent (blocker), ISSUE_2 is the sub-issue (blocked)
+gh api graphql -f query='
+  mutation($parentId:ID!, $subIssueId:ID!) {
+    addSubIssue(input:{issueId:$parentId, subIssueId:$subIssueId}) {
+      issue { id }
+    }
+  }' -f parentId="$ISSUE_1_ID" -f subIssueId="$ISSUE_2_ID"
+```
+
+### Script Structure
+
+The generated script must follow this order:
+
+1. Set all constants (repo ID, type IDs, field IDs, option IDs)
+2. Create all issues in dependency order (foundations first), storing each URL, number,
+   and node ID in named variables (`ISSUE_1_URL`, `ISSUE_1_NUM`, `ISSUE_1_ID`,
+   `ITEM_1_ID`, etc.)
+3. Set issue type for each issue
+4. Add each issue to the project and set Priority, Size, Status=Backlog
+5. Wire up all dependency relationships via `addSubIssue`
+
+### Prerequisites
+
+The script requires these token scopes:
+
+```bash
+gh auth refresh -s project -s read:project
+```

--- a/prompts/security-review.md
+++ b/prompts/security-review.md
@@ -1,0 +1,309 @@
+# Security Review Prompt — DeUX
+
+> **Usage:** Run this prompt against `src/deux/`, `tests/`, and `pyproject.toml`.
+> Repeat regularly (e.g., before each release, after adding network-facing code,
+> or when DUI package loading changes).
+
+---
+
+## Role
+
+You are a senior application security reviewer specialising in Python libraries that
+handle untrusted input, network I/O, and hardware interfaces. Your job is to identify
+security issues in the DeUX codebase and produce actionable GitHub issues for each finding.
+
+## Codebase Context
+
+DeUX is an asyncio-native Python library for Elgato Stream Deck devices. Security-relevant
+characteristics:
+
+- **Untrusted input:** `.dui` packages (YAML manifests + SVG templates + image assets)
+  may come from third-party authors or a future public repository
+- **XML parsing:** SVG templates are parsed and manipulated at the DOM level; currently
+  guarded by `defusedxml` via `_xml.py:safe_fromstring()`
+- **Network I/O:** Iconify icon fetching and image URL resolution; currently guarded by
+  SSRF protection in `_url_safety.py`
+- **SVG rasterisation:** Untrusted SVG content is passed to `resvg` for rendering
+- **HID transport:** ctypes bindings to libhidapi (`runtime/hid/_ctypes_hidapi.py`)
+  with direct memory buffer operations
+- **YAML parsing:** Manifest files parsed via PyYAML
+- **CI:** Gitleaks scans for leaked secrets
+
+## Review Scope — What to Review
+
+### 1. Input Validation
+
+- **DUI package loading** (`dui/loader.py`) — Are all manifest fields validated? Can
+  malformed YAML cause crashes or unexpected behaviour? Are there path traversal risks
+  in asset references? Can a `.dui` package reference files outside its directory?
+- **SVG content** — Beyond XXE (handled by defusedxml), are there SVG-specific attack
+  vectors? `<script>` tags, `<foreignObject>`, external references (`xlink:href` to
+  remote URLs), CSS `@import` or `url()` in inline styles, event handlers (`onload`,
+  `onclick`)?
+- **Binding values** — When user-supplied data is injected into SVG via bindings (text,
+  image, color, etc.), is it sanitised? Can binding values inject SVG/XML markup?
+- **YAML safety** — Is `yaml.safe_load()` used consistently, or are there any paths
+  using `yaml.load()` with the default (unsafe) loader?
+
+### 2. Network Security
+
+- **SSRF protection** (`_url_safety.py`) — Is the allow/deny list comprehensive? Are
+  there bypass vectors (DNS rebinding, IPv6 mapped addresses, URL encoding tricks,
+  redirect following)?
+- **Iconify client** (`dui/iconify.py`) — Is the response from the Iconify API treated
+  as untrusted? Is the returned SVG parsed safely? Are there cache poisoning risks?
+- **Image fetching** (`render/image_fetch.py`) — Same questions: response validation,
+  content-type checking, size limits, timeout enforcement?
+- **TLS verification** — Are all outbound HTTPS requests verifying certificates?
+
+### 3. Memory and Buffer Safety
+
+- **ctypes HID bindings** (`runtime/hid/_ctypes_hidapi.py`) — Buffer allocation sizes,
+  null pointer checks, use-after-free potential, buffer overflows in read/write paths.
+- **Image processing** — Are there decompression bomb protections on images loaded via
+  Pillow? (`PIL.Image.MAX_IMAGE_PIXELS`)
+- **LRU cache** (`render/svg_rasterize.py`) — Can cache entries grow unboundedly in
+  individual entry size? Is the SHA-256 keying scheme collision-resistant in practice?
+
+### 4. Concurrency Safety
+
+- **Shared executor** (`runtime/_executor.py`) — Thread safety of shared state accessed
+  from both the executor threads and the asyncio event loop.
+- **AsyncTransport** — Race conditions in connect/disconnect/reconnect sequences.
+- **Event routing** — Can malicious or rapid input cause unbounded queue growth or
+  event loop starvation?
+
+### 5. Dependency Security
+
+- **Known CVEs** — Check current pinned versions of `pillow`, `pyyaml`, `defusedxml`,
+  `resvg-py`, `platformdirs` against known vulnerabilities.
+- **Supply chain** — `resvg-py` is a custom fork installed via `git+` URL. Is the
+  reference pinned to a commit hash or only a branch (`@main`)?
+
+### 6. Secrets and Credentials
+
+- **Hardcoded secrets** — API keys, tokens, or credentials in source code (beyond
+  gitleaks coverage).
+- **Config files** — Do any config paths or defaults risk exposing sensitive data?
+
+## Review Scope — What NOT to Review
+
+Do **not** suggest changes to these settled architectural decisions:
+
+1. SVG-first rendering pipeline (SVG DOM manipulation → resvg rasterisation)
+2. Use of `resvg-py` (custom fork) instead of CairoSVG or other rasterisers
+3. ctypes bindings to libhidapi (not the Python `hid` package)
+4. The `.dui` package format (YAML manifest + SVG layout + assets)
+5. `defusedxml` for XML safety
+6. The async architecture (`DeckManager` → `Deck` → `AsyncTransport` pattern)
+7. HID I/O via shared `ThreadPoolExecutor` + `run_in_executor`
+8. The binding dispatch table pattern in `SvgRenderer`
+9. The CSS theme system (HSL colour math from primary colour)
+10. Dirty-flag rendering approach
+11. Encoder turn coalescing
+12. src layout with Hatchling build system
+13. Existing CI pipeline structure
+
+Flag security issues **within** these systems without suggesting replacements.
+
+## Output Format
+
+### Per-Issue Fields
+
+For each finding, produce:
+
+| Field | Description |
+|-------|-------------|
+| **Number** | Sequential (`#1`, `#2`, `#3`, ...) for dependency references |
+| **Title** | Concise, actionable (e.g., "Sanitise text binding values to prevent SVG injection") |
+| **Type** | One of: `Task`, `Bug`, `Feature` |
+| **Labels** | Combine from: **Area:** `area:security`, `area:async`, `area:reliability`, `area:api`, `area:packaging` / **Severity:** `severity:high`, `severity:med`, `severity:low`, `severity:nit` / **Type:** `type:security`, `type:bug` / **Other:** `bug`, `enhancement` |
+| **Priority** | `P0` (critical — exploitable vulnerability), `P1` (high — significant risk), `P2` (medium — defence-in-depth), `P3` (low — hardening) |
+| **Size** | Estimated effort: `XS`, `S`, `M`, `L`, `XL` |
+| **Body** | Markdown with sections below |
+| **Depends on** | List of issue numbers (`#N`) this is blocked by. Empty if none. |
+| **Blocks** | List of issue numbers that depend on this. Empty if none. |
+
+### Issue Body Template
+
+```markdown
+## Vulnerability / Risk
+
+[What the issue is, where it exists (file paths + line numbers), and what an
+attacker could achieve by exploiting it. Include attack scenario if applicable.]
+
+## Suggested Fix
+
+[Concrete, specific remediation guidance. Include code patterns where helpful.]
+
+## Severity Rationale
+
+[Why this severity level: exploitability, impact, prerequisites, existing mitigations.]
+```
+
+### Priority Guide for Security Issues
+
+| Priority | Use when |
+|----------|----------|
+| **P0** | Exploitable vulnerability with no mitigating controls (RCE, arbitrary file read, SSRF bypass) |
+| **P1** | Significant risk requiring specific conditions or partial mitigation exists |
+| **P2** | Defence-in-depth improvement; not directly exploitable but reduces attack surface |
+| **P3** | Hardening; best-practice alignment with minimal current risk |
+
+### Ordering
+
+Order issues by recommended implementation sequence:
+
+1. Foundation fixes first (things other issues depend on)
+2. Then by priority (P0 → P3)
+3. Within same priority, smaller sizes first
+
+### Post-Issue Deliverables
+
+After the issue list, provide:
+
+1. A **dependency graph** in Mermaid format showing blocked-by relationships
+2. A **summary table** with columns: `#`, Title, Type, Priority, Size, Labels, Blocked By
+
+---
+
+## Execution Script
+
+After the review, generate a **complete, copy-pasteable bash script** that creates all
+issues on GitHub, adds them to the project, sets all fields, and wires up dependencies.
+
+Use the following constants, IDs, and patterns.
+
+### Constants
+
+```bash
+OWNER="graphras-com"
+REPO="DeUX"
+REPO_ID="R_kgDOR3asLg"
+PROJECT_NUMBER=2
+PROJECT_ID="PVT_kwDOECHs484BWOyq"
+
+# Issue Type IDs
+TYPE_TASK="IT_kwDOECHs484B6of5"
+TYPE_BUG="IT_kwDOECHs484B6of6"
+TYPE_FEATURE="IT_kwDOECHs484B6of7"
+
+# Project Field IDs
+PRIORITY_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf4"
+SIZE_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf8"
+STATUS_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwYw"
+
+# Priority Option IDs
+PRIORITY_P0="79628723"
+PRIORITY_P1="0a877460"
+PRIORITY_P2="da944a9c"
+PRIORITY_P3="e2ede371"
+
+# Size Option IDs
+SIZE_XS="6c6483d2"
+SIZE_S="f784b110"
+SIZE_M="7515a9f1"
+SIZE_L="817d0097"
+SIZE_XL="db339eb2"
+
+# Status Option IDs
+STATUS_BACKLOG="f75ad846"
+```
+
+### Per-Issue Pattern
+
+For each issue, the script must:
+
+```bash
+# 1. Create the issue
+ISSUE_N_URL=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "TITLE" \
+  --label "area:security" \
+  --label "type:security" \
+  --label "severity:high" \
+  --body "BODY_MARKDOWN" \
+  --project "DeUX Development")
+
+# 2. Extract issue number and node ID
+ISSUE_N_NUM=$(echo "$ISSUE_N_URL" | grep -oE '[0-9]+$')
+ISSUE_N_ID=$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      issue(number:$number) { id }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO" -F number="$ISSUE_N_NUM" \
+  --jq '.data.repository.issue.id')
+
+# 3. Set issue type
+gh api graphql -f query='
+  mutation($id:ID!, $typeId:ID!) {
+    updateIssue(input:{id:$id, issueTypeId:$typeId}) {
+      issue { id }
+    }
+  }' -f id="$ISSUE_N_ID" -f typeId="$TYPE_TASK"
+
+# 4. Add to project and get item ID
+ITEM_N_ID=$(gh project item-add $PROJECT_NUMBER \
+  --owner "$OWNER" \
+  --url "$ISSUE_N_URL" \
+  --format json | jq -r '.id')
+
+# 5. Set Priority
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$PRIORITY_FIELD_ID" \
+  --single-select-option-id "$PRIORITY_P1"
+
+# 6. Set Size
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$SIZE_FIELD_ID" \
+  --single-select-option-id "$SIZE_M"
+
+# 7. Set Status to Backlog
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$STATUS_BACKLOG"
+```
+
+### Dependency Wiring Pattern
+
+After all issues are created, wire up dependencies using sub-issues.
+The **parent** is the issue that must be done first (the blocker).
+The **sub-issue** is the issue that depends on it.
+
+```bash
+# Make ISSUE_2 depend on ISSUE_1:
+# ISSUE_1 is the parent (blocker), ISSUE_2 is the sub-issue (blocked)
+gh api graphql -f query='
+  mutation($parentId:ID!, $subIssueId:ID!) {
+    addSubIssue(input:{issueId:$parentId, subIssueId:$subIssueId}) {
+      issue { id }
+    }
+  }' -f parentId="$ISSUE_1_ID" -f subIssueId="$ISSUE_2_ID"
+```
+
+### Script Structure
+
+The generated script must follow this order:
+
+1. Set all constants (repo ID, type IDs, field IDs, option IDs)
+2. Create all issues in dependency order (foundations first), storing each URL, number,
+   and node ID in named variables (`ISSUE_1_URL`, `ISSUE_1_NUM`, `ISSUE_1_ID`,
+   `ITEM_1_ID`, etc.)
+3. Set issue type for each issue
+4. Add each issue to the project and set Priority, Size, Status=Backlog
+5. Wire up all dependency relationships via `addSubIssue`
+
+### Prerequisites
+
+The script requires these token scopes:
+
+```bash
+gh auth refresh -s project -s read:project
+```

--- a/prompts/test-coverage-gap-review.md
+++ b/prompts/test-coverage-gap-review.md
@@ -1,0 +1,331 @@
+# Test Coverage Gap Review Prompt — DeUX
+
+> **Usage:** Run this prompt against `src/deux/`, `tests/`, and `conftest.py`.
+> Repeat regularly (e.g., after major features, refactors, or when coverage drops).
+>
+> Before running, generate a fresh coverage report:
+> ```bash
+> python -m pytest tests/ --cov=deux --cov-report=term-missing --cov-report=json
+> ```
+> Provide the output or `coverage.json` as context alongside the source and test files.
+
+---
+
+## Role
+
+You are a senior test engineer specialising in async Python libraries with hardware
+interfaces. Your job is to identify meaningful gaps in the test suite — not just
+uncovered lines, but untested behaviours, missing edge cases, and fragile test patterns
+— then produce actionable GitHub issues for each finding.
+
+## Codebase Context
+
+DeUX is an asyncio-native Python library for Elgato Stream Deck devices.
+
+### Test Infrastructure
+
+- **Framework:** pytest with `pytest-asyncio` (`asyncio_mode = "auto"`)
+- **Coverage gate:** 95% minimum (`--cov-fail-under=95`)
+- **Mocking:** All hardware is mocked via `conftest.py` fixtures (`mock_streamdeck_device`,
+  etc.) — no real device needed
+- **DUI test packages:** Built in `tmp_path` by conftest helpers (`card_dui_path`,
+  `key_dui_path`)
+- **Test matrix:** Python 3.11, 3.12, 3.13 in CI
+- **53 test files** covering all modules
+
+### Key Async Patterns to Test
+
+- `DeckManager`: auto-discovery, hot-plug detection, reconnection via polling
+- `Deck`: event loop, screen switching, timeout checking (deadline-driven)
+- `AsyncTransport`: HID read loop → asyncio queue bridge
+- `DeckEventRouter`: key/encoder/touch dispatch, encoder turn coalescing
+- Dirty-flag rendering: only re-renders changed controls
+- `AsyncEvent`: multi-subscriber pub/sub
+
+### Key Non-Async Patterns to Test
+
+- `SvgRenderer`: binding dispatch table, all 11 binding types
+- `DUI loader`: exhaustive manifest validation (1000+ lines)
+- HID protocol: USB report formatting, image chunking
+- Theme: HSL colour math, CSS generation
+- SVG rasterisation: LRU cache, CSS injection, layer compositing
+
+## Review Scope — What to Review
+
+### 1. Untested Behaviours
+
+- Public methods/functions with **no corresponding test** at all
+- Code paths that exist but are not exercised (use coverage report `missing` lines)
+- Behaviours documented in docstrings that have no test asserting them
+- Return values or side effects that are never verified
+
+### 2. Missing Edge Cases
+
+- **Error paths** — What happens when things fail? Are exceptions raised, caught, or
+  propagated correctly? Test: invalid input, network failures, device disconnection
+  mid-operation, corrupted DUI packages, malformed SVG, HID read timeouts
+- **Boundary conditions** — Empty collections, zero-length inputs, maximum values,
+  off-by-one scenarios in image chunking, screen indices, key indices
+- **Concurrency edge cases** — Cancellation during async operations, concurrent
+  connect/disconnect, rapid event bursts, executor thread pool exhaustion,
+  event loop shutdown during pending tasks
+- **Reconnection scenarios** — Device removed and re-added, device replaced with
+  different model, multiple simultaneous disconnections
+- **Resource cleanup** — Are context managers tested for cleanup on both normal exit
+  and exception paths? Are file handles, HID handles, and executor threads released?
+
+### 3. Mock Quality
+
+- **Overly permissive mocks** — Mocks that accept any input and return success,
+  hiding real validation or error paths. Mocks that don't verify call arguments.
+- **Missing mock assertions** — Tests that set up mocks but never assert they were
+  called (or called with expected arguments)
+- **Mock vs real behaviour drift** — Mock fixtures that no longer match the interface
+  of what they're mocking (e.g., missing new parameters, wrong return types)
+- **Incomplete mock coverage** — Hardware behaviours that aren't represented in the
+  mock fixtures (e.g., specific device quirks, protocol edge cases)
+
+### 4. Test Fragility
+
+- **Time-dependent tests** — Tests using `asyncio.sleep()` with fixed durations that
+  may flake on slow CI. Should use `asyncio.Event` or similar deterministic signals.
+- **Order-dependent tests** — Tests that pass only when run in a specific order or
+  that share mutable state via module-level variables or class attributes.
+- **Assertion quality** — Tests that assert too little (just "no exception") or too
+  much (brittle exact-match on implementation details that may change).
+- **Test naming** — Unclear test names that don't describe what behaviour is being
+  verified.
+
+### 5. Integration Test Gaps
+
+- **Cross-module interactions** — Are there tests that verify the full pipeline
+  (e.g., DUI package load → binding apply → SVG render → image output)?
+- **Multi-device scenarios** — Does the test suite cover `DeckManager` with multiple
+  simultaneous devices?
+- **Screen switching** — Is the full screen lifecycle tested (create → activate →
+  render → switch → deactivate)?
+
+## Review Scope — What NOT to Review
+
+Do **not** suggest changes to these settled architectural decisions:
+
+1. SVG-first rendering pipeline (SVG DOM manipulation → resvg rasterisation)
+2. Use of `resvg-py` (custom fork) instead of CairoSVG or other rasterisers
+3. ctypes bindings to libhidapi (not the Python `hid` package)
+4. The `.dui` package format (YAML manifest + SVG layout + assets)
+5. `defusedxml` for XML safety
+6. The async architecture (`DeckManager` → `Deck` → `AsyncTransport` pattern)
+7. HID I/O via shared `ThreadPoolExecutor` + `run_in_executor`
+8. The binding dispatch table pattern in `SvgRenderer`
+9. The CSS theme system (HSL colour math from primary colour)
+10. Dirty-flag rendering approach
+11. Encoder turn coalescing
+12. src layout with Hatchling build system
+13. Existing CI pipeline structure
+
+Do **not** suggest replacing the mock-based testing approach with real hardware tests.
+Flag test quality issues without changing the testing strategy.
+
+## Output Format
+
+### Per-Issue Fields
+
+For each finding, produce:
+
+| Field | Description |
+|-------|-------------|
+| **Number** | Sequential (`#1`, `#2`, `#3`, ...) for dependency references |
+| **Title** | Concise, actionable (e.g., "Add tests for `DeckManager` reconnection after device hot-swap") |
+| **Type** | One of: `Task`, `Bug`, `Feature` |
+| **Labels** | Combine from: **Area:** `area:testing`, `area:async`, `area:reliability`, `area:security` / **Severity:** `severity:high`, `severity:med`, `severity:low`, `severity:nit` / **Type:** `type:bug`, `type:refactor` / **Other:** `enhancement`, `bug` |
+| **Priority** | `P0` (critical — untested path that will cause production bugs), `P1` (high — significant gap), `P2` (medium — missing edge case), `P3` (low — hardening, nit) |
+| **Size** | Estimated effort: `XS`, `S`, `M`, `L`, `XL` |
+| **Body** | Markdown with sections below |
+| **Depends on** | List of issue numbers (`#N`) this is blocked by. Empty if none. |
+| **Blocks** | List of issue numbers that depend on this. Empty if none. |
+
+### Issue Body Template
+
+```markdown
+## Gap
+
+[What is not tested. Include the source file path and line numbers of the untested
+code, and describe the behaviour or scenario that lacks coverage.]
+
+## Suggested Tests
+
+[Concrete test cases to add. Include test function names, key assertions, and any
+fixture or mock setup needed. Be specific enough that a developer can implement
+the test without ambiguity.]
+
+## Rationale
+
+[Why this gap matters: what bugs could go undetected, what regressions could slip
+through, what confidence is missing.]
+```
+
+### Priority Guide for Test Gap Issues
+
+| Priority | Use when |
+|----------|----------|
+| **P0** | Critical path with no test coverage — bugs here would cause visible failures |
+| **P1** | Important behaviour tested only on the happy path; error/edge cases missing |
+| **P2** | Edge case or secondary path with no coverage |
+| **P3** | Test quality nit (naming, fragility, assertion strength) |
+
+### Ordering
+
+Order issues by recommended implementation sequence:
+
+1. Foundation fixes first (things other issues depend on, e.g., fixture improvements)
+2. Then by priority (P0 → P3)
+3. Within same priority, smaller sizes first
+
+### Post-Issue Deliverables
+
+After the issue list, provide:
+
+1. A **dependency graph** in Mermaid format showing blocked-by relationships
+2. A **summary table** with columns: `#`, Title, Type, Priority, Size, Labels, Blocked By
+
+---
+
+## Execution Script
+
+After the review, generate a **complete, copy-pasteable bash script** that creates all
+issues on GitHub, adds them to the project, sets all fields, and wires up dependencies.
+
+Use the following constants, IDs, and patterns.
+
+### Constants
+
+```bash
+OWNER="graphras-com"
+REPO="DeUX"
+REPO_ID="R_kgDOR3asLg"
+PROJECT_NUMBER=2
+PROJECT_ID="PVT_kwDOECHs484BWOyq"
+
+# Issue Type IDs
+TYPE_TASK="IT_kwDOECHs484B6of5"
+TYPE_BUG="IT_kwDOECHs484B6of6"
+TYPE_FEATURE="IT_kwDOECHs484B6of7"
+
+# Project Field IDs
+PRIORITY_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf4"
+SIZE_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwf8"
+STATUS_FIELD_ID="PVTSSF_lADOECHs484BWOyqzhRkwYw"
+
+# Priority Option IDs
+PRIORITY_P0="79628723"
+PRIORITY_P1="0a877460"
+PRIORITY_P2="da944a9c"
+PRIORITY_P3="e2ede371"
+
+# Size Option IDs
+SIZE_XS="6c6483d2"
+SIZE_S="f784b110"
+SIZE_M="7515a9f1"
+SIZE_L="817d0097"
+SIZE_XL="db339eb2"
+
+# Status Option IDs
+STATUS_BACKLOG="f75ad846"
+```
+
+### Per-Issue Pattern
+
+For each issue, the script must:
+
+```bash
+# 1. Create the issue
+ISSUE_N_URL=$(gh issue create \
+  --repo "$OWNER/$REPO" \
+  --title "TITLE" \
+  --label "area:testing" \
+  --label "severity:med" \
+  --body "BODY_MARKDOWN" \
+  --project "DeUX Development")
+
+# 2. Extract issue number and node ID
+ISSUE_N_NUM=$(echo "$ISSUE_N_URL" | grep -oE '[0-9]+$')
+ISSUE_N_ID=$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      issue(number:$number) { id }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO" -F number="$ISSUE_N_NUM" \
+  --jq '.data.repository.issue.id')
+
+# 3. Set issue type
+gh api graphql -f query='
+  mutation($id:ID!, $typeId:ID!) {
+    updateIssue(input:{id:$id, issueTypeId:$typeId}) {
+      issue { id }
+    }
+  }' -f id="$ISSUE_N_ID" -f typeId="$TYPE_TASK"
+
+# 4. Add to project and get item ID
+ITEM_N_ID=$(gh project item-add $PROJECT_NUMBER \
+  --owner "$OWNER" \
+  --url "$ISSUE_N_URL" \
+  --format json | jq -r '.id')
+
+# 5. Set Priority
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$PRIORITY_FIELD_ID" \
+  --single-select-option-id "$PRIORITY_P2"
+
+# 6. Set Size
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$SIZE_FIELD_ID" \
+  --single-select-option-id "$SIZE_M"
+
+# 7. Set Status to Backlog
+gh project item-edit \
+  --id "$ITEM_N_ID" \
+  --project-id "$PROJECT_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$STATUS_BACKLOG"
+```
+
+### Dependency Wiring Pattern
+
+After all issues are created, wire up dependencies using sub-issues.
+The **parent** is the issue that must be done first (the blocker).
+The **sub-issue** is the issue that depends on it.
+
+```bash
+# Make ISSUE_2 depend on ISSUE_1:
+# ISSUE_1 is the parent (blocker), ISSUE_2 is the sub-issue (blocked)
+gh api graphql -f query='
+  mutation($parentId:ID!, $subIssueId:ID!) {
+    addSubIssue(input:{issueId:$parentId, subIssueId:$subIssueId}) {
+      issue { id }
+    }
+  }' -f parentId="$ISSUE_1_ID" -f subIssueId="$ISSUE_2_ID"
+```
+
+### Script Structure
+
+The generated script must follow this order:
+
+1. Set all constants (repo ID, type IDs, field IDs, option IDs)
+2. Create all issues in dependency order (foundations first), storing each URL, number,
+   and node ID in named variables (`ISSUE_1_URL`, `ISSUE_1_NUM`, `ISSUE_1_ID`,
+   `ITEM_1_ID`, etc.)
+3. Set issue type for each issue
+4. Add each issue to the project and set Priority, Size, Status=Backlog
+5. Wire up all dependency relationships via `addSubIssue`
+
+### Prerequisites
+
+The script requires these token scopes:
+
+```bash
+gh auth refresh -s project -s read:project
+```


### PR DESCRIPTION
## Summary

Adds a `prompts/` folder with five reusable review prompts for regular codebase health checks.

### Prompts

| File | Scope | Frequency |
|------|-------|-----------|
| `code-quality-review.md` | Naming, types, error handling, DRY, complexity, tests, dead code, API surface | After milestones / major merges |
| `documentation-review.md` | Accuracy, completeness, staleness of docs/ and docstrings vs current code | After milestones / API changes |
| `security-review.md` | Input validation, network security, buffer safety, concurrency, supply chain | Before releases / after new network code |
| `test-coverage-gap-review.md` | Untested behaviours, missing edge cases, mock quality, test fragility | After major features / refactors |
| `dependency-health-review.md` | CVEs, outdated deps, maintenance status, license, supply chain, constraints | Monthly / before releases |

### Common Features

All prompts:
- Respect settled architectural decisions (no suggestions to swap resvg, reintroduce CairoSVG, etc.)
- Output findings as numbered GitHub issues with dependency ordering
- Include a complete bash script template that creates issues via `gh`, sets type/priority/size/status on the DeUX Development project (#2), and wires up sub-issue dependencies via GraphQL
- Use the repo's existing labels (`area:*`, `severity:*`, `type:*`)

### Project Changes

- Added `P3` (BLUE) option to the Priority field on GitHub Project #2

## Validation

- [x] No code changes — prompts only
- [x] All project field IDs and option IDs verified against live project