### PR TITLE
docs: remove unsupported Stream Deck Mini from supported devices list (#348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A high-level, asyncio-native Python library for Elgato Stream Deck devices. Defi
 - TouchStrip and InfoScreen support
 - `.dui` package format: declarative touchscreen card UIs using SVG layouts + YAML manifests with data bindings
 - Iconify icon integration
-- Supports Stream Deck+, Mini, Neo, and XL
+- Supports Stream Deck (Classic 15-key), Stream Deck XL, Stream Deck Neo, Stream Deck+, and Stream Deck+ XL
 
 ## System requirements
 


### PR DESCRIPTION
## Issue validity assessment

Issue #348 is **valid**. Verified:
- `README.md:24` advertised support for Stream Deck Mini.
- `src/deux/runtime/hid/protocol.py` explicitly states the legacy Stream Deck Mini protocol is not supported by DeUX.
- The PID rotation map (`protocol.py`) and family map (`device.py`) contain no Mini PIDs — only Classic, XL, Neo, Plus, and Plus XL.

The claim is actively misleading to users who might purchase a Mini expecting compatibility.

## Fix

Replaced the inaccurate line in `README.md` with the actual supported family:

> Supports Stream Deck (Classic 15-key), Stream Deck XL, Stream Deck Neo, Stream Deck+, and Stream Deck+ XL

`docs/index.md` is a symlink to `README.md` so it picks up the change automatically. The reference to Mini in `docs/elgato-hid-protocol.md` is accurate (it explains the legacy Mini protocol is *not* covered) and was left untouched.

## Checks run

- `ruff check .` — all checks passed
- `mypy src/deux` (strict) — no issues found in 67 source files
- `pytest tests/ --cov=deux --cov-fail-under=95` — 1974 passed, 1 skipped, 95.61% coverage

No tests added — doc-only change with no code paths affected.

Closes #348