### PR TITLE
Narrow except Exception swallowing in manager.py and screen.py

### DIFF
--- a/src/deux/runtime/manager.py
+++ b/src/deux/runtime/manager.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 from ._executor import get_executor, shutdown_executor
 from .deck import Deck, DeckError
 from .device_info import DeviceInfo
-from .hid._ctypes_hidapi import HidApiError
 from .hid.discovery import enumerate_devices
 
 if TYPE_CHECKING:
@@ -120,7 +119,7 @@ class DeckManager:
             try:
                 await deck.stop()
             except Exception:
-                logger.warning("Error stopping deck %s", serial)
+                logger.warning("Error stopping deck %s", serial, exc_info=True)
         self._decks.clear()
 
         self._closed_event.set()
@@ -238,8 +237,8 @@ class DeckManager:
             devices = await loop.run_in_executor(
                 get_executor(), enumerate_devices
             )
-        except (HidApiError, Exception):
-            logger.debug("Device enumeration failed")
+        except OSError:
+            logger.warning("Device enumeration failed", exc_info=True)
             return
 
         managed_paths: dict[str, str] = {}
@@ -270,7 +269,7 @@ class DeckManager:
                 device_by_serial[serial] = d
                 self._path_serial_cache[dev_path] = serial
                 await loop.run_in_executor(get_executor(), d.close)
-            except (HidApiError, Exception):
+            except OSError:
                 if dev_path not in self._failed_probe_paths:
                     self._failed_probe_paths.add(dev_path)
                     logger.info(
@@ -294,7 +293,7 @@ class DeckManager:
                 logger.info("Device disconnected: %s", serial)
                 try:
                     info = deck.info
-                except Exception:
+                except (DeckError, OSError):
                     info = DeviceInfo(
                         deck_type="unknown",
                         serial=serial,

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -95,29 +95,36 @@ class Screen:
         background has been explicitly configured.  Failures are logged
         but never raised — defaults are best-effort.
         """
+        import xml.etree.ElementTree as ET
+
         from ..render.defaults import get_default_backgrounds
+        from ..render.svg_rasterize import RasterizeError
 
         try:
             backgrounds = get_default_backgrounds(
                 self._caps.vendor_id, self._caps.product_id
             )
         except Exception:
-            logger.debug("Could not load default backgrounds", exc_info=True)
+            logger.warning("Could not load default backgrounds", exc_info=True)
             return
 
         if "touchscreen" in backgrounds and self._touch_strip is not None:
             try:
                 svg_data = backgrounds["touchscreen"]
                 self._touch_strip.bg_layer.set_svg(svg_data, trusted=True)
-            except Exception:
-                logger.debug("Failed to apply default touchscreen background", exc_info=True)
+            except (ET.ParseError, RasterizeError, OSError):
+                logger.warning(
+                    "Failed to apply default touchscreen background", exc_info=True
+                )
 
         if "key" in backgrounds:
             try:
                 svg_data = backgrounds["key"]
                 self._key_bg_layer.set_svg(svg_data, trusted=True)
-            except Exception:
-                logger.debug("Failed to apply default key background", exc_info=True)
+            except (ET.ParseError, RasterizeError, OSError):
+                logger.warning(
+                    "Failed to apply default key background", exc_info=True
+                )
 
     def _rasterize_key_background(self) -> None:
         """Re-rasterize the key background via the BackgroundLayer.

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -338,7 +338,9 @@ class TestDeckManagerDecks:
 
 class TestDeckManagerDisconnectInfoError:
     async def test_disconnect_info_error_fallback(self):
-        """When deck.info raises, a fallback DeviceInfo is used."""
+        """When deck.info raises ``DeckError``, a fallback DeviceInfo is used."""
+        from deux.runtime.deck import DeckError
+
         m = DeckManager(poll_interval=10.0)
         disconnected = []
 
@@ -348,7 +350,9 @@ class TestDeckManagerDisconnectInfoError:
 
         mock_deck = MagicMock()
         mock_deck.stop = AsyncMock()
-        type(mock_deck).info = property(lambda self: (_ for _ in ()).throw(Exception("no device")))
+        type(mock_deck).info = property(
+            lambda self: (_ for _ in ()).throw(DeckError("no device"))
+        )
         mock_deck.device_path = "/dev/hid/FALLBACK1"
         m._decks["FALLBACK1"] = mock_deck
 


### PR DESCRIPTION
Closes #319.

## Changes

### `src/deux/runtime/manager.py`
- Drop redundant `(HidApiError, Exception)` tuples (ruff B014). `HidApiError` is an `OSError` subclass, so catch `OSError` directly for `enumerate_devices` and device probe failures.
- Log enumeration / probe failures at WARNING / INFO with `exc_info=True` so genuine HID failures surface in production logs instead of being lost at DEBUG.
- Narrow `deck.info` fallback to `(DeckError, OSError)` — `Deck.info` only raises `DeckError` when the device is not opened, so a real `AttributeError` from a controller no longer hides behind the fallback.
- `stop()` logs `deck.stop()` failures with `exc_info` for traceability.
- Removed unused `HidApiError` import.

### `src/deux/ui/screen.py`
- `_apply_default_backgrounds` narrows per-surface catches to `(xml.etree.ElementTree.ParseError, RasterizeError, OSError)` to distinguish parse errors, rasterise errors, and missing files from genuine logic bugs.
- All log lines upgraded from DEBUG to WARNING with `exc_info=True` so background-loading failures are visible in production.

### `tests/test_manager.py`
- Updated `test_disconnect_info_error_fallback` to raise `DeckError` (the real failure mode of `Deck.info`) instead of a bare `Exception`, matching the narrowed catch.

## Validation
- `ruff check .` — passes
- `mypy src/deux` — passes (strict)
- `pytest tests/ --cov=deux --cov-fail-under=95` — 1808 passed, coverage 95.36%