### PR TITLE
docs: add NumPy-style docstrings to public __init__ methods

### DIFF
--- a/src/deux/_errors.py
+++ b/src/deux/_errors.py
@@ -13,9 +13,4 @@ from __future__ import annotations
 
 
 class DeuxError(Exception):
-    """Root exception for every error raised by the deux library.
-
-    Application code can catch ``DeuxError`` to handle any
-    library-level failure in a single clause while still being
-    able to catch more specific subclasses when needed.
-    """
+    """Root exception for every error raised by the deux library."""

--- a/src/deux/dui/card.py
+++ b/src/deux/dui/card.py
@@ -59,16 +59,35 @@ class DuiCard(BindingMixin, Card):
 
     The card index is assigned automatically when you install the card
     on a screen with :meth:`~deux.ui.screen.Screen.set_card`.
-
-    Parameters
-    ----------
-    spec : PackageSpec or str
-        A validated :class:`~deux.dui.schema.PackageSpec`, or a
-        package name (e.g. ``"DashboardCard"``) to resolve from the
-        DUI repository.
     """
 
     def __init__(self, spec: PackageSpec | str) -> None:
+        """Construct a DUI-backed touchscreen card.
+
+        Parameters
+        ----------
+        spec : PackageSpec or str
+            Either a pre-validated
+            :class:`~deux.dui.schema.PackageSpec`, or a package name
+            (for example ``"DashboardCard"``) to resolve from the DUI
+            repository.  String resolution is deferred to
+            :func:`~deux.dui.repository.resolve_dui` at call time so
+            tests that monkeypatch that symbol behave correctly.
+
+        Raises
+        ------
+        deux.dui.repository.PackageError
+            If *spec* is a string and no matching package is found in
+            any registered search path.
+
+        Notes
+        -----
+        Construction performs no rendering and no device I/O.  The
+        underlying :class:`~deux.dui.svg_renderer.SvgRenderer` and
+        :class:`~deux.dui.events.EventMap` are built eagerly from
+        *spec*; binding values, push callbacks, and background tiles
+        are configured later via the corresponding setters.
+        """
         if isinstance(spec, str):
             # Inline import: keeps the lookup go through repository.resolve_dui
             # at call time so monkeypatching that symbol in tests works.

--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -71,13 +71,29 @@ class Deck:
         serial_number: str,
         brightness: int = 80,
     ) -> None:
-        """
+        """Construct a deck handle for the given serial number.
+
+        Instances are normally created by :class:`DeckManager` in
+        response to a device-connect event; application code receives
+        them via ``on_connect`` handlers.  For unit tests that need a
+        deck without HID I/O, use :meth:`Deck.for_testing`.
+
         Parameters
         ----------
-        serial_number
-            The serial number of the target device.
-        brightness
-            Initial brightness (0-100).
+        serial_number : str
+            Serial number of the target device.  Used during
+            :meth:`start` to locate the matching HID device.
+        brightness : int, default=80
+            Initial brightness percentage in ``[0, 100]`` applied once
+            the device is opened.
+
+        Notes
+        -----
+        Construction performs no I/O.  The HID device is opened and the
+        event loop started by :meth:`start`.  The
+        :attr:`on_brightness_changed` and :attr:`on_screen_changed`
+        events are wired up here and ready for subscription before
+        :meth:`start` is called.
         """
         self._serial_number = serial_number
         self._brightness = brightness

--- a/src/deux/runtime/manager.py
+++ b/src/deux/runtime/manager.py
@@ -51,17 +51,6 @@ class DeckManager:
 
         async with manager:
             await manager.wait_closed()
-
-    Parameters
-    ----------
-    poll_interval
-        Seconds between device scans (default 2.0).
-    brightness
-        Default brightness for new Deck instances (0-100).
-    auto_reconnect
-        If ``True`` (default), automatically reconnect
-        devices that disconnect.  The ``on_connect`` handler is
-        called again on reconnection.
     """
 
     def __init__(
@@ -70,6 +59,32 @@ class DeckManager:
         brightness: int = 80,
         auto_reconnect: bool = True,
     ) -> None:
+        """Construct a deck manager.
+
+        Construction is side-effect free; no devices are scanned until
+        :meth:`start` is called (directly or via ``async with``).
+
+        Parameters
+        ----------
+        poll_interval : float, default=2.0
+            Seconds between HID device scans.  Lower values detect
+            hot-plug events faster at the cost of more frequent
+            enumeration.
+        brightness : int, default=80
+            Default brightness percentage in ``[0, 100]`` applied to
+            newly connected :class:`Deck` instances.
+        auto_reconnect : bool, default=True
+            When ``True``, devices that disconnect are automatically
+            reopened on the next scan and registered ``on_connect``
+            handlers fire again.  When ``False``, disconnected devices
+            stay disconnected until the next manual restart.
+
+        Notes
+        -----
+        The scan loop, executor lifecycle, and event subscriptions are
+        created lazily by :meth:`start`; constructing a manager is
+        cheap and does no I/O.
+        """
         self._poll_interval = poll_interval
         self._brightness = brightness
         self._auto_reconnect = auto_reconnect

--- a/src/deux/ui/screen.py
+++ b/src/deux/ui/screen.py
@@ -54,6 +54,36 @@ class Screen:
     """
 
     def __init__(self, name: str, caps: DeviceCapabilities) -> None:
+        """Initialise a screen for the given device capabilities.
+
+        Screens are normally created via :meth:`Deck.screen` rather than
+        instantiated directly; the deck supplies the matching device
+        capabilities.
+
+        Parameters
+        ----------
+        name : str
+            Identifier used to look up and activate this screen via
+            :meth:`Deck.set_screen`.
+        caps : DeviceCapabilities
+            Capability snapshot describing the target device.  Drives
+            which controls are provisioned (touch strip, info screen)
+            and which slot indices are valid.
+
+        Notes
+        -----
+        Construction has the following side effects:
+
+        * A :class:`~deux.render.background_layer.BackgroundLayer` is
+          created for keys regardless of device.
+        * A :class:`~deux.ui.touch_strip.TouchStrip` is provisioned only
+          when the device has both a touchscreen and at least one dial.
+        * An :class:`~deux.ui.info_screen.InfoScreen` is provisioned
+          only when the device reports an info screen.
+        * Bundled default backgrounds for the device's VID:PID are
+          applied on a best-effort basis; failures are logged but never
+          raised.
+        """
         self._name = name
         self._caps = caps
         self._keys: dict[int, KeySlot] = {}


### PR DESCRIPTION
Closes #327

## Validity assessment

Valid and actionable. The issue is a documentation-compliance task that aligns with the project convention in `AGENTS.md` requiring NumPy-style docstrings on public methods (including constructors). Verified each gap:

- `Screen.__init__` (`src/deux/ui/screen.py:56`) had no docstring at all.
- `Deck.__init__` (`src/deux/runtime/deck.py:69`) had a minimal `Parameters`-only stub.
- `DeckManager.__init__` (`src/deux/runtime/manager.py:67`) had no docstring; parameters were only documented on the class docstring.
- `DuiCard.__init__` (`src/deux/dui/card.py:71`) had no docstring; parameters were only documented on the class docstring.
- `src/deux/_errors.py` duplicated the module-level explanation in the `DeuxError` class docstring.

Labels `area:docs`, `documentation`, `severity:low` confirm scope. No behavioural change required.

## Fix

Pure docstring changes, no code-behaviour changes:

- **`src/deux/ui/screen.py`** — added a full NumPy-style docstring to `Screen.__init__` with `Parameters` (`name`, `caps`) and `Notes` documenting side effects (touch strip / info screen provisioning, best-effort default backgrounds).
- **`src/deux/runtime/deck.py`** — expanded `Deck.__init__` with a summary cross-referencing `DeckManager` and `for_testing`, typed `Parameters`, and `Notes` clarifying that construction performs no I/O.
- **`src/deux/runtime/manager.py`** — added a NumPy-style docstring to `DeckManager.__init__` (typed `Parameters` for `poll_interval`, `brightness`, `auto_reconnect` and `Notes` on lazy startup). Removed the now-duplicate `Parameters` block from the class docstring; the class docstring retains the conceptual overview and Examples.
- **`src/deux/dui/card.py`** — added a NumPy-style docstring to `DuiCard.__init__` (`Parameters`, `Raises` referencing `PackageError` from `resolve_dui`, and `Notes` about the deferred-import pattern). Removed the duplicate `Parameters` block from the class docstring.
- **`src/deux/_errors.py`** — collapsed the redundant `DeuxError` class docstring to a single canonical line; the module docstring remains the single source of truth and example.

## Tests / checks run

All commands run from a clean working tree on this branch:

```
ruff check .                       # All checks passed!
mypy src/deux                      # Success: no issues found in 65 source files
uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95
# 1868 passed, 1 skipped
# Required test coverage of 95% reached. Total coverage: 95.46%
```

No new tests added — pure docstring edits with no observable behaviour to cover.