### PR TITLE
fix(deck): remove misleading except tuple in stop()

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -180,7 +180,10 @@ class Deck:
                 try:
                     await self._exec_device_io(self._device.show_logo)
                     await self._exec_device_io(self._device.close)
-                except (HidWriteTimeout, HidApiError, Exception) as e:
+                except Exception as e:
+                    # Intentional catch-all: shutdown must never raise.
+                    # Covers HidWriteTimeout/HidApiError plus any transport,
+                    # OS, or backend-specific errors surfaced during close.
                     logger.warning("Error closing device: %s", e)
             else:
                 logger.debug("Device already closed; skipping show_logo/close")


### PR DESCRIPTION
## Issue validity

Closes #320 — **valid and actionable.**

`src/deux/runtime/deck.py:183` had `except (HidWriteTimeout, HidApiError, Exception) as e:`, which is misleading (`Exception` already subsumes the two subclasses) and triggers ruff B014.

## Fix

The intent of the handler is a defensive catch-all during shutdown — `stop()` must never raise. Replaced the tuple with a plain `except Exception` and added a comment documenting the intentional catch-all (covering HidWriteTimeout / HidApiError / transport / OS / backend-specific errors).

## Checks run

- `ruff check .` — all checks passed
- `mypy src/deux` (strict) — no issues, 65 files
- `pytest tests/ --cov=deux --cov-fail-under=95` — 1819 passed, 1 skipped, coverage 95.64%

No test changes needed: the path is exercised by existing `stop()` tests, and behavior is unchanged (same exceptions caught, same log line).