### PR TITLE
Validate payload_len bounds in HID protocol parser (#325)

### DIFF
--- a/src/deux/runtime/hid/protocol.py
+++ b/src/deux/runtime/hid/protocol.py
@@ -7,9 +7,12 @@ is not supported.
 
 from __future__ import annotations
 
+import logging
 import struct
 from dataclasses import dataclass
 from enum import IntEnum
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -292,7 +295,9 @@ def parse_input_report(data: bytes) -> InputEvent | None:
     Returns
     -------
     InputEvent or None
-        A typed event, or ``None`` if the report is unrecognised.
+        A typed event, or ``None`` if the report is unrecognised or
+        malformed (e.g. the declared ``payload_len`` exceeds the actual
+        bytes available, or an encoder report has no content type byte).
     """
     if len(data) < 4:
         return None
@@ -308,6 +313,16 @@ def parse_input_report(data: bytes) -> InputEvent | None:
     command = data[0]
     payload_len = struct.unpack_from("<H", data, 1)[0]
     payload = data[3:]
+
+    # Defensive bounds check: a malformed device report (or fuzzed input)
+    # may declare a payload length larger than the bytes actually present.
+    # Reject such reports rather than silently truncating to avoid producing
+    # empty event tuples that mask buggy firmware or USB corruption.
+    if payload_len > len(payload):
+        logger.debug(
+            "Truncated HID report: declared %d, actual %d", payload_len, len(payload)
+        )
+        return None
 
     if command == InputCommand.KEY_STATE:
         states = tuple(b != 0 for b in payload[:payload_len])
@@ -331,7 +346,7 @@ def parse_input_report(data: bytes) -> InputEvent | None:
         return None
 
     if command == InputCommand.ENCODER:
-        if len(payload) < 2:
+        if len(payload) < 2 or payload_len < 2:
             return None
         content_type = payload[0]
         encoder_data = payload[1:payload_len]

--- a/tests/test_hid_protocol.py
+++ b/tests/test_hid_protocol.py
@@ -223,6 +223,40 @@ class TestParseInputReportEdgeCases:
         assert parse_input_report(b"\x00\x00") is None
         assert parse_input_report(b"") is None
 
+    def test_declared_payload_len_exceeds_actual_returns_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Reports with declared payload_len > actual payload are rejected.
+
+        Defensive bounds check: a malformed device report (or fuzzed input)
+        where ``payload_len > len(payload)`` must not be silently truncated.
+        """
+        # KEY_STATE: declared 10, only 3 actual payload bytes
+        data = _build_input(InputCommand.KEY_STATE, b"\x01\x00\x01", payload_len=10)
+        with caplog.at_level("DEBUG", logger="deux.runtime.hid.protocol"):
+            assert parse_input_report(data) is None
+        assert "Truncated HID report" in caplog.text
+
+    def test_encoder_declared_payload_len_exceeds_actual_returns_none(self) -> None:
+        """Encoder reports with declared payload_len > actual are rejected."""
+        payload = bytes([EncoderEventType.ROTATE]) + struct.pack("bb", 1, -1)
+        data = _build_input(InputCommand.ENCODER, payload, payload_len=20)
+        assert parse_input_report(data) is None
+
+    def test_encoder_payload_len_too_small_returns_none(self) -> None:
+        """Encoder reports with payload_len < 2 are rejected.
+
+        Previously these would silently emit an empty event tuple because
+        ``payload[1:payload_len]`` returned an empty slice.
+        """
+        # payload_len=1 means there's no encoder data after the content type
+        payload = bytes([EncoderEventType.ROTATE, 0x05, 0x06])
+        data = _build_input(InputCommand.ENCODER, payload, payload_len=1)
+        assert parse_input_report(data) is None
+
+        data = _build_input(InputCommand.ENCODER, payload, payload_len=0)
+        assert parse_input_report(data) is None
+
 
 class TestParseInputReportWithReportId:
     """Tests that parse_input_report handles Report ID prefix.


### PR DESCRIPTION
## Issue validity assessment

Issue #325 is **valid and actionable**. `parse_input_report` in `src/deux/runtime/hid/protocol.py` blindly trusted the `payload_len` field from the device:

- KEY_STATE: `payload[:payload_len]` silently truncated when the declared length exceeded the actual payload (or padding was stripped), masking firmware bugs / USB corruption.
- ENCODER: `payload[1:payload_len]` returned an empty slice when `payload_len <= 1`, producing empty `EncoderButtonEvent`/`EncoderRotateEvent` tuples instead of rejecting the report.

## Fix

`src/deux/runtime/hid/protocol.py`:

- Added module-level `logger`.
- After unpacking `payload_len`, validate `payload_len <= len(payload)`. On mismatch, log `logger.debug('Truncated HID report: declared %d, actual %d', ...)` and return `None`.
- For the encoder branch, also require `payload_len >= 2` so a malformed report without encoder data is rejected rather than emitting an empty tuple.
- Updated the parser's docstring to note that malformed reports return `None`.

This is the smallest correct fix: it surfaces buggy firmware / fuzzed input instead of silently producing empty events, without changing semantics for well-formed reports.

## Tests / checks run

Added three regression tests in `tests/test_hid_protocol.py`:

- `test_declared_payload_len_exceeds_actual_returns_none` — KEY_STATE with declared > actual is rejected and the debug log is emitted.
- `test_encoder_declared_payload_len_exceeds_actual_returns_none` — ENCODER with declared > actual is rejected.
- `test_encoder_payload_len_too_small_returns_none` — ENCODER with `payload_len` of 0 or 1 is rejected (previously emitted empty tuples).

Validation:

- `uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` -> **1822 passed**, 1 skipped, coverage **95.64%** (gate met).
- `uv run ruff check .` -> **All checks passed**.
- `uv run mypy src/deux` -> **Success: no issues found in 65 source files** (strict mode).

Closes #325.