### PR TITLE
refactor(render): encapsulate SVG rasteriser globals in holder classes (#311)

### DIFF
--- a/src/deux/render/context.py
+++ b/src/deux/render/context.py
@@ -39,7 +39,7 @@ class RenderingContext:
         "use the system-wide default".
     stylesheet : str or None
         CSS stylesheet text derived from *theme*.  When set, this
-        overrides the module-level ``_active_stylesheet`` in
+        overrides the module-level ``_stylesheet`` holder in
         :mod:`~deux.render.svg_rasterize` for the duration of the
         render.
 

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -47,12 +47,96 @@ class RasterizeError(DeuxError):
 #: Maximum number of rasterised images to keep in the LRU cache.
 _SVG_CACHE_MAX_SIZE: int = 128
 
-_svg_image_cache: OrderedDict[tuple[bytes, int, int, str], bytes] = OrderedDict()
-_svg_image_cache_lock = threading.Lock()
 
-#: Cache hit/miss counters for diagnostics.
-_svg_cache_hits: int = 0
-_svg_cache_misses: int = 0
+class _SvgRasterCache:
+    """Thread-safe LRU cache for rasterised SVG output.
+
+    Encapsulates the cache storage, lock, hit/miss counters, and size
+    bound previously held as module-level globals.  Tests may construct
+    a fresh instance for isolation, but production code uses the
+    module-level singleton :data:`_raster_cache`.
+
+    Parameters
+    ----------
+    max_size : int, default=:data:`_SVG_CACHE_MAX_SIZE`
+        Maximum number of cached entries before LRU eviction kicks in.
+
+    Attributes
+    ----------
+    max_size : int
+        Configured maximum cache size.
+    """
+
+    def __init__(self, max_size: int = _SVG_CACHE_MAX_SIZE) -> None:
+        self.max_size = max_size
+        self._store: OrderedDict[tuple[bytes, int, int, str], bytes] = OrderedDict()
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._misses = 0
+
+    def get(self, key: tuple[bytes, int, int, str]) -> bytes | None:
+        """Look up a cached entry, updating LRU order and hit counter on success.
+
+        Parameters
+        ----------
+        key : tuple[bytes, int, int, str]
+            Cache key from :func:`_svg_cache_key`.
+
+        Returns
+        -------
+        bytes or None
+            Cached image bytes, or ``None`` on a miss.
+        """
+        with self._lock:
+            value = self._store.get(key)
+            if value is not None:
+                self._store.move_to_end(key)
+                self._hits += 1
+                return value
+        return None
+
+    def put(self, key: tuple[bytes, int, int, str], value: bytes) -> None:
+        """Store an entry, evicting the LRU element if ``max_size`` is exceeded.
+
+        Parameters
+        ----------
+        key : tuple[bytes, int, int, str]
+            Cache key from :func:`_svg_cache_key`.
+        value : bytes
+            Serialised image bytes to cache.
+        """
+        with self._lock:
+            self._store[key] = value
+            self._store.move_to_end(key)
+            self._misses += 1
+            while len(self._store) > self.max_size:
+                self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        """Drop all entries and reset hit/miss counters."""
+        with self._lock:
+            self._store.clear()
+            self._hits = 0
+            self._misses = 0
+
+    def stats(self) -> dict[str, int]:
+        """Return a snapshot of size, hit, and miss counters.
+
+        Returns
+        -------
+        dict[str, int]
+            Dictionary with ``"size"``, ``"hits"``, and ``"misses"`` keys.
+        """
+        with self._lock:
+            return {
+                "size": len(self._store),
+                "hits": self._hits,
+                "misses": self._misses,
+            }
+
+
+#: Module-level singleton used by the public rasterisation entry points.
+_raster_cache = _SvgRasterCache()
 
 
 def _svg_cache_key(
@@ -89,9 +173,9 @@ def _svg_cache_key(
 
 
 def _svg_cache_get(key: tuple[bytes, int, int, str]) -> bytes | None:
-    """Look up a cached rasterisation result.
+    """Look up a cached rasterisation result in the module-level cache.
 
-    Moves the entry to the end of the LRU on hit.
+    Thin wrapper around :meth:`_SvgRasterCache.get` on :data:`_raster_cache`.
 
     Parameters
     ----------
@@ -103,21 +187,13 @@ def _svg_cache_get(key: tuple[bytes, int, int, str]) -> bytes | None:
     bytes or None
         Cached image bytes, or ``None`` on a miss.
     """
-    global _svg_cache_hits  # noqa: PLW0603
-    with _svg_image_cache_lock:
-        value = _svg_image_cache.get(key)
-        if value is not None:
-            _svg_image_cache.move_to_end(key)
-            _svg_cache_hits += 1
-            return value
-    return None
+    return _raster_cache.get(key)
 
 
 def _svg_cache_put(key: tuple[bytes, int, int, str], value: bytes) -> None:
-    """Store a rasterisation result in the cache.
+    """Store a rasterisation result in the module-level cache.
 
-    Evicts the least-recently-used entry when the cache exceeds
-    :data:`_SVG_CACHE_MAX_SIZE`.
+    Thin wrapper around :meth:`_SvgRasterCache.put` on :data:`_raster_cache`.
 
     Parameters
     ----------
@@ -126,13 +202,7 @@ def _svg_cache_put(key: tuple[bytes, int, int, str], value: bytes) -> None:
     value : bytes
         Serialised image bytes to cache.
     """
-    global _svg_cache_misses  # noqa: PLW0603
-    with _svg_image_cache_lock:
-        _svg_image_cache[key] = value
-        _svg_image_cache.move_to_end(key)
-        _svg_cache_misses += 1
-        while len(_svg_image_cache) > _SVG_CACHE_MAX_SIZE:
-            _svg_image_cache.popitem(last=False)
+    _raster_cache.put(key, value)
 
 
 def clear_svg_cache() -> None:
@@ -142,11 +212,7 @@ def clear_svg_cache() -> None:
     counters.  Call this after changing the global stylesheet or
     theme to ensure stale images are not served.
     """
-    global _svg_cache_hits, _svg_cache_misses  # noqa: PLW0603
-    with _svg_image_cache_lock:
-        _svg_image_cache.clear()
-        _svg_cache_hits = 0
-        _svg_cache_misses = 0
+    _raster_cache.clear()
     logger.debug("SVG rasterisation cache cleared")
 
 
@@ -158,12 +224,7 @@ def svg_cache_stats() -> dict[str, int]:
     dict[str, int]
         Dictionary with ``"size"``, ``"hits"``, and ``"misses"`` keys.
     """
-    with _svg_image_cache_lock:
-        return {
-            "size": len(_svg_image_cache),
-            "hits": _svg_cache_hits,
-            "misses": _svg_cache_misses,
-        }
+    return _raster_cache.stats()
 
 
 # ---------------------------------------------------------------------------
@@ -324,7 +385,27 @@ def _resvg_rasterize_rgba(
 # Application-wide CSS stylesheet
 # ---------------------------------------------------------------------------
 
-_active_stylesheet: str | None = None
+class _StylesheetHolder:
+    """Holder for the application-wide CSS stylesheet override.
+
+    Encapsulates the previously module-level ``_active_stylesheet``
+    global so that callers (and tests) interact with an explicit
+    object rather than rebinding a module attribute.
+
+    Attributes
+    ----------
+    css : str or None
+        Current stylesheet text, or ``None`` if none is active.
+    """
+
+    __slots__ = ("css",)
+
+    def __init__(self) -> None:
+        self.css: str | None = None
+
+
+#: Module-level singleton tracking the active application-wide stylesheet.
+_stylesheet = _StylesheetHolder()
 
 
 def set_svg_stylesheet(css: str | None) -> None:
@@ -350,10 +431,9 @@ def set_svg_stylesheet(css: str | None) -> None:
 
         set_svg_stylesheet(\"\"\".text-primary { color: #ff0000; }\"\"\")
     """
-    global _active_stylesheet  # noqa: PLW0603
-    if css == _active_stylesheet:
+    if css == _stylesheet.css:
         return
-    _active_stylesheet = css
+    _stylesheet.css = css
     clear_svg_cache()
     logger.debug(
         "SVG stylesheet %s",
@@ -370,7 +450,7 @@ def get_svg_stylesheet() -> str | None:
         The CSS text set via :func:`set_svg_stylesheet`, or ``None``
         if no stylesheet is active.
     """
-    return _active_stylesheet
+    return _stylesheet.css
 
 
 def load_svg_stylesheet(path: str | Path) -> None:
@@ -482,7 +562,7 @@ def _svg_to_png(
     RasterizeError
         If resvg is not available or rasterisation fails.
     """
-    css = ctx.resolve_stylesheet() if ctx is not None else _active_stylesheet
+    css = ctx.resolve_stylesheet() if ctx is not None else _stylesheet.css
 
     t0 = time.perf_counter()
     if css is not None:
@@ -537,7 +617,7 @@ def _svg_to_image(
     """
     from PIL import Image
 
-    css = ctx.resolve_stylesheet() if ctx is not None else _active_stylesheet
+    css = ctx.resolve_stylesheet() if ctx is not None else _stylesheet.css
 
     t0 = time.perf_counter()
 
@@ -621,7 +701,7 @@ def _rasterize_svg(
     if fmt not in ("png", "jpeg", "bmp"):
         raise ValueError(f"Unsupported output format: {output_format!r}")
 
-    css = ctx.resolve_stylesheet() if ctx is not None else _active_stylesheet
+    css = ctx.resolve_stylesheet() if ctx is not None else _stylesheet.css
     cache_key = _svg_cache_key(svg_data, width, height, f"raster:{fmt}:{quality}", css)
     cached = _svg_cache_get(cache_key)
     if cached is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from deux.ui.screen import Screen
 from deux.ui.touch_strip import TouchStrip
 
 # Capture pristine state BEFORE any test modules are imported.
-_PRISTINE_ACTIVE_STYLESHEET: str | None = _svg_mod._active_stylesheet
+_PRISTINE_ACTIVE_STYLESHEET: str | None = _svg_mod._stylesheet.css
 _PRISTINE_ACTIVE_THEME = _theme_mod._active_theme
 
 if TYPE_CHECKING:
@@ -36,10 +36,10 @@ def _reset_svg_state():
     Restores the pristine state captured at conftest import time.
     Also resets ``_active_theme`` to prevent cross-test state bleed.
     """
-    _svg_mod._active_stylesheet = _PRISTINE_ACTIVE_STYLESHEET
+    _svg_mod._stylesheet.css = _PRISTINE_ACTIVE_STYLESHEET
     _theme_mod._active_theme = _PRISTINE_ACTIVE_THEME
     yield
-    _svg_mod._active_stylesheet = _PRISTINE_ACTIVE_STYLESHEET
+    _svg_mod._stylesheet.css = _PRISTINE_ACTIVE_STYLESHEET
     _theme_mod._active_theme = _PRISTINE_ACTIVE_THEME
 
 

--- a/tests/test_rendering_context.py
+++ b/tests/test_rendering_context.py
@@ -47,26 +47,26 @@ class TestContextIsolation:
         """_svg_to_png with ctx= does not read or modify global stylesheet."""
         import deux.render.svg_rasterize as svg_mod
 
-        original_stylesheet = svg_mod._active_stylesheet
+        original_stylesheet = svg_mod._stylesheet.css
 
         theme = Theme.from_color(255, 0, 0)
         _ctx = RenderingContext.from_theme(theme)
 
         # The global should remain unchanged after creating a context.
-        assert svg_mod._active_stylesheet == original_stylesheet
+        assert svg_mod._stylesheet.css == original_stylesheet
         assert _ctx.resolve_stylesheet() == theme.css
 
     def test_rasterize_svg_with_context_does_not_mutate_global(self):
         """_rasterize_svg with ctx= does not read or modify global stylesheet."""
         import deux.render.svg_rasterize as svg_mod
 
-        original_stylesheet = svg_mod._active_stylesheet
+        original_stylesheet = svg_mod._stylesheet.css
 
         theme = Theme.from_color(0, 255, 0)
         _ctx = RenderingContext.from_theme(theme)
 
         # The global should remain unchanged.
-        assert svg_mod._active_stylesheet == original_stylesheet
+        assert svg_mod._stylesheet.css == original_stylesheet
         assert _ctx.resolve_stylesheet() == theme.css
 
 

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -31,12 +31,12 @@ def _fake_png(width: int = 10, height: int = 10) -> bytes:
 @pytest.fixture(autouse=True)
 def _reset_stylesheet():
     """Reset stylesheet and cached usvg options before/after each test."""
-    original_stylesheet = svg_mod._active_stylesheet
+    original_stylesheet = svg_mod._stylesheet.css
     # Clear thread-local usvg opts cache so each test gets fresh mocks
     original_opts = getattr(svg_mod._thread_local, "usvg_opts", None)
     svg_mod._thread_local.usvg_opts = None
     yield
-    svg_mod._active_stylesheet = original_stylesheet
+    svg_mod._stylesheet.css = original_stylesheet
     svg_mod._thread_local.usvg_opts = original_opts
 
 
@@ -165,7 +165,7 @@ class TestSvgStylesheet:
 
     def test_default_stylesheet_is_none(self):
         """No stylesheet is active by default."""
-        svg_mod._active_stylesheet = None
+        svg_mod._stylesheet.css = None
         assert get_svg_stylesheet() is None
 
     def test_set_and_get_stylesheet(self):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -31,10 +31,10 @@ from deux.ui.screen import Screen
 def _reset_theme():
     """Reset theme state before/after each test."""
     original = theme_mod._active_theme
-    original_css = svg_mod._active_stylesheet
+    original_css = svg_mod._stylesheet.css
     yield
     theme_mod._active_theme = original
-    svg_mod._active_stylesheet = original_css
+    svg_mod._stylesheet.css = original_css
 
 
 # ---------------------------------------------------------------------------
@@ -324,7 +324,7 @@ class TestActiveTheme:
     def test_set_active_theme_updates_stylesheet(self):
         custom = Theme.from_color(255, 0, 0)
         set_active_theme(custom)
-        assert svg_mod._active_stylesheet == custom.css
+        assert svg_mod._stylesheet.css == custom.css
 
     def test_set_active_theme_none_resets_to_default(self):
         set_active_theme(Theme.from_color(255, 0, 0))


### PR DESCRIPTION
Closes #311.

## Issue validity

Valid and actionable. `src/deux/render/svg_rasterize.py` exposed five
mutable module-level globals (`_svg_image_cache`,
`_svg_image_cache_lock`, `_svg_cache_hits`, `_svg_cache_misses`,
`_active_stylesheet`) plus three `# noqa: PLW0603` suppressions and
matching `global` statements. This complicates test isolation and
muddies ownership of the rasteriser's runtime state.

## Fix

- Introduce `_SvgRasterCache` holding the `OrderedDict` store, lock,
  hit/miss counters, and `max_size` bound, with `get`/`put`/`clear`/`stats`
  methods.
- Introduce `_StylesheetHolder` with a single `css` slot for the
  application-wide stylesheet override.
- Replace module-level globals with the singletons `_raster_cache` and
  `_stylesheet`; `_svg_cache_get`/`_svg_cache_put`/`clear_svg_cache`/
  `svg_cache_stats`/`set_svg_stylesheet`/`get_svg_stylesheet` become
  thin wrappers.
- Drop all three `global` statements and `# noqa: PLW0603` comments.
- Update `RenderingContext` docstring and the four tests that reached
  into `svg_mod._active_stylesheet` to mutate `svg_mod._stylesheet.css`
  on the holder instead. No public API changed.

## Checks run

- `uv run ruff check .` — clean
- `uv run mypy src/deux/` — clean (65 files)
- `uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` —
  **1822 passed, 1 skipped**, coverage **95.63%**
