### PR TITLE
refactor(tools/preview): deduplicate compose and fit helpers (#323)

### DIFF
--- a/src/deux/tools/preview.py
+++ b/src/deux/tools/preview.py
@@ -46,11 +46,26 @@ if TYPE_CHECKING:
 from PIL import Image
 
 from deux.render.key_renderer import _encode_image_bytes
-from deux.render.svg_rasterize import _svg_to_png
+from deux.render.svg_rasterize import _svg_to_image, _svg_to_png
 from deux.runtime.capabilities import DeviceCapabilities
 from deux.runtime.deck import _HID_WRITE_TIMEOUT
 
+from .._xml import safe_fromstring
+
 logger = logging.getLogger(__name__)
+
+# CLI output convention
+# ---------------------
+# User-facing messages and errors are written to stderr via
+# ``print(..., file=sys.stderr)`` (annotated with a ruff T201 ignore
+# directive at each call site). This is the deliberate CLI convention:
+# such output should always reach the user regardless of the configured
+# logging level. The ``logger`` is reserved for diagnostic / status
+# output (``debug`` and ``info``) that respects the ``--verbose`` flag.
+
+# Regex used to strip unit suffixes (``"px"``, ``"pt"``, ...) from SVG
+# width / height attributes.
+_DIM_RE = re.compile(r"([\d.]+)")
 
 # Upper-bound slot counts used only to generate ``--keyN`` / ``--cardN``
 # CLI flags. The tool ignores flags that don't correspond to an actual
@@ -97,13 +112,55 @@ def parse_hex_color(value: str) -> str:
 
 
 
+def _compute_fit_dims(
+    svg_data: bytes, max_width: int, max_height: int
+) -> tuple[int, int]:
+    """Compute output dimensions that fit *svg_data* into a bounding box.
+
+    Parses the SVG's intrinsic ``width`` / ``height`` attributes and
+    returns ``(out_w, out_h)`` preserving aspect ratio within
+    *max_width* x *max_height*. Falls back to ``(max_width, max_height)``
+    if the SVG omits or has unparseable dimensions.
+
+    Parameters
+    ----------
+    svg_data : bytes
+        Raw SVG content (UTF-8).
+    max_width : int
+        Maximum output width in pixels.
+    max_height : int
+        Maximum output height in pixels.
+
+    Returns
+    -------
+    tuple[int, int]
+        ``(out_w, out_h)`` — both ``>= 1``.
+    """
+    try:
+        root = safe_fromstring(svg_data)  # untrusted: user-supplied SVG
+        w_match = _DIM_RE.match(root.get("width", ""))
+        h_match = _DIM_RE.match(root.get("height", ""))
+        if w_match and h_match:
+            svg_w = float(w_match.group(1))
+            svg_h = float(h_match.group(1))
+            if svg_w > 0 and svg_h > 0:
+                scale = min(max_width / svg_w, max_height / svg_h)
+                return max(1, int(svg_w * scale)), max(1, int(svg_h * scale))
+    except Exception:
+        logger.debug(
+            "Failed to parse SVG intrinsic dimensions; using fallback raster size %dx%d.",
+            max_width,
+            max_height,
+        )
+    return max_width, max_height
+
+
 def _svg_to_png_fit(svg_data: bytes, max_width: int, max_height: int) -> bytes:
     """Rasterise SVG bytes to PNG, fitting within a bounding box.
 
-    Parses the SVG's intrinsic ``width`` and ``height`` attributes to
-    compute the correct output size that preserves aspect ratio within
-    the *max_width* x *max_height* bounding box, then delegates to
-    the active SVG backend.
+    Parses the SVG's intrinsic dimensions to compute the correct output
+    size that preserves aspect ratio within *max_width* x *max_height*,
+    then delegates to the active SVG backend.
 
     Parameters
     ----------
@@ -124,35 +181,8 @@ def _svg_to_png_fit(svg_data: bytes, max_width: int, max_height: int) -> bytes:
     RasterizeError
         If no SVG renderer backend is available.
     """
-    import re as _re
-
-    from .._xml import safe_fromstring
-
-    # Try to extract intrinsic dimensions to preserve aspect ratio.
-    try:
-        root = safe_fromstring(svg_data)  # untrusted: user-supplied SVG
-        w_attr = root.get("width", "")
-        h_attr = root.get("height", "")
-        # Strip unit suffixes like "px", "pt", etc.
-        w_match = _re.match(r"([\d.]+)", w_attr)
-        h_match = _re.match(r"([\d.]+)", h_attr)
-        if w_match and h_match:
-            svg_w = float(w_match.group(1))
-            svg_h = float(h_match.group(1))
-            if svg_w > 0 and svg_h > 0:
-                scale = min(max_width / svg_w, max_height / svg_h)
-                out_w = max(1, int(svg_w * scale))
-                out_h = max(1, int(svg_h * scale))
-                return _svg_to_png(svg_data, out_w, out_h)
-    except Exception:
-        logger.debug(
-            "Failed to parse SVG intrinsic dimensions; using fallback raster size %dx%d.",
-            max_width,
-            max_height,
-        )
-
-    # Fallback: force exact dimensions.
-    return _svg_to_png(svg_data, max_width, max_height)
+    out_w, out_h = _compute_fit_dims(svg_data, max_width, max_height)
+    return _svg_to_png(svg_data, out_w, out_h)
 
 
 def _svg_to_image_fit(
@@ -160,7 +190,7 @@ def _svg_to_image_fit(
 ) -> Image.Image:
     """Rasterise SVG bytes to a PIL RGBA Image fitted within a bounding box.
 
-    Preserves the SVG's intrinsic aspect ratio.  Uses the raw-RGBA path
+    Preserves the SVG's intrinsic aspect ratio. Uses the raw-RGBA path
     to avoid a PNG encode/decode round-trip.
 
     Parameters
@@ -182,32 +212,7 @@ def _svg_to_image_fit(
     RasterizeError
         If no SVG renderer backend is available.
     """
-    import re as _re
-
-    from .._xml import safe_fromstring
-    from ..render.svg_rasterize import _svg_to_image
-
-    out_w, out_h = max_width, max_height
-    try:
-        root = safe_fromstring(svg_data)
-        w_attr = root.get("width", "")
-        h_attr = root.get("height", "")
-        w_match = _re.match(r"([\d.]+)", w_attr)
-        h_match = _re.match(r"([\d.]+)", h_attr)
-        if w_match and h_match:
-            svg_w = float(w_match.group(1))
-            svg_h = float(h_match.group(1))
-            if svg_w > 0 and svg_h > 0:
-                scale = min(max_width / svg_w, max_height / svg_h)
-                out_w = max(1, int(svg_w * scale))
-                out_h = max(1, int(svg_h * scale))
-    except Exception:
-        logger.debug(
-            "Failed to parse SVG intrinsic dimensions; using fallback raster size %dx%d.",
-            max_width,
-            max_height,
-        )
-
+    out_w, out_h = _compute_fit_dims(svg_data, max_width, max_height)
     return _svg_to_image(svg_data, out_w, out_h, mode="RGBA")
 
 
@@ -222,6 +227,39 @@ def load_svg(path: Path, max_width: int, max_height: int) -> Image.Image:
     img = _svg_to_image_fit(svg_data, max_width, max_height)
     img.thumbnail((max_width, max_height), Image.Resampling.LANCZOS)
     return img
+
+
+def _center_on_canvas(
+    svg_img: Image.Image,
+    size: tuple[int, int],
+    background: str,
+) -> Image.Image:
+    """Centre *svg_img* on an RGB canvas of *size* filled with *background*.
+
+    Pastes using *svg_img*'s alpha channel as the mask when present.
+
+    Parameters
+    ----------
+    svg_img : Image.Image
+        Image to composite onto the canvas.
+    size : tuple[int, int]
+        ``(width, height)`` of the target canvas.
+    background : str
+        Canvas fill colour (any PIL-compatible colour string).
+
+    Returns
+    -------
+    Image.Image
+        New RGB canvas with *svg_img* centred.
+    """
+    canvas = Image.new("RGB", size, background)
+    x = (size[0] - svg_img.width) // 2
+    y = (size[1] - svg_img.height) // 2
+    if svg_img.mode == "RGBA":
+        canvas.paste(svg_img, (x, y), svg_img)
+    else:
+        canvas.paste(svg_img, (x, y))
+    return canvas
 
 
 def compose_key_image(
@@ -248,14 +286,7 @@ def compose_key_image(
     bytes
         JPEG-encoded image bytes ready for ``set_key_image``.
     """
-    canvas = Image.new("RGB", key_size, background)
-    x = (key_size[0] - svg_img.width) // 2
-    y = (key_size[1] - svg_img.height) // 2
-    if svg_img.mode == "RGBA":
-        canvas.paste(svg_img, (x, y), svg_img)
-    else:
-        canvas.paste(svg_img, (x, y))
-    return _encode_image_bytes(canvas)
+    return _encode_image_bytes(_center_on_canvas(svg_img, key_size, background))
 
 
 def compose_card_image(
@@ -279,14 +310,7 @@ def compose_card_image(
     Image.Image
         Composited card image at *panel_size*.
     """
-    canvas = Image.new("RGB", panel_size, background)
-    x = (panel_size[0] - svg_img.width) // 2
-    y = (panel_size[1] - svg_img.height) // 2
-    if svg_img.mode == "RGBA":
-        canvas.paste(svg_img, (x, y), svg_img)
-    else:
-        canvas.paste(svg_img, (x, y))
-    return canvas
+    return _center_on_canvas(svg_img, panel_size, background)
 
 
 def compose_touchstrip(
@@ -338,14 +362,9 @@ def compose_full_touchstrip(
     bytes
         JPEG-encoded image bytes ready for ``set_touchscreen_image``.
     """
-    canvas = Image.new("RGB", touchscreen_size, background)
-    x = (touchscreen_size[0] - svg_img.width) // 2
-    y = (touchscreen_size[1] - svg_img.height) // 2
-    if svg_img.mode == "RGBA":
-        canvas.paste(svg_img, (x, y), svg_img)
-    else:
-        canvas.paste(svg_img, (x, y))
-    return _encode_image_bytes(canvas)
+    return _encode_image_bytes(
+        _center_on_canvas(svg_img, touchscreen_size, background)
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 from deux.tools.preview import (
     _MAX_CARD_SLOTS,
     _MAX_KEY_SLOTS,
+    _center_on_canvas,
+    _compute_fit_dims,
     _svg_to_png_fit,
     _watch_and_reload,
     build_parser,
@@ -573,6 +575,79 @@ class TestSvgToPngFit:
         png_bytes = _svg_to_png_fit(svg, 80, 80)
         img = Image.open(io.BytesIO(png_bytes))
         assert img.height <= 80
+
+
+class TestComputeFitDims:
+    """Tests for the shared ``_compute_fit_dims`` helper."""
+
+    def test_preserves_aspect_ratio_wide(self):
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">'
+            b"</svg>"
+        )
+        assert _compute_fit_dims(svg, 80, 80) == (80, 40)
+
+    def test_preserves_aspect_ratio_tall(self):
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="50" height="200">'
+            b"</svg>"
+        )
+        assert _compute_fit_dims(svg, 80, 80) == (20, 80)
+
+    def test_strips_unit_suffix(self):
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="100px" height="50px">'
+            b"</svg>"
+        )
+        assert _compute_fit_dims(svg, 200, 200) == (200, 100)
+
+    def test_missing_dims_falls_back(self):
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+        assert _compute_fit_dims(svg, 64, 32) == (64, 32)
+
+    def test_zero_dim_falls_back(self):
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="0" height="100">'
+            b"</svg>"
+        )
+        assert _compute_fit_dims(svg, 64, 32) == (64, 32)
+
+    def test_malformed_svg_falls_back(self):
+        assert _compute_fit_dims(b"not valid svg", 10, 20) == (10, 20)
+
+    def test_dims_never_below_one(self):
+        svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10000" height="1">'
+            b"</svg>"
+        )
+        out_w, out_h = _compute_fit_dims(svg, 100, 100)
+        assert out_w >= 1 and out_h >= 1
+
+
+class TestCenterOnCanvas:
+    """Tests for the shared ``_center_on_canvas`` helper."""
+
+    def test_returns_rgb_canvas_at_size(self):
+        svg_img = Image.new("RGBA", (20, 20), (255, 0, 0, 255))
+        canvas = _center_on_canvas(svg_img, (100, 100), "black")
+        assert canvas.mode == "RGB"
+        assert canvas.size == (100, 100)
+
+    def test_centres_smaller_image(self):
+        svg_img = Image.new("RGBA", (20, 20), (255, 0, 0, 255))
+        canvas = _center_on_canvas(svg_img, (100, 100), "black")
+        assert canvas.getpixel((50, 50)) == (255, 0, 0)
+        assert canvas.getpixel((0, 0)) == (0, 0, 0)
+
+    def test_rgb_image_no_alpha(self):
+        svg_img = Image.new("RGB", (40, 40), (0, 255, 0))
+        canvas = _center_on_canvas(svg_img, (60, 60), "black")
+        assert canvas.getpixel((30, 30)) == (0, 255, 0)
+
+    def test_custom_background(self):
+        svg_img = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+        canvas = _center_on_canvas(svg_img, (40, 40), "#0000ff")
+        assert canvas.getpixel((0, 0)) == (0, 0, 255)
 
 
 class TestFindAndOpenDevice:


### PR DESCRIPTION
## Issue validity

Issue #323 is **valid and actionable**. The file `src/deux/tools/preview.py` did contain:

- Near-duplicate `_svg_to_png_fit` / `_svg_to_image_fit` (~95% identical SVG-dimension parsing).
- Near-duplicate `compose_key_image` / `compose_card_image` / `compose_full_touchstrip` (same centre-on-canvas paste logic, differing only in canvas size and whether they JPEG-encode).
- Inline `import re as _re` / `safe_fromstring` repeated in each fit helper.
- A mixed `print(..., file=sys.stderr)` + `logger.*` convention with no explicit policy documented (no `logger.warning` calls were actually present — the asymmetry was between user-facing CLI output and diagnostic logging).

## Fix

- Extract `_compute_fit_dims(svg_data, max_w, max_h) -> (out_w, out_h)` and use it from both `_svg_to_png_fit` and `_svg_to_image_fit`.
- Extract `_center_on_canvas(svg_img, size, background) -> Image` and use it from `compose_key_image`, `compose_card_image`, and `compose_full_touchstrip`. Each `compose_*` collapses to a one-liner wrapper.
- Hoist `import re`, `safe_fromstring`, and `_svg_to_image` to module top; remove inline imports.
- Add a module-level comment documenting the deliberate CLI convention (`print(..., file=sys.stderr)` for user-facing messages and errors that must bypass log level; `logger` for diagnostic / status output that respects `--verbose`).

Net change: -81 / +175 (most of the +175 is new tests).

## Tests / checks

- `ruff check .` — clean.
- `mypy src/deux` — clean (strict mode, 65 source files).
- Full suite: **1866 passed, 1 skipped** (`uv run python -m pytest tests/ --cov=deux --cov-fail-under=95`).
- Coverage: total **95.45%**, `src/deux/tools/preview.py` at **100%**.
- Added `TestComputeFitDims` (7 cases: aspect-ratio wide/tall, unit-suffix stripping, missing dims fallback, zero-dim fallback, malformed-SVG fallback, never-below-1 clamp) and `TestCenterOnCanvas` (4 cases: size, centring, RGB-no-alpha, custom background).

Closes #323