### PR TITLE
refactor: stop reaching into private renderer state (#321)

### DIFF
--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import logging
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any
@@ -18,6 +19,7 @@ from .svg_renderer import SvgRenderer
 if TYPE_CHECKING:
     from PIL import Image
 
+    from ..render.context import RenderingContext
     from ..render.metrics import RenderMetrics
     from ..runtime.async_event import AsyncEvent
     from ..runtime.events import AsyncHandler, TouchEvent
@@ -298,6 +300,28 @@ class DuiCard(BindingMixin, Card):
             If *name* is not a known binding.
         """
         return self._renderer.get(name)
+
+    def collect_icon_names(self) -> builtins.set[str]:
+        """Return all Iconify icon identifiers needed by this card.
+
+        Returns
+        -------
+        set[str]
+            A set of ``"prefix:icon"`` strings referenced by the card's
+            bindings (defaults and current values).
+        """
+        return self._renderer.collect_icon_names()
+
+    def set_rendering_context(self, ctx: RenderingContext | None) -> None:
+        """Set the explicit rendering context for this card.
+
+        Parameters
+        ----------
+        ctx : RenderingContext or None
+            The rendering context to apply, or ``None`` to revert to
+            module-level defaults.
+        """
+        self._renderer.set_rendering_context(ctx)
 
     def set_range(
         self, name: str, value: float, *, min_val: float = 0, max_val: float = 1

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +16,7 @@ from .spinner import SpinnerFrames
 from .svg_renderer import SvgRenderer
 
 if TYPE_CHECKING:
+    from ..render.context import RenderingContext
     from ..runtime.async_event import AsyncEvent
     from ..runtime.events import AsyncHandler
 
@@ -153,6 +155,28 @@ class DuiKey(BindingMixin, KeySlot):
             If *name* is not a known binding.
         """
         return self._renderer.get(name)
+
+    def collect_icon_names(self) -> builtins.set[str]:
+        """Return all Iconify icon identifiers needed by this key.
+
+        Returns
+        -------
+        set[str]
+            A set of ``"prefix:icon"`` strings referenced by the key's
+            bindings (defaults and current values).
+        """
+        return self._renderer.collect_icon_names()
+
+    def set_rendering_context(self, ctx: RenderingContext | None) -> None:
+        """Set the explicit rendering context for this key.
+
+        Parameters
+        ----------
+        ctx : RenderingContext or None
+            The rendering context to apply, or ``None`` to revert to
+            module-level defaults.
+        """
+        self._renderer.set_rendering_context(ctx)
 
     def set_range(
         self, name: str, value: float, *, min_val: float = 0, max_val: float = 1

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -361,7 +361,7 @@ class Deck:
         if all_icons:
             await prefetch_icons(all_icons)
 
-    def _resolve_stylesheet(self) -> str:
+    def resolve_stylesheet(self) -> str:
         """Resolve the effective CSS stylesheet for the active screen.
 
         The cascade is: screen theme > deck theme > system theme.
@@ -371,7 +371,19 @@ class Deck:
         str
             CSS stylesheet string from the most specific theme.
         """
-        return self._renderer._resolve_stylesheet()
+        from ..render.theme import get_active_theme
+
+        screen = self._active_screen
+        if screen is not None and screen.theme is not None:
+            return screen.theme.css
+        if self._theme is not None:
+            return self._theme.css
+        return get_active_theme().css
+
+    # Backwards-compatible alias preserved for callers that used the
+    # private name prior to the encapsulation refactor.  Prefer the
+    # public :meth:`resolve_stylesheet` for new code.
+    _resolve_stylesheet = resolve_stylesheet
 
     async def set_brightness(self, percent: int) -> None:
         """Set screen brightness.
@@ -548,7 +560,7 @@ class Deck:
 
         # Only drain cards that actually have pending callbacks.
         cards_with_pending = [
-            card for card in screen.cards if card._pending_callbacks
+            card for card in screen.cards if card.has_pending_callbacks
         ]
         if cards_with_pending:
             await asyncio.gather(

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -91,21 +91,17 @@ class DeckRenderer:
     def _resolve_stylesheet(self) -> str:
         """Resolve the effective CSS stylesheet for the active screen.
 
-        The cascade is: screen theme > deck theme > system theme.
+        .. deprecated::
+            Use :meth:`Deck.resolve_stylesheet` instead.  This method is
+            retained as a thin pass-through to avoid breaking downstream
+            callers and is scheduled for removal in a future release.
 
         Returns
         -------
         str
             CSS stylesheet string from the most specific theme.
         """
-        from ..render.theme import get_active_theme
-
-        screen = self._deck._active_screen
-        if screen is not None and screen.theme is not None:
-            return screen.theme.css
-        if self._deck._theme is not None:
-            return self._deck._theme.css
-        return get_active_theme().css
+        return self._deck.resolve_stylesheet()
 
     # ------------------------------------------------------------------
     # Key rendering
@@ -606,7 +602,7 @@ class DeckRenderer:
         from ..render.context import RenderingContext
         from ..render.svg_rasterize import set_svg_stylesheet
 
-        css = self._resolve_stylesheet()
+        css = self._deck.resolve_stylesheet()
 
         # Update global stylesheet for renderers without an explicit context.
         set_svg_stylesheet(css)
@@ -626,17 +622,17 @@ class DeckRenderer:
         from ..dui.card import DuiCard
         from ..dui.key import DuiKey
 
-        screen = self._deck._active_screen
+        screen = self._deck.active_screen
         if screen is None:
             return
 
         # Keys
         for key_slot in screen.keys.values():
             if isinstance(key_slot, DuiKey):
-                key_slot._renderer.set_rendering_context(ctx)
+                key_slot.set_rendering_context(ctx)
 
         # Touchscreen cards
         if screen.touch_strip is not None:
             for card in screen.touch_strip.cards:
                 if isinstance(card, DuiCard):
-                    card._renderer.set_rendering_context(ctx)
+                    card.set_rendering_context(ctx)

--- a/src/deux/ui/cards/base.py
+++ b/src/deux/ui/cards/base.py
@@ -223,6 +223,19 @@ class Card(ABC):
         return callbacks
 
     @property
+    def has_pending_callbacks(self) -> bool:
+        """Whether the card has callbacks queued for the next drain.
+
+        Returns
+        -------
+        bool
+            ``True`` if at least one callback has been queued via
+            :meth:`queue_pending_callback` and has not yet been drained
+            by :meth:`drain_pending_callbacks`.
+        """
+        return bool(self._pending_callbacks)
+
+    @property
     def is_dirty(self) -> bool:
         """Whether the card needs re-rendering."""
         return self._dirty

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -421,11 +421,11 @@ class Screen:
         icons: set[str] = set()
         for key_slot in self._keys.values():
             if isinstance(key_slot, DuiKey):
-                icons.update(key_slot._renderer.collect_icon_names())
+                icons.update(key_slot.collect_icon_names())
         if self._touch_strip is not None:
             for card in self._touch_strip.cards:
                 if isinstance(card, DuiCard):
-                    icons.update(card._renderer.collect_icon_names())
+                    icons.update(card.collect_icon_names())
         return icons
 
     def screenshot(self, directory: str | Path) -> list[Path]:

--- a/tests/test_dui_card.py
+++ b/tests/test_dui_card.py
@@ -70,6 +70,35 @@ class TestDuiCardIsCard:
         assert card.spec is card_package_spec
 
 
+class TestDuiCardPublicPassThroughs:
+    """Public pass-throughs that avoid reaching into ``_renderer``."""
+
+    def test_collect_icon_names_delegates(self, card_package_spec):
+        card = DuiCard(card_package_spec)
+        assert card.collect_icon_names() == card._renderer.collect_icon_names()
+
+    def test_set_rendering_context_delegates(self, card_package_spec):
+        from deux.render.context import RenderingContext
+
+        card = DuiCard(card_package_spec)
+        ctx = RenderingContext(stylesheet="x { }")
+        card.set_rendering_context(ctx)
+        assert card._renderer.rendering_context is ctx
+        card.set_rendering_context(None)
+        assert card._renderer.rendering_context is None
+
+    def test_has_pending_callbacks_property(self, card_package_spec):
+        async def handler():
+            return None
+
+        card = DuiCard(card_package_spec)
+        assert card.has_pending_callbacks is False
+        card.queue_pending_callback(handler, ())
+        assert card.has_pending_callbacks is True
+        card.drain_pending_callbacks()
+        assert card.has_pending_callbacks is False
+
+
 class TestDuiCardDataBinding:
     def test_set_marks_dirty(self):
         spec = _make_card_spec(

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -404,7 +404,7 @@ class TestDeckResolveStylesheet:
         set_active_theme(system_theme)
         screen = deck.screen("main")
         deck._active_screen = screen
-        assert deck._resolve_stylesheet() == system_theme.css
+        assert deck.resolve_stylesheet() == system_theme.css
 
     def test_deck_theme_overrides_system(self, deck):
         """Deck theme takes precedence over system theme."""
@@ -413,7 +413,7 @@ class TestDeckResolveStylesheet:
         deck.theme = deck_theme
         screen = deck.screen("main")
         deck._active_screen = screen
-        assert deck._resolve_stylesheet() == deck_theme.css
+        assert deck.resolve_stylesheet() == deck_theme.css
 
     def test_screen_theme_overrides_deck(self, deck):
         """Screen theme takes precedence over deck theme."""
@@ -422,7 +422,7 @@ class TestDeckResolveStylesheet:
         screen_theme = Theme.from_color(200, 200, 200)
         screen.theme = screen_theme
         deck._active_screen = screen
-        assert deck._resolve_stylesheet() == screen_theme.css
+        assert deck.resolve_stylesheet() == screen_theme.css
 
     def test_screen_theme_overrides_system(self, deck):
         """Screen theme takes precedence over system theme."""
@@ -431,13 +431,20 @@ class TestDeckResolveStylesheet:
         screen_theme = Theme.from_color(200, 200, 200)
         screen.theme = screen_theme
         deck._active_screen = screen
-        assert deck._resolve_stylesheet() == screen_theme.css
+        assert deck.resolve_stylesheet() == screen_theme.css
 
     def test_no_active_screen_uses_system(self, deck):
         """No active screen at all — uses system theme."""
         system_theme = Theme.from_color(10, 20, 30)
         set_active_theme(system_theme)
-        assert deck._resolve_stylesheet() == system_theme.css
+        assert deck.resolve_stylesheet() == system_theme.css
+
+    def test_private_alias_matches_public(self, deck):
+        """The legacy ``_resolve_stylesheet`` alias mirrors the public API."""
+        deck.theme = Theme.from_color(42, 42, 42)
+        screen = deck.screen("main")
+        deck._active_screen = screen
+        assert deck._resolve_stylesheet() == deck.resolve_stylesheet()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #321.

## Issue assessment

**Valid and actionable.** The issue identifies four concrete locations where layers reach into each other's privates (Deck <-> DeckRenderer, Screen -> DuiKey._renderer / DuiCard._renderer, DeckRenderer -> DuiCard._renderer, Deck -> Card._pending_callbacks). The suggested fix - add public methods on the owning objects - is sound and self-contained.

## Fix

Surfaced the previously private interactions as public APIs on the owning objects:

- `Deck.resolve_stylesheet()` - cascade logic moved out of `DeckRenderer._resolve_stylesheet`. The renderer now calls back into the deck rather than reading `Deck._active_screen` and `Deck._theme`. `DeckRenderer._resolve_stylesheet` is retained as a thin deprecated pass-through.
- `DuiKey.collect_icon_names()` / `DuiCard.collect_icon_names()` - public pass-throughs. `Screen.collect_all_icons()` updated to use them.
- `DuiKey.set_rendering_context()` / `DuiCard.set_rendering_context()` - public pass-throughs. `DeckRenderer._apply_context_to_screen()` updated to use them.
- `Card.has_pending_callbacks` - boolean property. `Deck.refresh()` updated to use it instead of inspecting `_pending_callbacks` directly.
- `Deck._resolve_stylesheet` retained as an alias of `resolve_stylesheet` so any external callers still work.

No behavior changes; this is encapsulation-only.

## Tests / checks

- `pytest tests/ --cov=deux --cov-fail-under=95`: 1846 passed, 1 skipped, coverage 95.60%.
- `ruff check .`: clean.
- `mypy src/deux` (strict): clean.

New targeted tests added for the pass-throughs (`TestDuiCardPublicPassThroughs`) and for the legacy `_resolve_stylesheet` alias. Existing theme tests updated to use the public `deck.resolve_stylesheet()`.
