### PR TITLE
refactor(hid): extract _build_chunked_reports helper (#314)

### DIFF
--- a/src/deux/runtime/hid/protocol.py
+++ b/src/deux/runtime/hid/protocol.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import struct
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
 
@@ -494,6 +495,45 @@ def _chunk_payload(
     return chunks
 
 
+def _build_chunked_reports(
+    payload: bytes,
+    header_size: int,
+    write_header: Callable[[bytearray, int, int, bool], None],
+) -> list[bytes]:
+    """Build a list of HID output reports by chunking ``payload``.
+
+    Encapsulates the common allocate/chunk/copy scaffold shared by every
+    image-update command. Per-command header layout is supplied via
+    ``write_header``.
+
+    Parameters
+    ----------
+    payload : bytes
+        The payload (typically JPEG image data) to split across reports.
+    header_size : int
+        Number of header bytes reserved at the start of each report; the
+        payload chunk is written immediately after.
+    write_header : Callable[[bytearray, int, int, bool], None]
+        Callback invoked for each report with
+        ``(buf, chunk_index, chunk_size, is_last)`` to populate the
+        command-specific header.
+
+    Returns
+    -------
+    list[bytes]
+        List of 1024-byte output reports ready for ``hid_write``.
+    """
+    max_data = OUTPUT_REPORT_SIZE - header_size
+    chunks = _chunk_payload(payload, max_data)
+    reports: list[bytes] = []
+    for chunk_idx, is_last, chunk_data in chunks:
+        buf = bytearray(OUTPUT_REPORT_SIZE)
+        write_header(buf, chunk_idx, len(chunk_data), is_last)
+        buf[header_size : header_size + len(chunk_data)] = chunk_data
+        reports.append(bytes(buf))
+    return reports
+
+
 def build_key_image_reports(key_index: int, jpeg_data: bytes) -> list[bytes]:
     """Build output reports for ``Update Key Image`` (command 0x07).
 
@@ -509,20 +549,16 @@ def build_key_image_reports(key_index: int, jpeg_data: bytes) -> list[bytes]:
     list[bytes]
         List of 1024-byte output reports ready for ``hid_write``.
     """
-    max_data = OUTPUT_REPORT_SIZE - _KEY_IMAGE_HEADER
-    chunks = _chunk_payload(jpeg_data, max_data)
-    reports: list[bytes] = []
-    for chunk_idx, is_last, chunk_data in chunks:
-        buf = bytearray(OUTPUT_REPORT_SIZE)
+
+    def write_header(buf: bytearray, chunk_idx: int, chunk_size: int, is_last: bool) -> None:
         buf[0] = ReportId.OUTPUT
         buf[1] = OutputCommand.UPDATE_KEY_IMAGE
         buf[2] = key_index
         buf[3] = 0x01 if is_last else 0x00
-        struct.pack_into("<H", buf, 4, len(chunk_data))
+        struct.pack_into("<H", buf, 4, chunk_size)
         struct.pack_into("<H", buf, 6, chunk_idx)
-        buf[8 : 8 + len(chunk_data)] = chunk_data
-        reports.append(bytes(buf))
-    return reports
+
+    return _build_chunked_reports(jpeg_data, _KEY_IMAGE_HEADER, write_header)
 
 
 def build_full_screen_reports(jpeg_data: bytes) -> list[bytes]:
@@ -538,20 +574,16 @@ def build_full_screen_reports(jpeg_data: bytes) -> list[bytes]:
     list[bytes]
         List of 1024-byte output reports ready for ``hid_write``.
     """
-    max_data = OUTPUT_REPORT_SIZE - _FULL_SCREEN_HEADER
-    chunks = _chunk_payload(jpeg_data, max_data)
-    reports: list[bytes] = []
-    for chunk_idx, is_last, chunk_data in chunks:
-        buf = bytearray(OUTPUT_REPORT_SIZE)
+
+    def write_header(buf: bytearray, chunk_idx: int, chunk_size: int, is_last: bool) -> None:
         buf[0] = ReportId.OUTPUT
         buf[1] = OutputCommand.UPDATE_FULL_SCREEN
         buf[2] = 0x00  # reserved
         buf[3] = 0x01 if is_last else 0x00
-        struct.pack_into("<H", buf, 4, len(chunk_data))
+        struct.pack_into("<H", buf, 4, chunk_size)
         struct.pack_into("<H", buf, 6, chunk_idx)
-        buf[8 : 8 + len(chunk_data)] = chunk_data
-        reports.append(bytes(buf))
-    return reports
+
+    return _build_chunked_reports(jpeg_data, _FULL_SCREEN_HEADER, write_header)
 
 
 def build_window_reports(jpeg_data: bytes) -> list[bytes]:
@@ -567,20 +599,16 @@ def build_window_reports(jpeg_data: bytes) -> list[bytes]:
     list[bytes]
         List of 1024-byte output reports ready for ``hid_write``.
     """
-    max_data = OUTPUT_REPORT_SIZE - _WINDOW_HEADER
-    chunks = _chunk_payload(jpeg_data, max_data)
-    reports: list[bytes] = []
-    for chunk_idx, is_last, chunk_data in chunks:
-        buf = bytearray(OUTPUT_REPORT_SIZE)
+
+    def write_header(buf: bytearray, chunk_idx: int, chunk_size: int, is_last: bool) -> None:
         buf[0] = ReportId.OUTPUT
         buf[1] = OutputCommand.UPDATE_WINDOW
         buf[2] = 0x00  # reserved
         buf[3] = 0x01 if is_last else 0x00
-        struct.pack_into("<H", buf, 4, len(chunk_data))
+        struct.pack_into("<H", buf, 4, chunk_size)
         struct.pack_into("<H", buf, 6, chunk_idx)
-        buf[8 : 8 + len(chunk_data)] = chunk_data
-        reports.append(bytes(buf))
-    return reports
+
+    return _build_chunked_reports(jpeg_data, _WINDOW_HEADER, write_header)
 
 
 def build_partial_window_reports(
@@ -606,11 +634,8 @@ def build_partial_window_reports(
     list[bytes]
         List of 1024-byte output reports ready for ``hid_write``.
     """
-    max_data = OUTPUT_REPORT_SIZE - _PARTIAL_WINDOW_HEADER
-    chunks = _chunk_payload(jpeg_data, max_data)
-    reports: list[bytes] = []
-    for chunk_idx, is_last, chunk_data in chunks:
-        buf = bytearray(OUTPUT_REPORT_SIZE)
+
+    def write_header(buf: bytearray, chunk_idx: int, chunk_size: int, is_last: bool) -> None:
         buf[0] = ReportId.OUTPUT
         buf[1] = OutputCommand.UPDATE_PARTIAL_WINDOW
         struct.pack_into("<H", buf, 2, x)
@@ -619,11 +644,10 @@ def build_partial_window_reports(
         struct.pack_into("<H", buf, 8, height)
         buf[0x0A] = 0x01 if is_last else 0x00
         struct.pack_into("<H", buf, 0x0B, chunk_idx)
-        struct.pack_into("<H", buf, 0x0D, len(chunk_data))
+        struct.pack_into("<H", buf, 0x0D, chunk_size)
         buf[0x0F] = 0x00  # reserved
-        buf[0x10 : 0x10 + len(chunk_data)] = chunk_data
-        reports.append(bytes(buf))
-    return reports
+
+    return _build_chunked_reports(jpeg_data, _PARTIAL_WINDOW_HEADER, write_header)
 
 
 def build_background_reports(bg_index: int, jpeg_data: bytes) -> list[bytes]:
@@ -648,21 +672,17 @@ def build_background_reports(bg_index: int, jpeg_data: bytes) -> list[bytes]:
     The ``Update Background`` command has chunk index and chunk contents
     size fields swapped compared to the other output commands.
     """
-    max_data = OUTPUT_REPORT_SIZE - _BACKGROUND_HEADER
-    chunks = _chunk_payload(jpeg_data, max_data)
-    reports: list[bytes] = []
-    for chunk_idx, is_last, chunk_data in chunks:
-        buf = bytearray(OUTPUT_REPORT_SIZE)
+
+    def write_header(buf: bytearray, chunk_idx: int, chunk_size: int, is_last: bool) -> None:
         buf[0] = ReportId.OUTPUT
         buf[1] = OutputCommand.UPDATE_BACKGROUND
         buf[2] = bg_index
         buf[3] = 0x01 if is_last else 0x00
         # Note: chunk_index and chunk_size are swapped vs other commands
         struct.pack_into("<H", buf, 4, chunk_idx)
-        struct.pack_into("<H", buf, 6, len(chunk_data))
-        buf[8 : 8 + len(chunk_data)] = chunk_data
-        reports.append(bytes(buf))
-    return reports
+        struct.pack_into("<H", buf, 6, chunk_size)
+
+    return _build_chunked_reports(jpeg_data, _BACKGROUND_HEADER, write_header)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue assessment

Issue #314 is **valid and actionable**. The five HID report builders in `src/deux/runtime/hid/protocol.py` (`build_key_image_reports`, `build_full_screen_reports`, `build_window_reports`, `build_partial_window_reports`, `build_background_reports`) share an identical allocate/chunk/copy scaffold; only the header layout differs. Centralizing the scaffold ensures future protocol fixes (e.g. final-chunk flag handling) apply to every command uniformly.

## Fix

- Added `_build_chunked_reports(payload, header_size, write_header)` helper that owns chunking, buffer allocation, and payload copy.
- Each public builder now defines only its command-specific `write_header` callback and delegates the rest.
- Behavior is preserved byte-for-byte: same chunk sizes, same indices, same flags, same empty-payload handling.

## Checks run

- `pytest` — 1824 passed, 1 skipped, total coverage 95.62% (gate: 95%)
- `ruff check .` — all checks passed
- `mypy src/deux` (strict) — no issues

Closes #314