### PR TITLE
refactor(dui): centralise binding default/coerce, drop handler stubs (#317)

### DIFF
--- a/src/deux/dui/schema.py
+++ b/src/deux/dui/schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 
 class PackageType(Enum):
@@ -78,6 +79,10 @@ class TextBinding:
     max_height: int | None = None
     line_height: float | None = None
 
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
+
 
 @dataclass(frozen=True, slots=True)
 class ImageBinding:
@@ -87,6 +92,14 @@ class ImageBinding:
     fit: ImageFit = ImageFit.COVER
     placeholder_node: str | None = None
 
+    # ImageBinding has no default-displayable value; renderer treats every
+    # assignment as a change (PIL Image equality is expensive/unreliable).
+    force_dirty = True
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return None
+
 
 @dataclass(frozen=True, slots=True)
 class VisibilityBinding:
@@ -94,6 +107,10 @@ class VisibilityBinding:
 
     node: str
     default: bool = True
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
 
 
 _COLOR_ATTRIBUTES: frozenset[str] = frozenset({"fill", "stroke", "color"})
@@ -115,6 +132,10 @@ class ColorBinding:
             )
             raise ValueError(msg)
 
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
+
 
 @dataclass(frozen=True, slots=True)
 class RangeBinding:
@@ -123,6 +144,10 @@ class RangeBinding:
     node: str
     default: float = 0.0
     direction: RangeDirection = RangeDirection.HORIZONTAL
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
 
 
 @dataclass(frozen=True, slots=True)
@@ -134,6 +159,10 @@ class SliderBinding:
     direction: RangeDirection = RangeDirection.HORIZONTAL
     min_pos: float = 0.0
     max_pos: float = 0.0
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,6 +176,10 @@ class ToggleBinding:
     node_on: str
     node_off: str
     default: bool = False
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,6 +199,10 @@ class IconifyBinding:
     node: str
     size: int
     default: str = ""
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
 
 
 @dataclass(frozen=True, slots=True)
@@ -214,6 +251,40 @@ class ListBinding:
     inactive_attrs: dict[str, str] = field(default_factory=dict)
     separator: str = ""
     icon_size: int = 16
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return {"items": list(self.default_items), "index": self.default_index}
+
+    def coerce(self, raw: Any, current: Any) -> Any:
+        """Merge a partial ``{"items": ..., "index": ...}`` payload into *current*.
+
+        When *raw* is a mapping containing only ``items`` or only ``index``,
+        the other half is preserved from *current*.  An ``index`` of ``-1``
+        is normalised to ``None``.  If ``items`` is provided without
+        ``index``, the existing index is clamped to the new bounds (or
+        cleared to ``None`` if the new list is empty).
+        """
+        if not isinstance(raw, dict):
+            return raw
+        base = current if isinstance(current, dict) else {"items": [], "index": None}
+        merged = dict(base)
+        if "items" in raw:
+            merged["items"] = list(raw["items"])
+        if "index" in raw:
+            merged["index"] = raw["index"]
+        # Clamp index when items changed but index wasn't explicitly set.
+        if "items" in raw and "index" not in raw:
+            items = merged["items"]
+            idx = merged["index"]
+            if idx is not None and idx != -1 and items and idx >= len(items):
+                merged["index"] = len(items) - 1
+            elif not items:
+                merged["index"] = None
+        # Normalise -1 → None.
+        if merged.get("index") == -1:
+            merged["index"] = None
+        return merged
 
 
 class TransformKind(Enum):
@@ -275,6 +346,10 @@ class TransformBinding:
     default: float = 0.0
     transforms: tuple[TransformSpec, ...] = ()
 
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
+
 
 @dataclass(frozen=True, slots=True)
 class CssClassBinding:
@@ -293,6 +368,10 @@ class CssClassBinding:
 
     node: str
     default: str = ""
+
+    def default_value(self) -> Any:
+        """Return the initial stored value for this binding."""
+        return self.default
 
 
 Binding = (

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -14,7 +14,7 @@ import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 from PIL import ImageFont
 
@@ -521,28 +521,43 @@ class SvgRenderer:
         self._parent_map_root: ET.Element | None = None
         self._parent_map_cache: dict[ET.Element, ET.Element] | None = None
 
+        # Register binding handlers as bound methods so subclasses can override
+        # ``_apply_*`` and have the override take effect without re-registering.
+        self._binding_handlers: dict[type[Binding], Callable[..., None]] = {
+            TextBinding: lambda root, elem, name, binding, value: self._apply_text(
+                root, elem, binding, value
+            ),
+            ImageBinding: lambda root, elem, name, binding, value: self._apply_image(
+                root, elem, binding, value
+            ),
+            VisibilityBinding: lambda root, elem, name, binding, value: self._apply_visibility(
+                elem, value
+            ),
+            ColorBinding: lambda root, elem, name, binding, value: self._apply_color(
+                elem, binding, value
+            ),
+            RangeBinding: lambda root, elem, name, binding, value: self._apply_range(
+                elem, name, binding, value
+            ),
+            SliderBinding: lambda root, elem, name, binding, value: self._apply_slider(
+                elem, binding, value
+            ),
+            IconifyBinding: lambda root, elem, name, binding, value: self._apply_iconify(
+                elem, binding, value
+            ),
+            ListBinding: lambda root, elem, name, binding, value: self._apply_list(
+                root, elem, binding, value
+            ),
+            TransformBinding: lambda root, elem, name, binding, value: self._apply_transform(
+                elem, binding, value
+            ),
+            CssClassBinding: lambda root, elem, name, binding, value: self._apply_css_class(
+                elem, value
+            ),
+        }
+
         for name, binding in spec.bindings.items():
-            if isinstance(binding, (TextBinding, VisibilityBinding, ColorBinding, CssClassBinding)):
-                self._values[name] = binding.default
-            elif isinstance(binding, RangeBinding):
-                self._values[name] = binding.default
-                elem = _find_element_by_id(self._base_root, binding.node)
-                if elem is not None:
-                    attr = (
-                        "width"
-                        if binding.direction == RangeDirection.HORIZONTAL
-                        else "height"
-                    )
-                    self._range_extents[name] = float(elem.get(attr, "0"))
-            elif isinstance(
-                binding, (SliderBinding, ToggleBinding, IconifyBinding, TransformBinding)
-            ):
-                self._values[name] = binding.default
-            elif isinstance(binding, ListBinding):
-                self._values[name] = {
-                    "items": list(binding.default_items),
-                    "index": binding.default_index,
-                }
+            self._values[name] = binding.default_value()
 
     def set(self, name: str, value: Any) -> bool:
         """Set a binding value.
@@ -573,37 +588,21 @@ class SvgRenderer:
 
         old = self._values.get(name)
         binding = self._spec.bindings[name]
-        if isinstance(binding, ImageBinding):
-            self._values[name] = value
+
+        # Per-binding coercion (e.g. ListBinding merges partial updates).
+        coerce = getattr(binding, "coerce", None)
+        new_value = coerce(value, old) if callable(coerce) else value
+
+        # Some bindings (e.g. images) always count as changed because their
+        # values aren't cheaply comparable.
+        if getattr(binding, "force_dirty", False):
+            self._values[name] = new_value
             return True
 
-        if isinstance(binding, ListBinding) and isinstance(value, dict):
-            current = self._values.get(name, {"items": [], "index": None})
-            merged = dict(current)
-            if "items" in value:
-                merged["items"] = list(value["items"])
-            if "index" in value:
-                merged["index"] = value["index"]
-            # Clamp index when items changed but index wasn't explicitly set.
-            if "items" in value and "index" not in value:
-                items = merged["items"]
-                idx = merged["index"]
-                if idx is not None and idx != -1 and items and idx >= len(items):
-                    merged["index"] = len(items) - 1
-                elif not items:
-                    merged["index"] = None
-            # Normalise -1 → None.
-            if merged.get("index") == -1:
-                merged["index"] = None
-            if old == merged:
-                return False
-            self._values[name] = merged
-            return True
-
-        if old == value:
+        if old == new_value:
             return False
 
-        self._values[name] = value
+        self._values[name] = new_value
         return True
 
     def set_many(self, **kwargs: Any) -> bool:
@@ -936,40 +935,9 @@ class SvgRenderer:
                 bg_elem.set("display", "none")
 
     #: Dispatch table mapping binding types to handler methods.
-    #: Each handler is called with (root, elem, name, binding, value).
-    #: To support a new binding type, register it here without modifying
-    #: ``_apply_binding`` itself.
-    _BINDING_HANDLERS: ClassVar[
-        dict[type[Binding], Callable[[SvgRenderer, ET.Element, ET.Element, str, Any, Any], None]]
-    ] = {}
-
-    @staticmethod
-    def _register_binding_handler(
-        binding_type: type[Binding],
-    ) -> Callable[
-        [Callable[[SvgRenderer, ET.Element, ET.Element, str, Any, Any], None]],
-        Callable[[SvgRenderer, ET.Element, ET.Element, str, Any, Any], None],
-    ]:
-        """Decorator to register a binding handler in the dispatch table.
-
-        Parameters
-        ----------
-        binding_type : type[Binding]
-            The binding class this handler processes.
-
-        Returns
-        -------
-        Callable
-            The decorator that registers the handler.
-        """
-
-        def decorator(
-            func: Callable[[SvgRenderer, ET.Element, ET.Element, str, Any, Any], None],
-        ) -> Callable[[SvgRenderer, ET.Element, ET.Element, str, Any, Any], None]:
-            SvgRenderer._BINDING_HANDLERS[binding_type] = func
-            return func
-
-        return decorator
+    #: Populated per-instance in :meth:`__init__` (bound to ``self``) so that
+    #: handler resolution is uniform across binding types and overriding
+    #: ``_apply_*`` in subclasses automatically takes effect.
 
     def _apply_binding(
         self,
@@ -1008,9 +976,9 @@ class SvgRenderer:
             )
             return
 
-        handler = self._BINDING_HANDLERS.get(type(binding))
+        handler = self._binding_handlers.get(type(binding))
         if handler is not None:
-            handler(self, root, elem, name, binding, value)
+            handler(root, elem, name, binding, value)
         else:
             logger.warning(
                 "Binding '%s': no handler registered for type '%s'",
@@ -1247,7 +1215,18 @@ class SvgRenderer:
         ratio = max(
             0.0, min(1.0, float(value if value is not None else binding.default))
         )
-        extent = self._range_extents.get(name, 0.0)
+        if name not in self._range_extents:
+            # Lazily capture the original extent from the unmodified template
+            # the first time this binding is applied, since per-render clones
+            # already carry the previously-mutated value.
+            original = _find_element_by_id(self._base_root, binding.node)
+            attr_lookup = (
+                "width" if binding.direction == RangeDirection.HORIZONTAL else "height"
+            )
+            self._range_extents[name] = (
+                float(original.get(attr_lookup, "0")) if original is not None else 0.0
+            )
+        extent = self._range_extents[name]
         attr = "width" if binding.direction == RangeDirection.HORIZONTAL else "height"
         elem.set(attr, str(ratio * extent))
 
@@ -1553,77 +1532,3 @@ class SvgRenderer:
 
         return _svg_to_image(svg_data, width, height, mode="RGBA", ctx=self._rendering_ctx)
 
-
-# ---------------------------------------------------------------------------
-# Binding handler registrations
-# ---------------------------------------------------------------------------
-
-
-@SvgRenderer._register_binding_handler(TextBinding)
-def _handle_text(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_text(root, elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(ImageBinding)
-def _handle_image(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_image(root, elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(VisibilityBinding)
-def _handle_visibility(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_visibility(elem, value)
-
-
-@SvgRenderer._register_binding_handler(ColorBinding)
-def _handle_color(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_color(elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(RangeBinding)
-def _handle_range(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_range(elem, name, binding, value)
-
-
-@SvgRenderer._register_binding_handler(SliderBinding)
-def _handle_slider(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_slider(elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(IconifyBinding)
-def _handle_iconify(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_iconify(elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(ListBinding)
-def _handle_list(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_list(root, elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(TransformBinding)
-def _handle_transform(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_transform(elem, binding, value)
-
-
-@SvgRenderer._register_binding_handler(CssClassBinding)
-def _handle_css_class(
-    self: SvgRenderer, root: ET.Element, elem: ET.Element, name: str, binding: Any, value: Any
-) -> None:
-    self._apply_css_class(elem, value)

--- a/tests/test_dui_schema.py
+++ b/tests/test_dui_schema.py
@@ -393,3 +393,97 @@ class TestListBinding:
         b = ListBinding(node="pager")
         with pytest.raises(AttributeError):
             b.node = "other"  # type: ignore[misc]
+
+
+class TestBindingDefaultValue:
+    """Each Binding subclass exposes a ``default_value()`` used by SvgRenderer."""
+
+    def test_text_default_value(self):
+        assert TextBinding(node="t", default="hi").default_value() == "hi"
+
+    def test_image_default_value_is_none(self):
+        from deux.dui.schema import ImageBinding
+
+        assert ImageBinding(node="i").default_value() is None
+
+    def test_image_is_force_dirty(self):
+        from deux.dui.schema import ImageBinding
+
+        assert ImageBinding.force_dirty is True
+
+    def test_visibility_default_value(self):
+        from deux.dui.schema import VisibilityBinding
+
+        assert VisibilityBinding(node="v", default=False).default_value() is False
+
+    def test_color_default_value(self):
+        assert ColorBinding(node="c", default="#abcdef").default_value() == "#abcdef"
+
+    def test_range_default_value(self):
+        from deux.dui.schema import RangeBinding
+
+        assert RangeBinding(node="r", default=0.42).default_value() == 0.42
+
+    def test_slider_default_value(self):
+        from deux.dui.schema import SliderBinding
+
+        assert SliderBinding(node="s", default=0.3).default_value() == 0.3
+
+    def test_toggle_default_value(self):
+        from deux.dui.schema import ToggleBinding
+
+        assert ToggleBinding(node_on="a", node_off="b", default=True).default_value() is True
+
+    def test_iconify_default_value(self):
+        from deux.dui.schema import IconifyBinding
+
+        assert (
+            IconifyBinding(node="i", size=16, default="mdi:home").default_value() == "mdi:home"
+        )
+
+    def test_transform_default_value(self):
+        from deux.dui.schema import TransformBinding
+
+        assert TransformBinding(node="t", default=0.25).default_value() == 0.25
+
+    def test_css_class_default_value(self):
+        assert CssClassBinding(node="x", default="cls").default_value() == "cls"
+
+    def test_list_default_value(self):
+        b = ListBinding(
+            node="pager", default_items=("a", "b", "c"), default_index=1
+        )
+        assert b.default_value() == {"items": ["a", "b", "c"], "index": 1}
+
+
+class TestListBindingCoerce:
+    """ListBinding.coerce merges partial ``{"items"|"index"}`` payloads."""
+
+    def test_coerce_items_only_preserves_index(self):
+        b = ListBinding(node="pager")
+        out = b.coerce({"items": ["x", "y"]}, {"items": ["a"], "index": 0})
+        assert out == {"items": ["x", "y"], "index": 0}
+
+    def test_coerce_index_only_preserves_items(self):
+        b = ListBinding(node="pager")
+        out = b.coerce({"index": 1}, {"items": ["a", "b"], "index": 0})
+        assert out == {"items": ["a", "b"], "index": 1}
+
+    def test_coerce_negative_one_normalised_to_none(self):
+        b = ListBinding(node="pager")
+        out = b.coerce({"index": -1}, {"items": ["a"], "index": 0})
+        assert out["index"] is None
+
+    def test_coerce_clamps_index_when_items_shrink(self):
+        b = ListBinding(node="pager")
+        out = b.coerce({"items": ["a"]}, {"items": ["a", "b", "c"], "index": 2})
+        assert out == {"items": ["a"], "index": 0}
+
+    def test_coerce_empty_items_clears_index(self):
+        b = ListBinding(node="pager")
+        out = b.coerce({"items": []}, {"items": ["a"], "index": 0})
+        assert out == {"items": [], "index": None}
+
+    def test_coerce_non_dict_returned_as_is(self):
+        b = ListBinding(node="pager")
+        assert b.coerce("plain", {"items": [], "index": None}) == "plain"

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -591,6 +591,8 @@ class TestSvgRendererRange:
             bindings={"bar": RangeBinding(node="bar", default=0.0)},
         )
         renderer = SvgRenderer(spec)
+        # Extents are populated lazily on first apply.
+        renderer.render()
         assert renderer._range_extents["bar"] == 80.0
 
     def test_range_extent_cached_vertical(self):
@@ -603,6 +605,8 @@ class TestSvgRendererRange:
             },
         )
         renderer = SvgRenderer(spec)
+        # Extents are populated lazily on first apply.
+        renderer.render()
         assert renderer._range_extents["vbar"] == 80.0
 
     def test_range_renders_differently(self):


### PR DESCRIPTION
Closes #317.

## Issue assessment

Valid. `src/deux/dui/svg_renderer.py` had three sites (`__init__`, `set`, and a module-level handler-stub block) that each duplicated the binding-type dispatch already handled by `_BINDING_HANDLERS`, plus ~75 lines of one-line wrappers that existed only to forward to `self._apply_*`. Adding a new binding kind required edits in 3+ places.

## Fix

- Added `default_value()` on every `Binding` subclass in `src/deux/dui/schema.py`. `SvgRenderer.__init__` now iterates bindings and calls `b.default_value()` instead of branching on type.
- Added `coerce(raw, current)` on `ListBinding` to encapsulate the partial-update merge logic; `SvgRenderer.set` now looks for `coerce` generically.
- Added a class-level `force_dirty` flag (only `ImageBinding` sets it) so `set` can preserve the 'always changed' semantics for images without an isinstance check.
- Replaced the module-level `@SvgRenderer._register_binding_handler(...)` stubs (and the `_BINDING_HANDLERS` ClassVar / `_register_binding_handler` decorator) with a per-instance `_binding_handlers` dict built in `__init__` from bound methods. Adding a binding kind now needs one entry in that dict rather than a separate module-level stub.
- Moved the `_range_extents` capture from `__init__` to lazy population on first `_apply_range`, removing the last init-time isinstance check.

## Tests / checks

- Added `TestBindingDefaultValue` and `TestListBindingCoerce` in `tests/test_dui_schema.py` covering the new methods for every binding subclass and every `ListBinding.coerce` merge path.
- Updated two `TestSvgRendererRange` tests that asserted on internal `_range_extents` state at init time to trigger a render first (matching the new lazy-population behaviour).
- Ran:
  - `ruff check .` — clean
  - `uv run mypy src/deux` — clean (strict mode, 65 files)
  - `uv run pytest tests/ --cov=deux --cov-fail-under=95` — 1842 passed, 1 skipped, 95.62% coverage