### PR TITLE
refactor(tests): add Deck.for_testing and drop duplicate test (#322)

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -100,6 +100,57 @@ class Deck:
         self._renderer = DeckRenderer(self)
         self._event_router = DeckEventRouter(self)
 
+    @classmethod
+    def for_testing(
+        cls,
+        capabilities: DeviceCapabilities,
+        *,
+        serial_number: str = "TEST",
+        brightness: int = 80,
+    ) -> Deck:
+        """Construct a :class:`Deck` pre-seeded with capabilities for tests.
+
+        Real construction goes through :meth:`start`, which discovers a
+        physical device and derives :attr:`capabilities` and
+        :attr:`metrics` from it.  Tests that exercise behaviour above
+        the device layer need those two attributes populated without
+        any HID I/O.
+
+        This helper provides the supported way to do so, so that tests
+        do not have to assign to the private ``_caps`` / ``_metrics``
+        attributes directly.  No device is opened and no transport is
+        started — :attr:`is_connected` remains ``False`` until the
+        normal :meth:`start` path is invoked.
+
+        Parameters
+        ----------
+        capabilities : DeviceCapabilities
+            The capabilities to seed onto the deck.  Drives the
+            derived :class:`~deux.render.metrics.RenderMetrics` and
+            anything else that reads :attr:`capabilities`.
+        serial_number : str, default="TEST"
+            Serial number recorded on the instance.  Does not need to
+            correspond to a real device.
+        brightness : int, default=80
+            Initial brightness (0-100).
+
+        Returns
+        -------
+        Deck
+            A deck instance with :attr:`capabilities` and
+            :attr:`metrics` populated.
+
+        Notes
+        -----
+        This constructor is intended for unit tests.  Production code
+        should use the normal :class:`Deck` constructor and
+        :meth:`start`.
+        """
+        deck = cls(serial_number=serial_number, brightness=brightness)
+        deck._caps = capabilities
+        deck._metrics = RenderMetrics(capabilities)
+        return deck
+
     async def start(self) -> None:
         """Discover the device by serial, open it, and start the event loop."""
         if self._running:

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -43,13 +43,12 @@ class _TestCard(Card):
 def deck(tmp_path):
     """A Deck instance with required serial_number.
 
-    Capabilities are pre-populated so tests can call ``deck.screen()``
-    without going through the real device-discovery path.
+    Capabilities are pre-populated via the public
+    :meth:`Deck.for_testing` constructor so tests can call
+    ``deck.screen()`` without going through the real
+    device-discovery path.
     """
-    d = Deck(serial_number="TEST123")
-    d._caps = STREAM_DECK_PLUS
-    d._metrics = RenderMetrics(STREAM_DECK_PLUS)
-    return d
+    return Deck.for_testing(STREAM_DECK_PLUS, serial_number="TEST123")
 
 
 class TestDeckInit:
@@ -70,11 +69,6 @@ class TestDeckInit:
 
 class TestDeckPage:
     def test_creates_screen(self, deck):
-        p = deck.screen("main")
-        assert isinstance(p, Screen)
-        assert p.name == "main"
-
-    def test_creates_page(self, deck):
         p = deck.screen("main")
         assert isinstance(p, Screen)
         assert p.name == "main"
@@ -855,6 +849,39 @@ class TestDeckCapabilities:
 
     def test_metrics_after_set(self, deck):
         assert deck.metrics.key_count == 8
+
+
+class TestDeckForTesting:
+    """Tests for the public :meth:`Deck.for_testing` constructor."""
+
+    def test_seeds_capabilities_and_metrics(self):
+        d = Deck.for_testing(STREAM_DECK_PLUS)
+        assert d.capabilities is STREAM_DECK_PLUS
+        assert d.metrics.key_count == STREAM_DECK_PLUS.key_count
+
+    def test_default_serial_and_brightness(self):
+        d = Deck.for_testing(STREAM_DECK_PLUS)
+        assert d.brightness == 80
+        assert d.is_connected is False
+
+    def test_custom_serial_and_brightness(self):
+        d = Deck.for_testing(
+            STREAM_DECK_PLUS, serial_number="ABC123", brightness=42
+        )
+        assert d.brightness == 42
+
+    def test_does_not_open_device(self):
+        """No HID I/O — info still raises until a device is attached."""
+        d = Deck.for_testing(STREAM_DECK_PLUS)
+        with pytest.raises(DeckError, match="Device not opened"):
+            _ = d.info
+
+    def test_screen_works_without_real_device(self):
+        """The whole point: screen() must succeed after for_testing."""
+        d = Deck.for_testing(STREAM_DECK_PLUS)
+        s = d.screen("main")
+        assert isinstance(s, Screen)
+        assert s.name == "main"
 
 
 class TestDeckStart:


### PR DESCRIPTION
Refs #322.

## Issue validity

Valid and actionable. Concretely:

- `tests/test_deck.py` reached into `deck._caps` / `deck._metrics` in the shared fixture purely to bypass the real device-discovery path.
- `test_creates_page` was a literal duplicate of `test_creates_screen` (identical body).

The broader part of #322 — a full sweep of `\._[a-z]` access across the rest of `tests/` (~800 hits in 30+ files) — is intentionally **out of scope** for this PR. Issue #322 itself frames that work as a multi-part effort (it references the sibling renderer-encapsulation issue #321), and most of those accesses would require new public surfaces on many different types. Scoping confirmed with the requester before implementation.

## Fix

- Add public classmethod `Deck.for_testing(capabilities, *, serial_number='TEST', brightness=80)` that constructs a `Deck` with `capabilities` / `metrics` pre-seeded, with no HID I/O. NumPy-style docstring included, explicitly marked as a test-only constructor.
- Migrate the `deck` fixture in `tests/test_deck.py` to use it; drops the `_caps` / `_metrics` assignments from the fixture.
- Remove the duplicate `test_creates_page`.
- Add `TestDeckForTesting` covering: seeded caps/metrics, default and custom serial/brightness, no device opened, and that `screen()` works without a real device.

Existing `deck._caps = ...` assignments scattered through individual tests in `test_deck.py` are left untouched — they belong to the broader sweep.

## Validation

All run on this branch, all green:

- `ruff check .` — clean
- `mypy src/deux` — clean (strict mode)
- `uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` — **1855 passed, 1 skipped**, total coverage **95.42%** (gate: 95%)