### PR TITLE
refactor(renderer): extract setup/push helpers from render_touchscreen

### DIFF
--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, cast
 from ..dui.key import DuiKey
 from ..render.key_renderer import render_blank_key
 from ..render.profiler import RenderProfiler
+from ..render.touch_renderer import composite_frame_on_tile
 
 if TYPE_CHECKING:
     from ..dui.animator import PushFn
@@ -264,6 +265,163 @@ class DeckRenderer:
     # Touchscreen rendering
     # ------------------------------------------------------------------
 
+    def _touchscreen_image_format(self) -> str:
+        """Return the touchscreen image format for the active device.
+
+        Returns
+        -------
+        str
+            Image format string (e.g. ``"JPEG"``) from device
+            capabilities, defaulting to ``"JPEG"`` if unavailable.
+        """
+        caps = self._deck._caps
+        return caps.touchscreen_image_format if caps else "JPEG"
+
+    def _make_card_push_fn(
+        self,
+        card_idx: int,
+        panel_width: int,
+        panel_height: int,
+        bg_tile: bytes | None,
+    ) -> PushFn:
+        """Build a ``push_fn`` that delivers a single panel frame to the device.
+
+        Used to wire spinner animations into per-panel updates.  The
+        returned coroutine optionally composites the frame onto the
+        provided background tile before pushing it to the device under
+        the deck's I/O lock.
+
+        Parameters
+        ----------
+        card_idx : int
+            Index of the card on the touch strip (0-based).
+        panel_width, panel_height : int
+            Panel dimensions in pixels.
+        bg_tile : bytes | None
+            Optional encoded background tile for compositing.
+
+        Returns
+        -------
+        PushFn
+            Async callable accepting raw frame bytes for the panel.
+        """
+        deck = self._deck
+        x_pos = card_idx * panel_width
+        y_pos = 0
+        image_fmt = self._touchscreen_image_format()
+
+        async def _push_card_frame(frame_bytes: bytes) -> None:
+            if bg_tile is not None:
+                out_bytes = await asyncio.to_thread(
+                    composite_frame_on_tile,
+                    frame_bytes,
+                    bg_tile_bytes=bg_tile,
+                    panel_width=panel_width,
+                    panel_height=panel_height,
+                    image_format=image_fmt,
+                )
+            else:
+                out_bytes = frame_bytes
+            async with deck._device_lock:
+                await deck._exec_device_io(
+                    deck._device.set_partial_window_image,  # type: ignore[union-attr]
+                    x_pos,
+                    y_pos,
+                    panel_width,
+                    panel_height,
+                    out_bytes,
+                )
+
+        return _push_card_frame
+
+    async def _setup_card(
+        self,
+        card_idx: int,
+        card: Card,
+        bg_tile: bytes | None,
+        bg_svg_root: Any,
+        panel_width: int,
+        panel_height: int,
+    ) -> bool:
+        """Configure a card's background layer and animation push hook.
+
+        For :class:`DuiCard` instances, this installs the background
+        tile, wires (or clears) the SVG background layer, and registers
+        a ``push_fn`` for spinner animations.
+
+        Parameters
+        ----------
+        card_idx : int
+            Index of the card on the touch strip.
+        card : Card
+            The card to set up.
+        bg_tile : bytes | None
+            Encoded background tile for this card slot, if any.
+        bg_svg_root : Any
+            Touch strip's root SVG element for background compositing,
+            or ``None`` if no background is configured.
+        panel_width, panel_height : int
+            Panel dimensions in pixels.
+
+        Returns
+        -------
+        bool
+            ``True`` if the card should be rendered this cycle (i.e. it
+            is dirty and not currently animating); ``False`` otherwise.
+        """
+        from ..dui.card import DuiCard
+
+        if isinstance(card, DuiCard):
+            card.set_bg_tile(bg_tile)
+
+            if bg_svg_root is not None:
+                card.set_background_layer(
+                    bg_svg_root,
+                    card_idx,
+                    panel_width,
+                    panel_height,
+                )
+            else:
+                card.clear_background_layer()
+
+            push_fn = self._make_card_push_fn(
+                card_idx, panel_width, panel_height, bg_tile
+            )
+            card.set_push_fn(push_fn, panel_size=(panel_width, panel_height))
+
+            if self.is_animating(card):
+                return False
+
+        return card.is_dirty
+
+    async def _push_card(
+        self, card_idx: int, panel_bytes: bytes, panel_width: int, panel_height: int
+    ) -> None:
+        """Push a rendered panel to the touchscreen at the given slot.
+
+        The caller is responsible for holding the deck's device lock.
+
+        Parameters
+        ----------
+        card_idx : int
+            Index of the card on the touch strip (0-based).
+        panel_bytes : bytes
+            Encoded panel image to send to the device.
+        panel_width, panel_height : int
+            Panel dimensions in pixels.
+        """
+        deck = self._deck
+        x_pos = card_idx * panel_width
+        y_pos = 0
+        await deck._exec_device_io(
+            deck._device.set_partial_window_image,  # type: ignore[union-attr]
+            x_pos,
+            y_pos,
+            panel_width,
+            panel_height,
+            panel_bytes,
+        )
+
     async def render_touchscreen(self) -> None:
         """Render and push each card panel individually to the device.
 
@@ -283,108 +441,35 @@ class DeckRenderer:
 
         metrics = deck._metrics
         touch_strip = screen.touch_strip
-
-        from ..dui.card import DuiCard
-
         bg_svg_root = touch_strip.bg_svg_root
 
         # Phase 1: set up cards (push_fn wiring, background layers)
         cards_to_render: list[tuple[int, Card, bytes | None]] = []
-
         for card_idx, card in enumerate(screen.cards):
             bg_tile = touch_strip.bg_tile(card_idx)
+            should_render = await self._setup_card(
+                card_idx,
+                card,
+                bg_tile,
+                bg_svg_root,
+                metrics.panel_width,
+                metrics.panel_height,
+            )
+            if should_render:
+                cards_to_render.append((card_idx, card, bg_tile))
 
-            if isinstance(card, DuiCard):
-                # Set up background layer for SVG-level compositing
-                card.set_bg_tile(bg_tile)
-
-                if bg_svg_root is not None:
-                    card.set_background_layer(
-                        bg_svg_root,
-                        card_idx,
-                        metrics.panel_width,
-                        metrics.panel_height,
-                    )
-                else:
-                    card.clear_background_layer()
-
-                # Wire push_fn for spinner animations (per-panel update)
-                x_pos = card_idx * metrics.panel_width
-                y_pos = 0
-
-                async def _make_push(
-                    x: int,
-                    y: int,
-                    w: int,
-                    h: int,
-                    tile: bytes | None,
-                ) -> PushFn:
-                    async def _push_card_frame(frame_bytes: bytes) -> None:
-                        if tile is not None:
-                            # Composite frame onto bg tile.
-                            from ..render.touch_renderer import composite_frame_on_tile
-
-                            def _compose(fb: bytes = frame_bytes) -> bytes:
-                                return composite_frame_on_tile(
-                                    fb,
-                                    bg_tile_bytes=tile,
-                                    panel_width=w,
-                                    panel_height=h,
-                                    image_format=(
-                                        deck._caps.touchscreen_image_format
-                                        if deck._caps
-                                        else "JPEG"
-                                    ),
-                                )
-
-                            out_bytes = await asyncio.to_thread(_compose)
-                        else:
-                            out_bytes = frame_bytes
-                        async with deck._device_lock:
-                            await deck._exec_device_io(
-                                deck._device.set_partial_window_image,  # type: ignore[union-attr]
-                                x,
-                                y,
-                                w,
-                                h,
-                                out_bytes,
-                            )
-
-                    return _push_card_frame
-
-                push_fn = await _make_push(
-                    x_pos,
-                    y_pos,
-                    metrics.panel_width,
-                    metrics.panel_height,
-                    bg_tile,
-                )
-                card.set_push_fn(
-                    push_fn, panel_size=(metrics.panel_width, metrics.panel_height)
-                )
-
-                # Skip re-rendering cards with active spinner animations
-                if self.is_animating(card):
-                    continue
-
-            # Only render cards that actually need updating.
-            if not card.is_dirty:
-                continue
-
-            cards_to_render.append((card_idx, card, bg_tile))
-
-        # Phase 2: prepare assets and render all cards concurrently
-        # Frame budget: skip render+push if called too soon after the last
-        # render.  The push_fn wiring above must still run every call so
-        # that spinner animations target the correct panel slot.
+        # Phase 2: frame budget.  push_fn wiring above must still run on
+        # every call so that spinner animations target the correct slot,
+        # but actual render/push is throttled.
         now = time.perf_counter()
         if now - self._last_touch_render < self._MIN_TOUCH_INTERVAL:
             return
         self._last_touch_render = now
 
-        image_fmt = (
-            deck._caps.touchscreen_image_format if deck._caps else "JPEG"
-        )
+        if not cards_to_render:
+            return
+
+        image_fmt = self._touchscreen_image_format()
 
         async def _render_card(
             cidx: int, crd: Card, tile: bytes | None
@@ -400,59 +485,23 @@ class DeckRenderer:
             )
             return (cidx, panel_bytes)
 
-        if cards_to_render:
-            prof = RenderProfiler("render_touchscreen")
-            if len(cards_to_render) == 1:
-                # Fast path: render and push a single dirty card without
-                # the overhead of asyncio.gather.
-                cidx, crd, tile = cards_to_render[0]
-                with prof.step("prepare_assets"):
-                    await crd.prepare_assets()
-                with prof.step("render_card"):
-                    panel_bytes = await asyncio.to_thread(
-                        crd.render_panel_bytes,
-                        metrics=metrics,
-                        card_index=cidx,
-                        bg_tile=tile,
-                        background=touch_strip.background_color,
-                        image_format=image_fmt,
-                    )
-                x_pos = cidx * metrics.panel_width
-                y_pos = 0
-                with prof.step("push_to_device"):
-                    async with deck._device_lock:
-                        await deck._exec_device_io(
-                            deck._device.set_partial_window_image,
-                            x_pos,
-                            y_pos,
-                            metrics.panel_width,
-                            metrics.panel_height,
-                            panel_bytes,
-                        )
-                prof.finish()
-                prof.log()
-            else:
-                with prof.step("render_cards"):
-                    results = await asyncio.gather(
-                        *[_render_card(cidx, crd, tile) for cidx, crd, tile in cards_to_render]
-                    )
+        # Phase 3: render all dirty cards concurrently, then push under a
+        # single device lock.  A single card still benefits from this
+        # path: asyncio.gather of one task adds negligible overhead.
+        prof = RenderProfiler("render_touchscreen")
+        with prof.step("render_cards"):
+            results = await asyncio.gather(
+                *[_render_card(cidx, crd, tile) for cidx, crd, tile in cards_to_render]
+            )
 
-                # Phase 3: push all panels to device under a single lock
-                with prof.step("push_to_device"):
-                    async with deck._device_lock:
-                        for cidx, panel_bytes in sorted(results, key=lambda r: r[0]):
-                            x_pos = cidx * metrics.panel_width
-                            y_pos = 0
-                            await deck._exec_device_io(
-                                deck._device.set_partial_window_image,
-                                x_pos,
-                                y_pos,
-                                metrics.panel_width,
-                                metrics.panel_height,
-                                panel_bytes,
-                            )
-                prof.finish()
-                prof.log()
+        with prof.step("push_to_device"):
+            async with deck._device_lock:
+                for cidx, panel_bytes in sorted(results, key=lambda r: r[0]):
+                    await self._push_card(
+                        cidx, panel_bytes, metrics.panel_width, metrics.panel_height
+                    )
+        prof.finish()
+        prof.log()
 
     # ------------------------------------------------------------------
     # Info-screen rendering

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -658,6 +658,114 @@ class TestDeckRenderTouchscreen:
         assert mock_streamdeck_device.set_partial_window_image.call_count == 4
 
 
+class TestDeckRendererTouchHelpers:
+    """Unit tests for the extracted touchscreen helpers on DeckRenderer."""
+
+    async def test_touchscreen_image_format_defaults_to_jpeg(self, deck):
+        """Returns JPEG when capabilities are absent."""
+        deck._caps = None
+        assert deck._renderer._touchscreen_image_format() == "JPEG"
+
+    async def test_touchscreen_image_format_uses_caps(self, deck):
+        """Returns the format declared by the device capabilities."""
+        deck._caps = STREAM_DECK_PLUS
+        assert (
+            deck._renderer._touchscreen_image_format()
+            == STREAM_DECK_PLUS.touchscreen_image_format
+        )
+
+    async def test_push_card_invokes_device_io_with_offset(
+        self, deck, mock_streamdeck_device
+    ):
+        """`_push_card` computes ``x = card_idx * panel_width`` and dispatches."""
+        deck._device = mock_streamdeck_device
+        payload = b"frame-bytes"
+        await deck._renderer._push_card(2, payload, PANEL_WIDTH, PANEL_HEIGHT)
+        mock_streamdeck_device.set_partial_window_image.assert_called_once_with(
+            2 * PANEL_WIDTH, 0, PANEL_WIDTH, PANEL_HEIGHT, payload
+        )
+
+    async def test_make_card_push_fn_pushes_frame_without_bg_tile(
+        self, deck, mock_streamdeck_device
+    ):
+        """Without a bg tile, the frame bytes are forwarded as-is."""
+        deck._device = mock_streamdeck_device
+        deck._caps = STREAM_DECK_PLUS
+        push_fn = deck._renderer._make_card_push_fn(
+            1, PANEL_WIDTH, PANEL_HEIGHT, bg_tile=None
+        )
+        frame = b"raw-frame"
+        await push_fn(frame)
+        mock_streamdeck_device.set_partial_window_image.assert_called_once_with(
+            PANEL_WIDTH, 0, PANEL_WIDTH, PANEL_HEIGHT, frame
+        )
+
+    async def test_make_card_push_fn_composites_when_bg_tile_present(
+        self, deck, mock_streamdeck_device
+    ):
+        """With a bg tile, the frame is composited before being pushed."""
+        deck._device = mock_streamdeck_device
+        deck._caps = STREAM_DECK_PLUS
+        bg_tile = _make_jpeg_frame(PANEL_WIDTH, PANEL_HEIGHT)
+        push_fn = deck._renderer._make_card_push_fn(
+            0, PANEL_WIDTH, PANEL_HEIGHT, bg_tile=bg_tile
+        )
+        frame = _make_jpeg_frame(PANEL_WIDTH, PANEL_HEIGHT)
+        with patch(
+            "deux.runtime.renderer.composite_frame_on_tile",
+            return_value=b"composited",
+        ) as mock_compose:
+            await push_fn(frame)
+        mock_compose.assert_called_once()
+        mock_streamdeck_device.set_partial_window_image.assert_called_once_with(
+            0, 0, PANEL_WIDTH, PANEL_HEIGHT, b"composited"
+        )
+
+    async def test_setup_card_non_dui_card_returns_dirty_flag(self, deck):
+        """Non-DUI cards skip background wiring and return ``is_dirty``."""
+        card = _TestCard()
+        # Force dirty=False to verify it propagates.
+        card._dirty = False  # type: ignore[attr-defined]
+        should_render = await deck._renderer._setup_card(
+            0, card, None, None, PANEL_WIDTH, PANEL_HEIGHT
+        )
+        assert should_render is False
+
+    async def test_setup_card_dui_card_animating_returns_false(self, deck):
+        """A DuiCard with an active animation is not re-rendered."""
+        from deux.dui.card import DuiCard
+
+        card = MagicMock(spec=DuiCard)
+        card.is_animating = True
+        card.is_dirty = True
+        should_render = await deck._renderer._setup_card(
+            0, card, None, None, PANEL_WIDTH, PANEL_HEIGHT
+        )
+        # Background layer cleared (no bg_svg_root) and push_fn wired.
+        card.set_bg_tile.assert_called_once_with(None)
+        card.clear_background_layer.assert_called_once()
+        card.set_push_fn.assert_called_once()
+        assert should_render is False
+
+    async def test_setup_card_dui_card_wires_bg_layer(self, deck):
+        """A non-animating DuiCard wires the SVG background and reports dirty."""
+        from deux.dui.card import DuiCard
+
+        card = MagicMock(spec=DuiCard)
+        card.is_animating = False
+        card.is_dirty = True
+        bg_root = object()
+        should_render = await deck._renderer._setup_card(
+            3, card, b"tile", bg_root, PANEL_WIDTH, PANEL_HEIGHT
+        )
+        card.set_bg_tile.assert_called_once_with(b"tile")
+        card.set_background_layer.assert_called_once_with(
+            bg_root, 3, PANEL_WIDTH, PANEL_HEIGHT
+        )
+        card.clear_background_layer.assert_not_called()
+        assert should_render is True
+
+
 class TestDeckInfo:
     def test_no_device_raises(self, deck):
         with pytest.raises(DeckError, match="Device not opened"):


### PR DESCRIPTION
Closes #318.

## Issue validity

Valid. `render_touchscreen` in `src/deux/runtime/renderer.py` was 188 lines with:

- Nested async closure (`_make_push` containing `_push_card_frame` containing `_compose`).
- An inline `from ..render.touch_renderer import composite_frame_on_tile` inside the closure.
- Duplicated single-card fast path vs multi-card path (the only meaningful difference was avoiding `asyncio.gather` of a single task — marginal).
- Repeated `deck._caps.touchscreen_image_format if deck._caps else "JPEG"` lookups.

The whole function was effectively untestable as a unit.

## Fix

- Hoisted `composite_frame_on_tile` to the module-top imports.
- Extracted helpers on `DeckRenderer`:
  - `_touchscreen_image_format()` — single source of truth for the format lookup.
  - `_make_card_push_fn(card_idx, w, h, bg_tile)` — builds the per-panel `PushFn` used by spinner animations.
  - `_setup_card(card_idx, card, bg_tile, bg_svg_root, w, h)` — wires background layer and push_fn for DuiCards, returns whether the card should be rendered this cycle.
  - `_push_card(card_idx, panel_bytes, w, h)` — single panel push under the caller's device lock.
- Collapsed the single-card fast path into the general path. `asyncio.gather` on one task adds negligible overhead and removes ~30 lines of duplication.
- `render_touchscreen` is now ~80 lines with a clear three-phase structure (setup → frame-budget → render+push).

Behavior is preserved:
- push_fn wiring still runs on every call (frame-budget gate is after Phase 1).
- Panels are still pushed in card-index order under a single device lock.
- Animating cards are still skipped for render but still receive a fresh push_fn.

## Tests / checks

Added 8 focused unit tests in `TestDeckRendererTouchHelpers` covering:

- `_touchscreen_image_format` with and without capabilities.
- `_push_card` x-offset and device dispatch.
- `_make_card_push_fn` both branches (with and without bg_tile composite).
- `_setup_card` for non-DUI cards, animating DuiCards, and non-animating DuiCards with a background SVG.

Existing `TestDeckRenderTouchscreen` integration tests continue to pass.

Validation run:

- `pytest tests/ --cov=deux --cov-fail-under=95`: **1816 passed, 1 skipped**, coverage **95.62%**.
- `ruff check .`: clean.
- `mypy src/deux` (strict): no issues.