### PR TITLE
refactor: hoist inline imports and standardise convention (#326)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,19 +59,20 @@ src = ["src"]
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "UP",  # pyupgrade
-    "C4",  # comprehensions
-    "SIM", # simplify
+    "E",       # pycodestyle errors
+    "W",       # pycodestyle warnings
+    "F",       # pyflakes
+    "I",       # isort
+    "B",       # flake8-bugbear
+    "UP",      # pyupgrade
+    "C4",      # comprehensions
+    "SIM",     # simplify
+    "PLC0415", # pylint: imports must live at the top of the module
 ]
 ignore = ["B008"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["B011"]
+"tests/*" = ["B011", "PLC0415"]
 
 [project.optional-dependencies]
 test = [

--- a/src/deux/__init__.py
+++ b/src/deux/__init__.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from ._errors import DeuxError
 from ._url_safety import SSRFError, set_allow_private_urls
+from ._version_safe import __version__
 from .dui import (
     DuiCard,
     DuiKey,
@@ -113,5 +114,3 @@ __all__ = [
     "set_active_theme",
     "set_allow_private_urls",
 ]
-
-from deux._version_safe import __version__

--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -70,6 +70,8 @@ class DuiCard(BindingMixin, Card):
 
     def __init__(self, spec: PackageSpec | str) -> None:
         if isinstance(spec, str):
+            # Inline import: keeps the lookup go through repository.resolve_dui
+            # at call time so monkeypatching that symbol in tests works.
             from .repository import resolve_dui
 
             spec = resolve_dui(spec)

--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -72,7 +72,7 @@ class DuiCard(BindingMixin, Card):
         if isinstance(spec, str):
             # Inline import: keeps the lookup go through repository.resolve_dui
             # at call time so monkeypatching that symbol in tests works.
-            from .repository import resolve_dui
+            from .repository import resolve_dui  # noqa: PLC0415
 
             spec = resolve_dui(spec)
         super().__init__()

--- a/src/deux/dui/event_map.py
+++ b/src/deux/dui/event_map.py
@@ -376,7 +376,9 @@ class EventMap:
         AsyncHandler or None
             The matched handler, or ``None`` if no region/mapping matched.
         """
-        from ..runtime.events import EventType as ET_Enum
+        # Inline import: importing runtime.events triggers runtime.__init__
+        # which loads runtime.deck and creates a cycle through dui.* modules.
+        from ..runtime.events import EventType as ET_Enum  # noqa: PLC0415
 
         if event_type == ET_Enum.TOUCH_SHORT:
             touch_name = "tap"

--- a/src/deux/dui/key.py
+++ b/src/deux/dui/key.py
@@ -66,7 +66,9 @@ class DuiKey(BindingMixin, KeySlot):
 
     def __init__(self, spec: PackageSpec | str) -> None:
         if isinstance(spec, str):
-            from .repository import resolve_dui
+            # Inline import: keeps the lookup go through repository.resolve_dui
+            # at call time so monkeypatching that symbol in tests works.
+            from .repository import resolve_dui  # noqa: PLC0415
 
             spec = resolve_dui(spec)
         super().__init__()

--- a/src/deux/dui/spinner.py
+++ b/src/deux/dui/spinner.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from PIL import Image
 
 from .._xml import safe_fromstring
+from .schema import SpinnerType
 from .svg_renderer import _find_element_by_id
 
 if TYPE_CHECKING:
@@ -86,8 +87,6 @@ class SpinnerFrames:
 
     def _generate(self) -> list[bytes]:
         """Generate all animation frames."""
-        from .schema import SpinnerType
-
         if self._spinner.type == SpinnerType.ROTATION:
             return self._generate_rotation()
         if self._spinner.type == SpinnerType.PULSE:
@@ -301,7 +300,9 @@ class SpinnerFrames:
         bytes
             Encoded image bytes.
         """
-        from ..render.key_renderer import _encode_image_bytes
+        # Inline import: tests patch ``deux.render.key_renderer._encode_image_bytes``;
+        # importing it lazily keeps that patching point effective.
+        from ..render.key_renderer import _encode_image_bytes  # noqa: PLC0415
 
         return _encode_image_bytes(img, self._image_format)
 
@@ -348,7 +349,9 @@ class SpinnerFrames:
         bytes
             Image data encoded in the instance's configured format.
         """
-        from ..render.svg_rasterize import _svg_to_image
+        # Inline import: tests patch ``deux.render.svg_rasterize._svg_to_image``;
+        # importing it lazily keeps that patching point effective.
+        from ..render.svg_rasterize import _svg_to_image  # noqa: PLC0415
 
         svg_bytes = ET.tostring(root, encoding="unicode", xml_declaration=True)
         frame = _svg_to_image(

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -186,7 +186,7 @@ def _get_default_font_family() -> str:
     try:
         # Inline import: tests patch ``deux.render.theme.get_default_font_family``;
         # importing it lazily keeps that patching point effective.
-        from ..render.theme import get_default_font_family
+        from ..render.theme import get_default_font_family  # noqa: PLC0415
 
         return get_default_font_family()
     except ImportError:

--- a/src/deux/dui/svg_renderer.py
+++ b/src/deux/dui/svg_renderer.py
@@ -6,6 +6,7 @@ import base64
 import builtins
 import copy
 import functools
+import io
 import logging
 import math
 import os
@@ -14,16 +15,21 @@ import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from defusedxml import DefusedXmlException
-from PIL import ImageFont
-
-if TYPE_CHECKING:
-    from PIL import Image
+from PIL import Image, ImageFont
 
 from .._xml import safe_fromstring
 from ..render.context import RenderingContext
+from ..render.svg_rasterize import (
+    _rasterize_svg,
+    _svg_to_image,
+    compose_svg_layers,
+    inject_background_rect,
+    set_svg_dimensions,
+    slice_background_viewbox,
+)
 from .iconify import IconifyError, fetch_icon
 from .schema import (
     Binding,
@@ -178,6 +184,8 @@ def _get_default_font_family() -> str:
         The default font family name.
     """
     try:
+        # Inline import: tests patch ``deux.render.theme.get_default_font_family``;
+        # importing it lazily keeps that patching point effective.
         from ..render.theme import get_default_font_family
 
         return get_default_font_family()
@@ -743,8 +751,6 @@ class SvgRenderer:
         panel_height : int
             Height of a single panel in pixels.
         """
-        from ..render.svg_rasterize import compose_svg_layers, slice_background_viewbox
-
         bg_slice = slice_background_viewbox(bg_root, card_index, panel_width, panel_height)
         card_layer = copy.deepcopy(self._original_root)
         card_layer.set("width", str(panel_width))
@@ -849,12 +855,6 @@ class SvgRenderer:
         bytes
             Encoded image bytes ready to send to the device.
         """
-        from ..render.svg_rasterize import (
-            _rasterize_svg,
-            inject_background_rect,
-            set_svg_dimensions,
-        )
-
         root = copy.deepcopy(self._base_root)
         self._reset_parent_map_cache()
 
@@ -1097,12 +1097,8 @@ class SvgRenderer:
             img_bytes = value
         else:
             # Accept PIL Image objects — encode to PNG bytes for embedding.
-            from PIL import Image as _PILImage
-
-            if isinstance(value, _PILImage.Image):
-                import io as _io
-
-                _buf = _io.BytesIO()
+            if isinstance(value, Image.Image):
+                _buf = io.BytesIO()
                 value.convert("RGBA").save(_buf, format="PNG")
                 img_bytes = _buf.getvalue()
             else:
@@ -1522,8 +1518,6 @@ class SvgRenderer:
         Image.Image
             An RGBA :class:`~PIL.Image.Image`.
         """
-        from ..render.svg_rasterize import _svg_to_image
-
         if self._target_width is not None and self._target_height is not None:
             width = self._target_width
             height = self._target_height

--- a/src/deux/render/background_layer.py
+++ b/src/deux/render/background_layer.py
@@ -15,6 +15,7 @@ import xml.etree.ElementTree as ET
 from typing import Literal
 
 from .._xml import safe_fromstring
+from .svg_rasterize import _rasterize_svg, _svg_to_image
 
 logger = logging.getLogger(__name__)
 _perf_logger = logging.getLogger("deux.render.profiler")
@@ -226,8 +227,6 @@ class BackgroundLayer:
 
     def _rasterize_touchstrip(self) -> None:
         """Rasterize and slice a touchstrip background SVG using Pillow."""
-        from .svg_rasterize import _svg_to_image
-
         assert self._svg is not None  # noqa: S101 — invariant
 
         t0 = time.perf_counter()
@@ -261,8 +260,6 @@ class BackgroundLayer:
 
     def _rasterize_key(self) -> None:
         """Rasterize a key background SVG to encoded device bytes."""
-        from .svg_rasterize import _rasterize_svg
-
         assert self._svg is not None  # noqa: S101 — invariant
 
         t0 = time.perf_counter()

--- a/src/deux/render/key_renderer.py
+++ b/src/deux/render/key_renderer.py
@@ -11,6 +11,8 @@ import time
 
 from PIL import Image
 
+from .touch_renderer import _parse_color
+
 _perf_logger = logging.getLogger("deux.render.profiler")
 
 
@@ -44,8 +46,6 @@ def render_key_image(
     bytes
         Encoded image bytes ready to send to the device.
     """
-    from .touch_renderer import _parse_color
-
     t0 = time.perf_counter()
     key_w, key_h = key_size
     r, g, b = _parse_color(background)

--- a/src/deux/render/svg_rasterize.py
+++ b/src/deux/render/svg_rasterize.py
@@ -24,12 +24,13 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from PIL import Image
+
 from .._errors import DeuxError
 from .._xml import safe_fromstring
 from .context import RenderingContext
 
 if TYPE_CHECKING:
-    from PIL import Image
     from resvg import usvg as _usvg_mod
 
 logger = logging.getLogger(__name__)
@@ -256,7 +257,10 @@ def _get_usvg_opts() -> _usvg_mod.Options:
     """
     opts = getattr(_thread_local, "usvg_opts", None)
     if opts is None:
-        from resvg import usvg
+        # Lazy import: resvg is an optional native dep; importing it lazily
+        # lets the module load even when resvg is missing so callers can
+        # catch the ImportError as a RasterizeError at call time.
+        from resvg import usvg  # noqa: PLC0415
 
         opts = usvg.Options.default()
         opts.load_system_fonts()
@@ -309,7 +313,8 @@ def _prepare_svg_tree(svg_data: bytes, width: int, height: int) -> _usvg_mod.Tre
     ET.register_namespace("xlink", _XLINK_NS)
     svg_text = ET.tostring(root, encoding="unicode", xml_declaration=False)
 
-    from resvg import usvg
+    # Lazy import: resvg is an optional native dep — see _get_usvg_opts.
+    from resvg import usvg  # noqa: PLC0415
 
     return usvg.Tree.from_str(svg_text, _get_usvg_opts())
 
@@ -343,7 +348,9 @@ def _resvg_rasterize(svg_data: bytes, width: int, height: int) -> bytes:
         If ``resvg`` is not installed or SVG parsing/rendering fails.
     """
     try:
-        from resvg import render as _resvg_render
+        # Lazy import: resvg is an optional native dep; the ImportError is
+        # caught below and re-raised as RasterizeError.
+        from resvg import render as _resvg_render  # noqa: PLC0415
 
         tree = _prepare_svg_tree(svg_data, width, height)
         png_bytes: bytes = _resvg_render(tree, (1.0, 0.0, 0.0, 0.0, 1.0, 0.0))
@@ -384,7 +391,9 @@ def _resvg_rasterize_rgba(
         If ``resvg`` is not installed or SVG parsing/rendering fails.
     """
     try:
-        from resvg import render_rgba as _resvg_render_rgba
+        # Lazy import: resvg is an optional native dep; the ImportError is
+        # caught below and re-raised as RasterizeError.
+        from resvg import render_rgba as _resvg_render_rgba  # noqa: PLC0415
 
         tree = _prepare_svg_tree(svg_data, width, height)
         rgba_bytes, w, h = _resvg_render_rgba(tree, (1.0, 0.0, 0.0, 0.0, 1.0, 0.0))
@@ -629,8 +638,6 @@ def _svg_to_image(
     RasterizeError
         If resvg is not available or rasterisation fails.
     """
-    from PIL import Image
-
     css = ctx.resolve_stylesheet() if ctx is not None else _stylesheet.css
 
     t0 = time.perf_counter()

--- a/src/deux/render/theme.py
+++ b/src/deux/render/theme.py
@@ -27,6 +27,8 @@ import colorsys
 import logging
 import random
 
+from .svg_rasterize import set_svg_stylesheet
+
 logger = logging.getLogger(__name__)
 
 # Default primary colour: rgb(39, 87, 179)
@@ -402,8 +404,6 @@ def set_active_theme(theme: Theme | None) -> None:
         default theme.
     """
     global _active_theme  # noqa: PLW0603
-    from .svg_rasterize import set_svg_stylesheet
-
     _active_theme = Theme.default() if theme is None else theme
     set_svg_stylesheet(_active_theme.css)
     logger.debug("Active theme set to %r", _active_theme)

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -8,7 +8,9 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from .._errors import DeuxError
+from ..dui.key import DuiKey
 from ..render.metrics import RenderMetrics
+from ..render.theme import get_active_theme
 from ._executor import get_executor
 from .async_event import AsyncEvent
 from .capabilities import DeviceCapabilities
@@ -253,8 +255,9 @@ class Deck:
         device.  Failures to stop an individual spinner are logged
         and swallowed — shutdown must never raise.
         """
+        # Inline import: dui.card transitively imports runtime.events, which
+        # triggers runtime package init while this module is still loading.
         from ..dui.card import DuiCard
-        from ..dui.key import DuiKey
 
         for screen in self._screens.values():
             for key_slot in screen.keys.values():
@@ -285,6 +288,8 @@ class Deck:
         This prevents handler accumulation across reconnect cycles
         without breaking reactive bindings to external services.
         """
+        # Inline import: dui.card transitively imports runtime.events, which
+        # triggers runtime package init while this module is still loading.
         from ..dui.card import DuiCard
 
         deck_events = (self.on_brightness_changed, self.on_screen_changed)
@@ -437,6 +442,8 @@ class Deck:
         Call this after all screens have been set up (keys and cards
         installed) to avoid network latency on first render.
         """
+        # Inline import: tests patch ``deux.dui.iconify.prefetch_icons``;
+        # importing it lazily keeps that patching point effective.
         from ..dui.iconify import prefetch_icons
 
         all_icons: set[str] = set()
@@ -455,8 +462,6 @@ class Deck:
         str
             CSS stylesheet string from the most specific theme.
         """
-        from ..render.theme import get_active_theme
-
         screen = self._active_screen
         if screen is not None and screen.theme is not None:
             return screen.theme.css
@@ -515,6 +520,8 @@ class Deck:
             If the device is not opened — capabilities are required to
             size the screen, and they are only known after :meth:`start`.
         """
+        # Inline import: ui.screen transitively imports runtime.events via
+        # ui.touch_strip -> ui.cards.base, creating a cycle at module load.
         from ..ui.screen import Screen
 
         if self._caps is None:

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -257,7 +257,7 @@ class Deck:
         """
         # Inline import: dui.card transitively imports runtime.events, which
         # triggers runtime package init while this module is still loading.
-        from ..dui.card import DuiCard
+        from ..dui.card import DuiCard  # noqa: PLC0415
 
         for screen in self._screens.values():
             for key_slot in screen.keys.values():
@@ -290,7 +290,7 @@ class Deck:
         """
         # Inline import: dui.card transitively imports runtime.events, which
         # triggers runtime package init while this module is still loading.
-        from ..dui.card import DuiCard
+        from ..dui.card import DuiCard  # noqa: PLC0415
 
         deck_events = (self.on_brightness_changed, self.on_screen_changed)
         for screen in self._screens.values():
@@ -444,7 +444,7 @@ class Deck:
         """
         # Inline import: tests patch ``deux.dui.iconify.prefetch_icons``;
         # importing it lazily keeps that patching point effective.
-        from ..dui.iconify import prefetch_icons
+        from ..dui.iconify import prefetch_icons  # noqa: PLC0415
 
         all_icons: set[str] = set()
         for screen in self._screens.values():
@@ -522,7 +522,7 @@ class Deck:
         """
         # Inline import: ui.screen transitively imports runtime.events via
         # ui.touch_strip -> ui.cards.base, creating a cycle at module load.
-        from ..ui.screen import Screen
+        from ..ui.screen import Screen  # noqa: PLC0415
 
         if self._caps is None:
             raise DeckError("Device not opened")

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -14,14 +14,15 @@ from typing import TYPE_CHECKING, Any, cast
 
 from ..dui.animator import DeviceUnavailable
 from ..dui.key import DuiKey
+from ..render.context import RenderingContext
 from ..render.key_renderer import render_blank_key
 from ..render.profiler import RenderProfiler
+from ..render.svg_rasterize import set_svg_stylesheet
 from ..render.touch_renderer import composite_frame_on_tile
 from .hid._ctypes_hidapi import HidApiError
 
 if TYPE_CHECKING:
     from ..dui.animator import PushFn
-    from ..render.context import RenderingContext
     from ..render.metrics import RenderMetrics
     from ..ui.cards.base import Card
     from ..ui.controls.key_slot import KeySlot
@@ -395,8 +396,10 @@ class DeckRenderer:
         -------
         bool
             ``True`` if the card should be rendered this cycle (i.e. it
-            is dirty and not currently animating); ``False`` otherwise.
+             is dirty and not currently animating); ``False`` otherwise.
         """
+        # Inline import: dui.card transitively imports runtime.events, which
+        # triggers runtime package init while this module is still loading.
         from ..dui.card import DuiCard
 
         if isinstance(card, DuiCard):
@@ -604,6 +607,8 @@ class DeckRenderer:
         # 1. Prefetch icons
         icons = screen.collect_all_icons()
         if icons:
+            # Inline import: tests patch ``deux.dui.iconify.prefetch_icons``;
+            # importing it lazily keeps that patching point effective.
             from ..dui.iconify import prefetch_icons
 
             with prof.step("prefetch_icons"):
@@ -631,9 +636,6 @@ class DeckRenderer:
         stylesheet is also updated so that renderers without an explicit
         context pick up the correct CSS.
         """
-        from ..render.context import RenderingContext
-        from ..render.svg_rasterize import set_svg_stylesheet
-
         css = self._deck.resolve_stylesheet()
 
         # Update global stylesheet for renderers without an explicit context.
@@ -651,8 +653,9 @@ class DeckRenderer:
         ctx : RenderingContext
             The context to propagate.
         """
+        # Inline import: dui.card transitively imports runtime.events, which
+        # triggers runtime package init while this module is still loading.
         from ..dui.card import DuiCard
-        from ..dui.key import DuiKey
 
         screen = self._deck.active_screen
         if screen is None:

--- a/src/deux/runtime/renderer.py
+++ b/src/deux/runtime/renderer.py
@@ -400,7 +400,7 @@ class DeckRenderer:
         """
         # Inline import: dui.card transitively imports runtime.events, which
         # triggers runtime package init while this module is still loading.
-        from ..dui.card import DuiCard
+        from ..dui.card import DuiCard  # noqa: PLC0415
 
         if isinstance(card, DuiCard):
             card.set_bg_tile(bg_tile)
@@ -609,7 +609,7 @@ class DeckRenderer:
         if icons:
             # Inline import: tests patch ``deux.dui.iconify.prefetch_icons``;
             # importing it lazily keeps that patching point effective.
-            from ..dui.iconify import prefetch_icons
+            from ..dui.iconify import prefetch_icons  # noqa: PLC0415
 
             with prof.step("prefetch_icons"):
                 await prefetch_icons(icons)
@@ -655,7 +655,7 @@ class DeckRenderer:
         """
         # Inline import: dui.card transitively imports runtime.events, which
         # triggers runtime package init while this module is still loading.
-        from ..dui.card import DuiCard
+        from ..dui.card import DuiCard  # noqa: PLC0415
 
         screen = self._deck.active_screen
         if screen is None:

--- a/src/deux/runtime/transport.py
+++ b/src/deux/runtime/transport.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from ._executor import get_executor
 from .events import (
     DeckEvent,
     EncoderPressEvent,
@@ -19,6 +20,7 @@ from .events import (
     KeyEvent,
     TouchEvent,
 )
+from .hid._ctypes_hidapi import HidApiError
 from .hid.protocol import (
     EncoderButtonEvent,
     EncoderRotateEvent,
@@ -90,9 +92,6 @@ class AsyncTransport:
 
     async def _poll_loop(self) -> None:
         """Background task: poll HID input and enqueue events."""
-        from ._executor import get_executor
-        from .hid._ctypes_hidapi import HidApiError
-
         loop = asyncio.get_running_loop()
         executor = get_executor()
 

--- a/src/deux/tools/preview.py
+++ b/src/deux/tools/preview.py
@@ -475,7 +475,9 @@ def _find_and_open_device() -> PreviewDeckDevice:
 
     Prints an error and exits if no device is found.
     """
-    from deux.runtime.hid.discovery import enumerate_devices
+    # Inline import: tests patch ``deux.runtime.hid.discovery.enumerate_devices``;
+    # importing it lazily keeps that patching point effective.
+    from deux.runtime.hid.discovery import enumerate_devices  # noqa: PLC0415
 
     devices = enumerate_devices()
     if not devices:

--- a/src/deux/ui/cards/base.py
+++ b/src/deux/ui/cards/base.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from ...render.touch_renderer import compose_card_with_background
 from ...runtime.events import AsyncHandler, EventType, TouchEvent
 
 if TYPE_CHECKING:
@@ -302,16 +304,12 @@ class Card(ABC):
         bytes
             Encoded image bytes ready to send to the device.
         """
-        from ...render.touch_renderer import compose_card_with_background
-
         rendered = self.render()
         self.set_rendered(rendered)
 
         # Convert PIL Image to PNG bytes for compositing.
         card_bytes: bytes | None = None
         if rendered is not None:
-            import io
-
             buf = io.BytesIO()
             rendered.save(buf, format="PNG")
             card_bytes = buf.getvalue()

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+from PIL import Image
+
 from ..dui.key import DuiKey
 from ..render.background_layer import BackgroundLayer
 from ..render.defaults import get_default_backgrounds
@@ -415,7 +417,7 @@ class Screen:
         """
         # Inline import: dui.card imports ui.cards.base, which would create
         # a cycle if hoisted to module top.
-        from ..dui.card import DuiCard
+        from ..dui.card import DuiCard  # noqa: PLC0415
 
         icons: set[str] = set()
         for key_slot in self._keys.values():
@@ -457,8 +459,6 @@ class Screen:
             # [PosixPath('/tmp/deck_screenshot/key_0.png'),
             #  PosixPath('/tmp/deck_screenshot/card_1.png')]
         """
-        from PIL import Image
-
         out_dir = Path(directory)
         out_dir.mkdir(parents=True, exist_ok=True)
         written: list[Path] = []

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import io
 import logging
+import xml.etree.ElementTree as ET
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+from ..dui.key import DuiKey
 from ..render.background_layer import BackgroundLayer
+from ..render.defaults import get_default_backgrounds
+from ..render.metrics import RenderMetrics
+from ..render.svg_rasterize import RasterizeError
 from .controls.encoder_slot import EncoderSlot
 from .controls.key_slot import KeySlot
 from .info_screen import InfoScreen
@@ -60,8 +65,6 @@ class Screen:
         self._key_bg_dirty: bool = False
 
         if self._caps.has_touchscreen and self._caps.dial_count > 0:
-            from ..render.metrics import RenderMetrics
-
             metrics = RenderMetrics(self._caps)
             self._touch_strip: TouchStrip | None = TouchStrip(
                 panel_count=metrics.panel_count,
@@ -95,11 +98,6 @@ class Screen:
         background has been explicitly configured.  Failures are logged
         but never raised — defaults are best-effort.
         """
-        import xml.etree.ElementTree as ET
-
-        from ..render.defaults import get_default_backgrounds
-        from ..render.svg_rasterize import RasterizeError
-
         try:
             backgrounds = get_default_backgrounds(
                 self._caps.vendor_id, self._caps.product_id
@@ -415,8 +413,9 @@ class Screen:
             A set of ``"prefix:icon"`` strings used across all
             keys and cards on this screen.
         """
+        # Inline import: dui.card imports ui.cards.base, which would create
+        # a cycle if hoisted to module top.
         from ..dui.card import DuiCard
-        from ..dui.key import DuiKey
 
         icons: set[str] = set()
         for key_slot in self._keys.values():


### PR DESCRIPTION
## Issue validity assessment

Issue #326 is **valid and actionable**: it identifies a clear code-quality
problem with concrete file references, a specific suggested convention,
and a justified rationale (hot-path overhead, hidden coupling, reviewer
clarity).

## Fix

Two commits:

### 1. `refactor: hoist inline imports and standardise convention`

Adopt a project-wide rule: imports at module top, circular dependencies
handled via `if TYPE_CHECKING` blocks and string annotations.

Hoisted imports in the five files called out by the issue plus moved the
`__version__` import to the top of `src/deux/__init__.py` (it was previously
placed after `__all__`, which already referenced it).

### 2. `lint: enforce top-level imports via ruff PLC0415`

Adds `PLC0415` to the ruff lint set so the convention is enforced
mechanically rather than living only in a PR description. Each remaining
inline import now carries a `# noqa: PLC0415` with a one-line reason,
in three documented categories:

- **True circular-import avoidance** (runtime/* <-> dui/*, ui/screen).
- **Monkeypatch-target preservation**: tests patch a symbol on its
  source module, so importing it lazily keeps the patch point effective
  (e.g. `resolve_dui`, `prefetch_icons`, `get_default_font_family`,
  `_svg_to_image`, `_encode_image_bytes`, `enumerate_devices`).
- **Optional native dependency**: `render/svg_rasterize` lazily imports
  the `resvg` package and re-raises `ImportError` as `RasterizeError`,
  so the module still loads when `resvg` is missing.

While auditing, also hoisted previously-inline imports in `dui/spinner.py`,
`render/{background_layer,key_renderer,svg_rasterize,theme}.py`,
`runtime/transport.py`, `ui/cards/base.py`, and `ui/screen.py` where no
cycle or patching constraint existed.

`tests/*` is excluded from `PLC0415` to allow legitimate lazy imports
(deferred patching, optional deps, import-error tests), mirroring the
existing `B011` exception.

## Checks run

- `uv run ruff check .` — All checks passed
- `uv run mypy src/deux` — Success: no issues found in 65 source files
- `uv run pytest tests/ --cov=deux --cov-fail-under=95` — 1868 passed, 1 skipped, 95.46% coverage

Closes #326