### PR TITLE
perf(dui/svg_renderer): cache parent map per render (#316)

### DIFF
--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -184,12 +184,55 @@ def _get_default_font_family() -> str:
         return _DEFAULT_FONT_FAMILY
 
 
-def _resolve_font_attrs(root: ET.Element, elem: ET.Element) -> tuple[str, float]:
+def _build_parent_map(root: ET.Element) -> dict[ET.Element, ET.Element]:
+    """Build a child-to-parent mapping for an SVG tree.
+
+    Walks the tree once and returns a dictionary mapping every child
+    element to its parent.  Use this when multiple lookups against the
+    same tree are required so the O(N) walk is amortised across all
+    callers.
+
+    Parameters
+    ----------
+    root : ET.Element
+        The SVG document root to walk.
+
+    Returns
+    -------
+    dict[ET.Element, ET.Element]
+        Mapping of each child element to its parent element.
+    """
+    parent_map: dict[ET.Element, ET.Element] = {}
+    for parent in root.iter():
+        for child in parent:
+            parent_map[child] = parent
+    return parent_map
+
+
+def _resolve_font_attrs(
+    root: ET.Element,
+    elem: ET.Element,
+    parent_map: dict[ET.Element, ET.Element] | None = None,
+) -> tuple[str, float]:
     """Resolve font-family and font-size from an SVG element and its ancestors.
 
     Walks from *elem* up through the SVG tree to find ``font-family``
     and ``font-size`` attributes.  Falls back to sensible defaults if
     neither the element nor any ancestor declares them.
+
+    Parameters
+    ----------
+    root : ET.Element
+        The SVG document root.  Used to build the parent map when one
+        is not supplied.
+    elem : ET.Element
+        The element whose font attributes are being resolved.
+    parent_map : dict[ET.Element, ET.Element] or None, optional
+        Pre-built child-to-parent mapping for *root*.  When omitted,
+        the map is rebuilt on every call (O(N) per call).  Callers that
+        resolve fonts for multiple elements against the same tree
+        should build the map once via :func:`_build_parent_map` and
+        pass it in to avoid an O(N*M) cost.
 
     Returns
     -------
@@ -199,10 +242,8 @@ def _resolve_font_attrs(root: ET.Element, elem: ET.Element) -> tuple[str, float]
     family: str | None = None
     size: float | None = None
 
-    parent_map: dict[ET.Element, ET.Element] = {}
-    for parent in root.iter():
-        for child in parent:
-            parent_map[child] = parent
+    if parent_map is None:
+        parent_map = _build_parent_map(root)
 
     current: ET.Element | None = elem
     while current is not None:
@@ -471,6 +512,14 @@ class SvgRenderer:
         self._target_width: int | None = None
         self._target_height: int | None = None
         self._rendering_ctx: RenderingContext | None = None
+        # Per-render cache of the child→parent map for the currently rendered
+        # tree.  Populated lazily by :meth:`_get_parent_map` during a render
+        # pass and reset to ``None`` between renders so that mutations done by
+        # bindings (e.g. wrapped-text ``<tspan>`` children) don't poison later
+        # renders.  Caching it here keeps font-attribute resolution at O(N)
+        # per render instead of O(N*M) for M text bindings.
+        self._parent_map_root: ET.Element | None = None
+        self._parent_map_cache: dict[ET.Element, ET.Element] | None = None
 
         for name, binding in spec.bindings.items():
             if isinstance(binding, (TextBinding, VisibilityBinding, ColorBinding, CssClassBinding)):
@@ -712,6 +761,39 @@ class SvgRenderer:
         """
         self._base_root = copy.deepcopy(self._original_root)
 
+    def _get_parent_map(self, root: ET.Element) -> dict[ET.Element, ET.Element]:
+        """Return a cached child→parent map for *root* for the current render.
+
+        The map is rebuilt only when *root* differs from the previously
+        cached tree (i.e. at the start of a new render pass).  Subsequent
+        calls within the same render reuse the cached map, avoiding the
+        O(N) walk per text-binding that was the dominant cost of dense
+        cards with multiple text bindings.
+
+        Parameters
+        ----------
+        root : ET.Element
+            The root of the SVG tree currently being rendered.
+
+        Returns
+        -------
+        dict[ET.Element, ET.Element]
+            Mapping of each child element to its parent element.
+        """
+        if self._parent_map_root is not root or self._parent_map_cache is None:
+            self._parent_map_root = root
+            self._parent_map_cache = _build_parent_map(root)
+        return self._parent_map_cache
+
+    def _reset_parent_map_cache(self) -> None:
+        """Drop the cached parent map.
+
+        Called at the start of each render so that the map is rebuilt
+        for the freshly cloned tree.
+        """
+        self._parent_map_root = None
+        self._parent_map_cache = None
+
     def render(self) -> Image.Image:
         """Rasterise the SVG with current binding values to a PIL Image.
 
@@ -724,6 +806,7 @@ class SvgRenderer:
             native dimensions.
         """
         root = copy.deepcopy(self._base_root)
+        self._reset_parent_map_cache()
 
         for name, binding in self._spec.bindings.items():
             value = self._values.get(name)
@@ -773,6 +856,7 @@ class SvgRenderer:
         )
 
         root = copy.deepcopy(self._base_root)
+        self._reset_parent_map_cache()
 
         for name, binding in self._spec.bindings.items():
             value = self._values.get(name)
@@ -816,6 +900,7 @@ class SvgRenderer:
             SVG markup as a Unicode string.
         """
         root = copy.deepcopy(self._base_root)
+        self._reset_parent_map_cache()
 
         for name, binding in self._spec.bindings.items():
             value = self._values.get(name)
@@ -960,7 +1045,7 @@ class SvgRenderer:
             return
 
         if binding.max_width is not None:
-            family, size_f = _resolve_font_attrs(root, elem)
+            family, size_f = _resolve_font_attrs(root, elem, self._get_parent_map(root))
             font = _load_font(family, int(size_f))
             text = _truncate_text(text, binding.max_width, binding.overflow, font=font)
         elem.text = text
@@ -978,7 +1063,7 @@ class SvgRenderer:
         attribute so that ``text-anchor`` alignment is respected on
         every line.
         """
-        family, size_f = _resolve_font_attrs(root, elem)
+        family, size_f = _resolve_font_attrs(root, elem, self._get_parent_map(root))
         font = _load_font(family, int(size_f))
 
         line_height = binding.line_height or (size_f * _DEFAULT_LINE_HEIGHT_RATIO)

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -1235,6 +1235,97 @@ class TestResolveFontAttrs:
         assert family == "Courier"
         assert size == 20.0
 
+    def test_accepts_prebuilt_parent_map(self):
+        import xml.etree.ElementTree as ET
+
+        from deux.dui.svg_renderer import _build_parent_map, _find_element_by_id
+
+        root = ET.fromstring(_WRAP_SVG)
+        elem = _find_element_by_id(root, "label")
+        parent_map = _build_parent_map(root)
+        family, size = _resolve_font_attrs(root, elem, parent_map)
+        assert family == "DejaVu Sans"
+        assert size == 15.0
+
+
+class TestParentMapCaching:
+    """Verify the per-render parent-map cache avoids O(N*M) rebuilds."""
+
+    def test_build_parent_map_walks_tree_once(self):
+        import xml.etree.ElementTree as ET
+
+        from deux.dui.svg_renderer import _build_parent_map
+
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<g id="outer"><g id="inner"><text id="t">x</text></g></g>'
+            "</svg>"
+        )
+        root = ET.fromstring(svg)
+        parent_map = _build_parent_map(root)
+        outer = root.find("{http://www.w3.org/2000/svg}g")
+        assert outer is not None
+        inner = outer.find("{http://www.w3.org/2000/svg}g")
+        assert inner is not None
+        text = inner.find("{http://www.w3.org/2000/svg}text")
+        assert text is not None
+        assert parent_map[outer] is root
+        assert parent_map[inner] is outer
+        assert parent_map[text] is inner
+
+    def test_render_builds_parent_map_once_per_render(self, monkeypatch, tmp_path):
+        """Multiple text bindings in one render share a single parent map build."""
+        from deux.dui import svg_renderer as svg_renderer_mod
+
+        # Build a minimal package with multiple text bindings against the
+        # same SVG tree.  Each text binding has max_width set so that
+        # _resolve_font_attrs (and thus the parent map) is invoked.
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" '
+            'font-family="DejaVu Sans" font-size="12">'
+            '<text id="t1" x="0" y="10">a</text>'
+            '<text id="t2" x="0" y="25">b</text>'
+            '<text id="t3" x="0" y="40">c</text>'
+            "</svg>"
+        )
+        from deux.dui.schema import TextBinding
+
+        spec = _make_spec(
+            svg,
+            bindings={
+                "a": TextBinding(node="t1", default="a", max_width=80),
+                "b": TextBinding(node="t2", default="b", max_width=80),
+                "c": TextBinding(node="t3", default="c", max_width=80),
+            },
+        )
+        renderer = SvgRenderer(spec)
+
+        call_count = {"n": 0}
+        real_build = svg_renderer_mod._build_parent_map
+
+        def counting_build(root):
+            call_count["n"] += 1
+            return real_build(root)
+
+        monkeypatch.setattr(svg_renderer_mod, "_build_parent_map", counting_build)
+
+        # Stub rasterise to avoid the cairosvg dependency in this test.
+        from PIL import Image as _PILImage
+
+        monkeypatch.setattr(
+            renderer, "_rasterise", lambda data: _PILImage.new("RGBA", (10, 10))
+        )
+
+        renderer.render()
+        assert call_count["n"] == 1, (
+            f"parent map rebuilt {call_count['n']} times for 3 text bindings; "
+            "expected exactly 1"
+        )
+
+        # A second render builds the map again (fresh deep-copied tree).
+        renderer.render()
+        assert call_count["n"] == 2
+
 
 class TestLoadFont:
     """Test _load_font — font loading with fallbacks."""


### PR DESCRIPTION
## Issue validity

Issue #316 is **valid and actionable**. Confirmed by inspection of `src/deux/dui/svg_renderer.py:187`: `_resolve_font_attrs` rebuilt the full element-to-parent map on every call by walking the entire SVG, and it was invoked from `_apply_text` / `_apply_wrapped_text` for every text binding on every render. Net cost was O(N*M) per frame, with the parent-map walk dominating re-renders on cards with multiple text bindings.

## Fix

- Extracted the walk into a small helper `_build_parent_map(root)`.
- `_resolve_font_attrs` now accepts an optional pre-built `parent_map`; when omitted it still builds one (backward compatible).
- `SvgRenderer` keeps a per-render cache (`_parent_map_cache`) keyed on the root element identity. The cache is reset at the start of `render()`, `render_bytes()`, and `render_svg()` so mutations from earlier renders cannot leak across calls.
- `_apply_text` and `_apply_wrapped_text` route through `_get_parent_map(root)` so the walk happens at most once per render regardless of binding count. Cost drops from O(N*M) to O(N+M).

## Tests

- Added `TestParentMapCaching` in `tests/test_dui_svg_renderer.py`:
  - `test_build_parent_map_walks_tree_once` — sanity-checks the helper.
  - `test_render_builds_parent_map_once_per_render` — patches `_build_parent_map` and asserts it is invoked **exactly once** for a render that touches 3 text bindings, and twice across two render calls.
- Extended `TestResolveFontAttrs` with `test_accepts_prebuilt_parent_map` to lock the new public-ish parameter.

## Checks run

- `uv run ruff check .` — all checks passed
- `uv run mypy src/deux` — no issues (strict)
- `uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` — 1819 passed, 1 skipped, coverage 95.64%

Closes #316