### PR TITLE
refactor(render): extract _prepare_svg_tree to dedupe rasterise paths

### DIFF
--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -265,6 +265,55 @@ def _get_usvg_opts() -> _usvg_mod.Options:
     return opts
 
 
+def _prepare_svg_tree(svg_data: bytes, width: int, height: int) -> _usvg_mod.Tree:
+    """Normalise SVG bytes and parse them into a ``usvg.Tree``.
+
+    Performs the shared preparation steps used by both PNG and RGBA
+    rasterisation paths: ensures a ``viewBox`` is present (preserving
+    the original design dimensions), sets the target ``width`` and
+    ``height`` attributes so resvg scales vector content correctly,
+    registers SVG namespaces to avoid ``ns0:`` prefixes, serialises
+    the tree back to text, and constructs a :class:`usvg.Tree`.
+
+    Parameters
+    ----------
+    svg_data : bytes
+        Raw SVG content.
+    width : int
+        Desired output width in pixels.
+    height : int
+        Desired output height in pixels.
+
+    Returns
+    -------
+    usvg.Tree
+        Parsed micro-SVG tree ready for rasterisation.
+
+    Raises
+    ------
+    ImportError
+        If the ``resvg`` package is not installed.
+    """
+    root = safe_fromstring(svg_data)
+    if "viewBox" not in root.attrib:
+        orig_w = root.get("width", str(width))
+        orig_h = root.get("height", str(height))
+        # Strip non-numeric units (e.g. "100px" -> "100")
+        orig_w = "".join(c for c in orig_w if c.isdigit() or c == ".")
+        orig_h = "".join(c for c in orig_h if c.isdigit() or c == ".")
+        root.set("viewBox", f"0 0 {orig_w} {orig_h}")
+    root.set("width", str(width))
+    root.set("height", str(height))
+
+    ET.register_namespace("", _SVG_NS)
+    ET.register_namespace("xlink", _XLINK_NS)
+    svg_text = ET.tostring(root, encoding="unicode", xml_declaration=False)
+
+    from resvg import usvg
+
+    return usvg.Tree.from_str(svg_text, _get_usvg_opts())
+
+
 def _resvg_rasterize(svg_data: bytes, width: int, height: int) -> bytes:
     """Rasterise SVG bytes to PNG via the ``resvg`` Rust binding.
 
@@ -296,25 +345,7 @@ def _resvg_rasterize(svg_data: bytes, width: int, height: int) -> bytes:
     try:
         from resvg import render as _resvg_render
 
-        root = safe_fromstring(svg_data)
-        if "viewBox" not in root.attrib:
-            orig_w = root.get("width", str(width))
-            orig_h = root.get("height", str(height))
-            # Strip non-numeric units (e.g. "100px" -> "100")
-            orig_w = "".join(c for c in orig_w if c.isdigit() or c == ".")
-            orig_h = "".join(c for c in orig_h if c.isdigit() or c == ".")
-            root.set("viewBox", f"0 0 {orig_w} {orig_h}")
-        root.set("width", str(width))
-        root.set("height", str(height))
-
-        ET.register_namespace("", _SVG_NS)
-        ET.register_namespace("xlink", _XLINK_NS)
-        svg_text = ET.tostring(root, encoding="unicode", xml_declaration=False)
-
-        from resvg import usvg
-
-        tree = usvg.Tree.from_str(svg_text, _get_usvg_opts())
-
+        tree = _prepare_svg_tree(svg_data, width, height)
         png_bytes: bytes = _resvg_render(tree, (1.0, 0.0, 0.0, 0.0, 1.0, 0.0))
         return png_bytes
     except ImportError as exc:
@@ -355,24 +386,7 @@ def _resvg_rasterize_rgba(
     try:
         from resvg import render_rgba as _resvg_render_rgba
 
-        root = safe_fromstring(svg_data)
-        if "viewBox" not in root.attrib:
-            orig_w = root.get("width", str(width))
-            orig_h = root.get("height", str(height))
-            orig_w = "".join(c for c in orig_w if c.isdigit() or c == ".")
-            orig_h = "".join(c for c in orig_h if c.isdigit() or c == ".")
-            root.set("viewBox", f"0 0 {orig_w} {orig_h}")
-        root.set("width", str(width))
-        root.set("height", str(height))
-
-        ET.register_namespace("", _SVG_NS)
-        ET.register_namespace("xlink", _XLINK_NS)
-        svg_text = ET.tostring(root, encoding="unicode", xml_declaration=False)
-
-        from resvg import usvg
-
-        tree = usvg.Tree.from_str(svg_text, _get_usvg_opts())
-
+        tree = _prepare_svg_tree(svg_data, width, height)
         rgba_bytes, w, h = _resvg_render_rgba(tree, (1.0, 0.0, 0.0, 0.0, 1.0, 0.0))
         return bytes(rgba_bytes), w, h
     except ImportError as exc:

--- a/tests/test_svg_rasterize.py
+++ b/tests/test_svg_rasterize.py
@@ -12,6 +12,7 @@ import deux.render.svg_rasterize as svg_mod
 from deux.render.svg_rasterize import (
     RasterizeError,
     _inject_stylesheet,
+    _prepare_svg_tree,
     _resvg_rasterize,
     _svg_to_png,
     get_svg_stylesheet,
@@ -100,6 +101,54 @@ class TestResvgRasterizer:
         assert 'viewBox="0 0 100 100"' in svg_arg
         assert 'width="50"' in svg_arg
         assert 'height="50"' in svg_arg
+
+
+class TestPrepareSvgTree:
+    """Tests for the shared _prepare_svg_tree helper."""
+
+    def _patch_usvg(self) -> tuple[MagicMock, MagicMock]:
+        mock_usvg = MagicMock()
+        mock_tree = MagicMock()
+        mock_usvg.Options.default.return_value = mock_usvg
+        mock_usvg.Tree.from_str.return_value = mock_tree
+        return mock_usvg, mock_tree
+
+    def test_injects_viewbox_when_missing(self):
+        """A missing viewBox is synthesised from existing width/height."""
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="80px" height="60">'
+            b'<rect/></svg>'
+        )
+        mock_usvg, mock_tree = self._patch_usvg()
+        mock_resvg_mod = MagicMock()
+        mock_resvg_mod.usvg = mock_usvg
+
+        with patch.dict("sys.modules", {"resvg": mock_resvg_mod, "resvg.usvg": mock_usvg}):
+            result = _prepare_svg_tree(svg, 40, 30)
+
+        assert result is mock_tree
+        svg_arg = mock_usvg.Tree.from_str.call_args[0][0]
+        assert 'viewBox="0 0 80 60"' in svg_arg
+        assert 'width="40"' in svg_arg
+        assert 'height="30"' in svg_arg
+
+    def test_preserves_existing_viewbox(self):
+        """An existing viewBox is preserved, only width/height are overridden."""
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200"'
+            b' viewBox="0 0 100 100"><rect/></svg>'
+        )
+        mock_usvg, _ = self._patch_usvg()
+        mock_resvg_mod = MagicMock()
+        mock_resvg_mod.usvg = mock_usvg
+
+        with patch.dict("sys.modules", {"resvg": mock_resvg_mod, "resvg.usvg": mock_usvg}):
+            _prepare_svg_tree(svg, 75, 75)
+
+        svg_arg = mock_usvg.Tree.from_str.call_args[0][0]
+        assert 'viewBox="0 0 100 100"' in svg_arg
+        assert 'width="75"' in svg_arg
+        assert 'height="75"' in svg_arg
 
 
 class TestSvgToPng:


### PR DESCRIPTION
## Issue validity

Issue #312 is valid. `_resvg_rasterize` and `_resvg_rasterize_rgba` in `src/deux/render/svg_rasterize.py` duplicated ~30 lines of SVG normalisation (viewBox injection, namespace registration, width/height setting, serialisation, `usvg.Tree.from_str`). Only the final render call differed. This is a real maintenance hazard.

## Fix

Extract `_prepare_svg_tree(svg_data, width, height) -> usvg.Tree` that performs all the shared preparation. Both `_resvg_rasterize` and `_resvg_rasterize_rgba` now reduce to one prepare call plus their respective render variant. No behavioural change.

## Tests / checks run

- Added `TestPrepareSvgTree` covering viewBox injection (with unit stripping) and viewBox preservation.
- `uv run pytest tests/ --cov=deux --cov-fail-under=95` -> 1824 passed, 1 skipped, coverage 95.63%
- `uv run ruff check .` -> All checks passed
- `uv run mypy src/deux` -> Success: no issues found in 65 source files

Closes #312