### PR TITLE
docs: correct architecture diagram regeneration claim (#349)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,19 @@
 # Architecture
 
-Auto-generated diagrams showing the structure of the DeUX codebase.
-These are regenerated from source on every docs build.
+Diagrams showing the structure of the DeUX codebase.
+
+These SVGs are produced from source by `tools/generate_diagrams.py` (invoked
+automatically via `docs/gen_diagrams.py` during `mkdocs build`). They are
+**not** committed to the repository — they are written into
+`docs/architecture/` (which is listed in `.gitignore`) at build time and
+require both [Graphviz](https://graphviz.org/) (`dot` on `PATH`) and
+[`pylint`](https://pypi.org/project/pylint/) (which ships `pyreverse`).
+
+To refresh them locally outside of a docs build, run:
+
+```bash
+python tools/generate_diagrams.py
+```
 
 ## Class Diagram
 


### PR DESCRIPTION
Fixes #349.

## Issue validity assessment

**Valid.** The text in `docs/architecture.md:3-4` claimed:

> Auto-generated diagrams showing the structure of the DeUX codebase.
> These are regenerated from source on every docs build.

That wording is misleading. While `docs/gen_diagrams.py` is wired into `mkdocs.yml` via the `gen-files` plugin, the claim glosses over:

- The SVGs are **not** committed (`docs/architecture/` is already in `.gitignore`), so a fresh checkout has no diagrams until `mkdocs build` runs.
- Regeneration silently requires two non-trivial system prerequisites: Graphviz (`dot`) and `pylint` (for `pyreverse`). Without them the build fails or produces nothing.
- There is no documented way to refresh diagrams locally outside of running the full docs build.

The reporter's secondary claim that the SVGs are committed was verified against `git ls-files docs/architecture/` and is not accurate on `main` today — but the doc text itself is still wrong, and that is the substantive bug.

The issue suggested two options. I chose a variant of option (b): keep the existing build-time regeneration mechanism (it works and is wired up), and rewrite the docs text to be accurate. Option (a) (deleting `gen_diagrams.py` from `mkdocs.yml`) would regress functionality already in place.

## Fix

Rewrote the intro of `docs/architecture.md` to:

- Describe the actual generation flow (`tools/generate_diagrams.py` invoked from `docs/gen_diagrams.py` during `mkdocs build`).
- Note that the SVGs are gitignored, not committed.
- Document the required tooling (`dot`, `pyreverse`).
- Give an explicit one-liner for local refresh.

## Tests / checks run

- `ruff check .` — All checks passed.
- `mypy src/deux/` (matches CI in `.github/workflows/python-typecheck.yml`) — Success, no issues in 67 source files.
- `uv run python -m pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` — **1974 passed, 1 skipped**, total coverage **95.61%**.

No code paths changed; the fix is documentation-only, so no new tests were added.