### PR TITLE
fix(spinner): stop animator cleanly when device disconnects

### DIFF
--- a/src/deux/dui/animator.py
+++ b/src/deux/dui/animator.py
@@ -14,6 +14,17 @@ PushFn = Callable[[bytes], Coroutine[Any, Any, None]]
 """Async callable that pushes a single image frame to the device."""
 
 
+class DeviceUnavailable(Exception):
+    """Raised by a ``PushFn`` when the target device is gone.
+
+    The :class:`SpinnerAnimator` treats this as a terminal signal:
+    it stops the loop silently instead of logging an error per frame.
+    A ``push_fn`` should raise this when it detects that the
+    underlying device handle is missing or has been closed (for
+    example, after a hot-unplug while the spinner is still running).
+    """
+
+
 class SpinnerAnimator:
     """Drive frame-by-frame spinner animation on an asyncio event loop.
 
@@ -75,7 +86,15 @@ class SpinnerAnimator:
             self._task = None
 
     async def _loop(self) -> None:
-        """Cycle through frames at the configured interval."""
+        """Cycle through frames at the configured interval.
+
+        The loop terminates silently if a frame push raises
+        :class:`DeviceUnavailable`, since further pushes cannot
+        succeed until the device reconnects and the spinner is
+        restarted by application code.  Other exceptions are
+        logged per frame so a transient hiccup does not kill
+        the animation.
+        """
         idx = 0
         n = len(self._frames)
         try:
@@ -83,6 +102,12 @@ class SpinnerAnimator:
                 frame = self._frames[idx % n]
                 try:
                     await self._push_fn(frame)
+                except DeviceUnavailable as exc:
+                    logger.debug(
+                        "Spinner stopping: device unavailable (%s)", exc
+                    )
+                    self._running = False
+                    break
                 except Exception:
                     logger.exception("Error pushing spinner frame")
                 idx += 1

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -165,6 +165,8 @@ class Deck:
 
         self._running = False
 
+        await self._stop_all_spinners()
+
         self._detach_all_cards()
 
         if self._transport:
@@ -191,6 +193,37 @@ class Deck:
         self._device = None
         self._closed_event.set()
         logger.info("Deck stopped")
+
+    async def _stop_all_spinners(self) -> None:
+        """Stop spinner animations on every DuiKey and DuiCard.
+
+        Called from :meth:`stop` before the device is closed so that
+        no in-flight spinner frames are pushed to a half-torn-down
+        device.  Failures to stop an individual spinner are logged
+        and swallowed — shutdown must never raise.
+        """
+        from ..dui.card import DuiCard
+        from ..dui.key import DuiKey
+
+        for screen in self._screens.values():
+            for key_slot in screen.keys.values():
+                if isinstance(key_slot, DuiKey) and key_slot.is_animating:
+                    try:
+                        await key_slot.finish_busy()
+                    except Exception:
+                        logger.exception(
+                            "Error stopping spinner on key %r", key_slot
+                        )
+            if screen.touch_strip is None:
+                continue
+            for card in screen.touch_strip.cards:
+                if isinstance(card, DuiCard) and card.is_animating:
+                    try:
+                        await card.finish_busy()
+                    except Exception:
+                        logger.exception(
+                            "Error stopping spinner on card %r", card
+                        )
 
     def _detach_all_cards(self) -> None:
         """Unsubscribe deck-owned AsyncEvent handlers on every DuiCard across all screens.

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -12,10 +12,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, cast
 
+from ..dui.animator import DeviceUnavailable
 from ..dui.key import DuiKey
 from ..render.key_renderer import render_blank_key
 from ..render.profiler import RenderProfiler
 from ..render.touch_renderer import composite_frame_on_tile
+from .hid._ctypes_hidapi import HidApiError
 
 if TYPE_CHECKING:
     from ..dui.animator import PushFn
@@ -145,11 +147,23 @@ class DeckRenderer:
                 async def _push_key_frame(
                     frame_bytes: bytes, idx: int = key_index
                 ) -> None:
-                    async with deck._device_lock:
-                        await deck._exec_device_io(
-                            deck._device.set_key_image,  # type: ignore[union-attr]
-                            idx, frame_bytes
+                    device = deck._device
+                    if device is None:
+                        raise DeviceUnavailable(
+                            f"deck {deck!r} device is None"
                         )
+                    async with deck._device_lock:
+                        device = deck._device
+                        if device is None:
+                            raise DeviceUnavailable(
+                                f"deck {deck!r} device closed"
+                            )
+                        try:
+                            await deck._exec_device_io(
+                                device.set_key_image, idx, frame_bytes
+                            )
+                        except HidApiError as exc:
+                            raise DeviceUnavailable(str(exc)) from exc
 
                 dui_key.set_push_fn(_push_key_frame, key_size=caps.key_size)
 
@@ -226,12 +240,21 @@ class DeckRenderer:
         # Re-wire push_fn every render so a DuiKey reused across screens
         # always animates at the slot of the currently active screen.
         async def _push_key_frame(frame_bytes: bytes) -> None:
+            device = deck._device
+            if device is None:
+                raise DeviceUnavailable(f"deck {deck!r} device is None")
             async with deck._device_lock:
-                await deck._exec_device_io(
-                    deck._device.set_key_image,  # type: ignore[union-attr]
-                    key_index,
-                    frame_bytes,
-                )
+                device = deck._device
+                if device is None:
+                    raise DeviceUnavailable(f"deck {deck!r} device closed")
+                try:
+                    await deck._exec_device_io(
+                        device.set_key_image,
+                        key_index,
+                        frame_bytes,
+                    )
+                except HidApiError as exc:
+                    raise DeviceUnavailable(str(exc)) from exc
 
         if deck._caps is None:
             return
@@ -318,15 +341,24 @@ class DeckRenderer:
                 )
             else:
                 out_bytes = frame_bytes
+            device = deck._device
+            if device is None:
+                raise DeviceUnavailable(f"deck {deck!r} device is None")
             async with deck._device_lock:
-                await deck._exec_device_io(
-                    deck._device.set_partial_window_image,  # type: ignore[union-attr]
-                    x_pos,
-                    y_pos,
-                    panel_width,
-                    panel_height,
-                    out_bytes,
-                )
+                device = deck._device
+                if device is None:
+                    raise DeviceUnavailable(f"deck {deck!r} device closed")
+                try:
+                    await deck._exec_device_io(
+                        device.set_partial_window_image,
+                        x_pos,
+                        y_pos,
+                        panel_width,
+                        panel_height,
+                        out_bytes,
+                    )
+                except HidApiError as exc:
+                    raise DeviceUnavailable(str(exc)) from exc
 
         return _push_card_frame
 

--- a/tests/test_animator.py
+++ b/tests/test_animator.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from deux.dui.animator import SpinnerAnimator
+from deux.dui.animator import DeviceUnavailable, SpinnerAnimator
 
 
 class TestSpinnerAnimatorLifecycle:
@@ -71,3 +71,44 @@ class TestSpinnerAnimatorLifecycle:
         push_fn = AsyncMock()
         with pytest.raises(ValueError, match="must not be empty"):
             SpinnerAnimator(frames=[], interval_ms=50, push_fn=push_fn)
+
+
+class TestSpinnerAnimatorErrors:
+    async def test_device_unavailable_stops_loop(self):
+        """A push raising DeviceUnavailable terminates the loop quietly."""
+        calls = 0
+
+        async def push_fn(_frame: bytes) -> None:
+            nonlocal calls
+            calls += 1
+            raise DeviceUnavailable("device gone")
+
+        animator = SpinnerAnimator(
+            frames=[b"a", b"b"], interval_ms=5, push_fn=push_fn
+        )
+        await animator.start()
+        # Give the loop time to attempt one push and exit.
+        await asyncio.sleep(0.05)
+        assert animator.is_running is False
+        # Only one push should be attempted before the loop bails out.
+        assert calls == 1
+        # stop() must be idempotent / safe after self-termination.
+        await animator.stop()
+
+    async def test_generic_exception_keeps_loop_running(self):
+        """Non-DeviceUnavailable errors are logged and looping continues."""
+        calls = 0
+
+        async def push_fn(_frame: bytes) -> None:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise RuntimeError("transient")
+
+        animator = SpinnerAnimator(
+            frames=[b"a"], interval_ms=10, push_fn=push_fn
+        )
+        await animator.start()
+        await asyncio.sleep(0.1)
+        await animator.stop()
+        assert calls >= 3

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -765,6 +765,54 @@ class TestDeckRendererTouchHelpers:
         card.clear_background_layer.assert_not_called()
         assert should_render is True
 
+    async def test_card_push_fn_raises_device_unavailable_when_closed(
+        self, deck
+    ):
+        """The card push_fn surfaces device-closed as DeviceUnavailable."""
+        from deux.dui.animator import DeviceUnavailable
+        from deux.dui.card import DuiCard
+
+        card = MagicMock(spec=DuiCard)
+        card.is_animating = False
+        card.is_dirty = True
+        await deck._renderer._setup_card(
+            0, card, None, None, PANEL_WIDTH, PANEL_HEIGHT
+        )
+
+        # Extract the push_fn that was wired onto the card.
+        push_fn, _kwargs = card.set_push_fn.call_args
+        push_callable = push_fn[0]
+
+        # Device is None — the closure must refuse to dereference it.
+        assert deck._device is None
+        with pytest.raises(DeviceUnavailable):
+            await push_callable(b"frame")
+
+    async def test_card_push_fn_translates_hid_error(
+        self, deck, mock_streamdeck_device
+    ):
+        """HidApiError from device I/O is translated to DeviceUnavailable."""
+        from deux.dui.animator import DeviceUnavailable
+        from deux.dui.card import DuiCard
+        from deux.runtime.hid._ctypes_hidapi import HidApiError
+
+        deck._device = mock_streamdeck_device
+        mock_streamdeck_device.set_partial_window_image.side_effect = (
+            HidApiError("hid_write failed: not ready")
+        )
+
+        card = MagicMock(spec=DuiCard)
+        card.is_animating = False
+        card.is_dirty = True
+        await deck._renderer._setup_card(
+            0, card, None, None, PANEL_WIDTH, PANEL_HEIGHT
+        )
+        push_fn, _kwargs = card.set_push_fn.call_args
+        push_callable = push_fn[0]
+
+        with pytest.raises(DeviceUnavailable):
+            await push_callable(b"frame")
+
 
 class TestDeckInfo:
     def test_no_device_raises(self, deck):
@@ -886,6 +934,34 @@ class TestDeckStop:
             mock_enum.return_value = [mock_streamdeck_device]
             await d.start()
             await d.stop()
+
+    async def test_stop_stops_active_spinners(self, deck):
+        """stop() halts active spinner animations on keys and cards."""
+        from deux.dui.card import DuiCard
+        from deux.dui.key import DuiKey
+
+        screen = deck.screen("main")
+
+        # Fabricate animating key + card with mocked animators so we
+        # don't need spinner specs / push wiring.
+        key = MagicMock(spec=DuiKey)
+        key.is_animating = True
+        key.finish_busy = AsyncMock()
+        screen._keys[0] = key
+
+        assert screen._touch_strip is not None
+        card = MagicMock(spec=DuiCard)
+        card.is_animating = True
+        card.finish_busy = AsyncMock()
+        screen._touch_strip._cards[0] = card
+
+        deck._running = True  # so stop() proceeds
+
+        # Stop without an underlying device.
+        await deck.stop()
+
+        key.finish_busy.assert_awaited_once()
+        card.finish_busy.assert_awaited_once()
 
 
 class TestDeckWaitClosed:


### PR DESCRIPTION
## Problem

Disconnecting the deck while a spinner animation was running produced a flood of errors from the animator loop. The sequence observed in the issue was:

1. HidApiError: hid_write failed: IOHIDDeviceSetReport failed: (0xE00002D8) (iokit/common) not ready — first failed frame as macOS tears down the HID handle.
2. HidApiError: Device is not open — subsequent frames while the device is mid-close.
3. AttributeError: 'NoneType' object has no attribute 'set_key_image' — once Deck._device has been set to None, the push_fn closure dereferences a None handle.

The animator kept looping the whole time, logging `Error pushing spinner frame` once per frame.

## Fix

Three coordinated changes:

* **New `DeviceUnavailable` exception in `deux.dui.animator`.** When a `PushFn` raises it, `SpinnerAnimator` terminates the loop silently instead of logging an error per frame.
* **Renderer push_fn closures are device-safe.** `DeckRenderer` now checks `deck._device` up-front (and again under the device lock) and translates `HidApiError` into `DeviceUnavailable`. The bare `deck._device.set_key_image` / `set_partial_window_image` accesses that produced `AttributeError` are gone.
* **`Deck.stop()` halts spinners first.** New `_stop_all_spinners()` walks every screen and calls `finish_busy()` on any animating DuiKey / DuiCard before tearing down the transport and clearing the device handle.

## Tests

* `test_animator.py`: `DeviceUnavailable` stops the loop after one push; generic exceptions keep the loop running.
* `test_deck.py`: `stop()` invokes `finish_busy` on animating key/card; card push_fn raises `DeviceUnavailable` when device is None and when underlying HID raises `HidApiError`.

All 1851 tests pass, coverage 95.42% (gate 95%).