### PR TITLE
fix(dui/svg_renderer): tighten exception handling in icon and font paths

### DIFF
--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -16,6 +16,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from defusedxml import DefusedXmlException
 from PIL import ImageFont
 
 if TYPE_CHECKING:
@@ -180,7 +181,7 @@ def _get_default_font_family() -> str:
         from ..render.theme import get_default_font_family
 
         return get_default_font_family()
-    except Exception:
+    except ImportError:
         return _DEFAULT_FONT_FAMILY
 
 
@@ -1349,7 +1350,7 @@ class SvgRenderer:
 
         try:
             icon_root = safe_fromstring(svg_source)  # untrusted: network (Iconify)
-        except Exception as exc:
+        except (ET.ParseError, DefusedXmlException) as exc:
             logger.warning(
                 "Iconify binding '%s': failed to parse icon SVG: %s",
                 binding.node,
@@ -1457,7 +1458,7 @@ class SvgRenderer:
 
         try:
             icon_root = safe_fromstring(svg_source)  # untrusted: network (Iconify)
-        except Exception as exc:
+        except (ET.ParseError, DefusedXmlException) as exc:
             logger.warning(
                 "List binding icon '%s': failed to parse SVG: %s", icon_name, exc
             )

--- a/tests/test_dui_svg_renderer.py
+++ b/tests/test_dui_svg_renderer.py
@@ -1984,6 +1984,32 @@ class TestIconifyBindingRendering:
         assert list(g) == []
         assert any("failed to parse" in rec.message for rec in caplog.records)
 
+    def test_unexpected_parser_error_propagates(self, monkeypatch):
+        """Non-parse errors (e.g. programming bugs) must NOT be swallowed."""
+        import deux.dui.svg_renderer as svg_renderer_mod
+
+        monkeypatch.setattr(
+            svg_renderer_mod, "fetch_icon", lambda name: "<svg/>", raising=True
+        )
+
+        spec = _make_spec(
+            _ICONIFY_SVG,
+            bindings={
+                "icon": IconifyBinding(node="icon", size=55, default="line-md:home"),
+            },
+        )
+        renderer = SvgRenderer(spec)
+
+        def boom(_data):
+            raise AttributeError("unexpected bug")
+
+        monkeypatch.setattr(
+            svg_renderer_mod, "safe_fromstring", boom, raising=True
+        )
+
+        with pytest.raises(AttributeError, match="unexpected bug"):
+            self._serialise_with_bindings(renderer)
+
     def test_full_render_produces_image(self, monkeypatch):
         """End-to-end render goes through CairoSVG without exceptions."""
         self._patch_fetch(monkeypatch)

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -484,6 +484,21 @@ class TestSvgRendererFontIntegration:
         result = _get_default_font_family()
         assert result == "Inter"
 
+    def test_get_default_font_family_propagates_unexpected_errors(self, monkeypatch):
+        """Non-ImportError failures must propagate, not silently fall back."""
+        import deux.render.theme as theme_module
+        from deux.dui.svg_renderer import _get_default_font_family
+
+        def boom() -> str:
+            raise RuntimeError("theme system broken")
+
+        monkeypatch.setattr(
+            theme_module, "get_default_font_family", boom, raising=True
+        )
+
+        with pytest.raises(RuntimeError, match="theme system broken"):
+            _get_default_font_family()
+
 
 # ---------------------------------------------------------------------------
 # Public API imports


### PR DESCRIPTION
Closes #324.

## Issue validity

Valid and actionable. Three locations in \`src/deux/dui/svg_renderer.py\` swallowed every \`Exception\`:

- Two \`safe_fromstring(...)\` calls in \`_emit_iconify_binding\` (line ~1351) and \`_emit_list_icon\` (line ~1459) — \`safe_fromstring\` only raises \`ET.ParseError\` or \`defusedxml.DefusedXmlException\`; \`IconifyError\` is already handled separately above.
- \`_get_default_font_family\` (line ~179) used \`except Exception\` to recover from a circular import, hiding any genuine bug in the theme system behind a hardcoded \`\"Inter\"\` default.

In all three cases the broad \`except\` would silently mask \`AttributeError\` / \`TypeError\` / etc., producing wrong rendering instead of a loud failure.

## Fix

- \`_emit_iconify_binding\`, \`_emit_list_icon\`: catch \`(ET.ParseError, DefusedXmlException)\` only; other errors propagate.
- \`_get_default_font_family\`: catch \`ImportError\` only; other errors propagate.
- Added \`from defusedxml import DefusedXmlException\` to module imports.

## Tests

- New: \`test_unexpected_parser_error_propagates\` — patches \`safe_fromstring\` to raise \`AttributeError\` and asserts the renderer re-raises rather than logging a warning.
- New: \`test_get_default_font_family_propagates_unexpected_errors\` — patches \`get_default_font_family\` to raise \`RuntimeError\` and asserts it propagates instead of falling back to \`\"Inter\"\`.
- Existing parse-failure and import-fallback tests still pass.

## Checks run

- \`uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95\` — **1868 passed**, 1 skipped, coverage 95.47%.
- \`uv run ruff check .\` — **All checks passed**.
- \`uv run mypy src/deux\` — **Success: no issues found in 65 source files**.