### PR TITLE
docs: surface nested sub-packages in API reference (#351)

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,34 +1,57 @@
 """Auto-generate API reference pages for mkdocstrings.
 
 This script is executed by the mkdocs-gen-files plugin during ``mkdocs build``.
-It recursively walks the ``src/deux`` package tree and creates a virtual
-``reference/<path>.md`` page for every public sub-package **and** every public
-top-level module within those sub-packages. Each page contains the appropriate
-``::: deux.<dotted.path>`` directive so that *mkdocstrings* renders the API
-docs from docstrings automatically.
+It walks the ``src/deux`` package tree and creates a virtual
+``reference/<path>.md`` page for every public sub-package, and additionally
+emits dedicated pages for nested sub-packages and modules **only when the
+parent ``__init__.py`` does not already re-export them**. Each page contains
+the appropriate ``::: deux.<dotted.path>`` directive so that *mkdocstrings*
+renders the API docs from docstrings automatically.
 
 A ``reference/SUMMARY.md`` file is also generated so that *mkdocs-literate-nav*
 can build a hierarchical sidebar without manual ``nav:`` entries.
 
-Why recursive?
---------------
+Why conditional recursion?
+--------------------------
 The previous implementation only walked the top-level sub-packages of
 ``src/deux`` and relied on each ``__init__.py`` re-exporting everything of
 interest. That left several user-facing surfaces invisible in the rendered
 reference (notably ``deux.runtime.hid`` and the CLI modules under
-``deux.tools``). Walking recursively and emitting one page per public package
-**and** per public module guarantees full coverage regardless of how
-aggressively a parent ``__init__`` re-exports.
+``deux.tools``, whose ``__init__.py`` is a stub).
+
+Naively emitting a page for every nested module would instead produce
+duplicate mkdocstrings anchors for symbols already documented on the parent
+package page (e.g. ``deux.dui.resolve_dui`` re-exported from
+``deux.dui.repository``). Those duplicates trip ``mkdocs --strict`` autoref
+warnings. The recursion therefore descends only into child modules whose
+symbols are *not* re-exported by their parent ``__init__.py``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import mkdocs_gen_files
 
 SRC = Path("src")
 PACKAGE = "deux"
+
+# Matches ``from .<child>`` and ``from .<child>.<...>`` imports in an
+# ``__init__.py``. The capture group yields the immediate child name.
+_REEXPORT_RE = re.compile(r"^\s*from\s+\.([A-Za-z_][A-Za-z0-9_]*)\b", re.MULTILINE)
+
+
+def _reexported_children(init_path: Path) -> frozenset[str]:
+    """Return the set of immediate children re-exported by an ``__init__.py``.
+
+    A child ``foo`` is considered re-exported when the parent ``__init__``
+    contains ``from .foo import ...`` or ``from .foo.bar import ...``.
+    """
+    if not init_path.is_file():
+        return frozenset()
+    text = init_path.read_text(encoding="utf-8")
+    return frozenset(_REEXPORT_RE.findall(text))
 
 
 def _is_public(path: Path) -> bool:
@@ -64,6 +87,10 @@ def _emit_module_page(dotted: str, doc_path: str, edit_path: str, title: str) ->
 def _walk_package(pkg_dir: Path, depth: int, dotted_prefix: str, rel_prefix: str) -> None:
     """Recursively emit reference pages for ``pkg_dir``.
 
+    Children whose symbols are re-exported by ``pkg_dir/__init__.py`` are
+    skipped so we do not produce duplicate mkdocstrings anchors that would
+    break ``mkdocs --strict``.
+
     Parameters
     ----------
     pkg_dir : Path
@@ -77,6 +104,14 @@ def _walk_package(pkg_dir: Path, depth: int, dotted_prefix: str, rel_prefix: str
         Path under ``reference/`` matching ``dotted_prefix`` without the
         leading ``deux`` segment (e.g. ``runtime`` or ``runtime/hid``).
     """
+    reexports = _reexported_children(pkg_dir / "__init__.py")
+    # The reference root (``src/deux`` itself) is depth 0. Its immediate
+    # children are the top-level sub-package landing pages and must always
+    # be emitted regardless of how aggressively ``deux/__init__.py``
+    # re-exports them, otherwise we would regress the existing reference
+    # surface entirely.
+    suppress_reexports = depth > 0
+
     # Collect sub-packages and public top-level modules.
     sub_packages: list[Path] = []
     sub_modules: list[Path] = []
@@ -90,16 +125,31 @@ def _walk_package(pkg_dir: Path, depth: int, dotted_prefix: str, rel_prefix: str
 
     for sub in sub_packages:
         name = sub.name
-        dotted = f"{dotted_prefix}.{name}"
-        rel = f"{rel_prefix}/{name}" if rel_prefix else name
-        doc_path = f"reference/{rel}.md"
-        edit_path = f"../src/{PACKAGE}/{rel}/__init__.py"
-        _emit_module_page(dotted, doc_path, edit_path, _title(name))
-        nav_entries.append((depth, _title(name), f"{rel}.md"))
-        _walk_package(sub, depth + 1, dotted, rel)
+        # Always recurse — a re-exported child may itself contain non-
+        # re-exported grandchildren that we still want to surface.
+        if not suppress_reexports or name not in reexports:
+            dotted = f"{dotted_prefix}.{name}"
+            rel = f"{rel_prefix}/{name}" if rel_prefix else name
+            doc_path = f"reference/{rel}.md"
+            edit_path = f"../src/{PACKAGE}/{rel}/__init__.py"
+            _emit_module_page(dotted, doc_path, edit_path, _title(name))
+            nav_entries.append((depth, _title(name), f"{rel}.md"))
+            _walk_package(sub, depth + 1, f"{dotted_prefix}.{name}", rel)
+        else:
+            # Re-exported sub-package: descend without emitting a page so
+            # any non-re-exported grandchildren still appear, but skip
+            # adding nav entries that would clutter the hierarchy.
+            _walk_package(
+                sub,
+                depth + 1,
+                f"{dotted_prefix}.{name}",
+                f"{rel_prefix}/{name}" if rel_prefix else name,
+            )
 
     for mod in sub_modules:
         name = mod.stem
+        if suppress_reexports and name in reexports:
+            continue
         dotted = f"{dotted_prefix}.{name}"
         rel = f"{rel_prefix}/{name}" if rel_prefix else name
         doc_path = f"reference/{rel}.md"
@@ -112,7 +162,10 @@ _walk_package(SRC / PACKAGE, depth=0, dotted_prefix=PACKAGE, rel_prefix="")
 
 
 # Write the SUMMARY consumed by mkdocs-literate-nav. Indentation drives nesting.
+# Python-markdown's list parser requires each nested level to be indented by
+# *two* spaces relative to the parent's bullet content; using four spaces
+# would be interpreted as a paragraph continuation, not a sub-list.
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as f:
     for depth, title, href in nav_entries:
-        indent = "    " * depth
+        indent = "  " * depth
         f.write(f"{indent}- [{title}]({href})\n")

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,14 +1,27 @@
 """Auto-generate API reference pages for mkdocstrings.
 
 This script is executed by the mkdocs-gen-files plugin during ``mkdocs build``.
-It walks the ``src/deux`` package tree and creates a virtual
-``reference/<module>.md`` page for every public sub-package, each containing
-the appropriate ``::: deux.<module>`` directive so that *mkdocstrings*
-renders the API docs from docstrings automatically.
+It recursively walks the ``src/deux`` package tree and creates a virtual
+``reference/<path>.md`` page for every public sub-package **and** every public
+top-level module within those sub-packages. Each page contains the appropriate
+``::: deux.<dotted.path>`` directive so that *mkdocstrings* renders the API
+docs from docstrings automatically.
 
 A ``reference/SUMMARY.md`` file is also generated so that *mkdocs-literate-nav*
-can build the sidebar navigation without manual ``nav:`` entries.
+can build a hierarchical sidebar without manual ``nav:`` entries.
+
+Why recursive?
+--------------
+The previous implementation only walked the top-level sub-packages of
+``src/deux`` and relied on each ``__init__.py`` re-exporting everything of
+interest. That left several user-facing surfaces invisible in the rendered
+reference (notably ``deux.runtime.hid`` and the CLI modules under
+``deux.tools``). Walking recursively and emitting one page per public package
+**and** per public module guarantees full coverage regardless of how
+aggressively a parent ``__init__`` re-exports.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 
@@ -17,25 +30,89 @@ import mkdocs_gen_files
 SRC = Path("src")
 PACKAGE = "deux"
 
-nav_lines: list[str] = []
 
-# Generate one page per top-level sub-package (runtime, ui, dui, render, tools)
-for child in sorted((SRC / PACKAGE).iterdir()):
-    if not child.is_dir() or child.name.startswith("_"):
-        continue
-    if not (child / "__init__.py").exists():
-        continue
+def _is_public(path: Path) -> bool:
+    """Return ``True`` if a path represents a public module or package.
 
-    module_path = f"{PACKAGE}.{child.name}"
-    doc_path = f"reference/{child.name}.md"
+    Public means the file/directory name does not start with an underscore
+    and is not a ``__pycache__`` directory.
+    """
+    name = path.name
+    if name.startswith("_"):
+        return False
+    return name != "__pycache__"
 
+
+def _title(name: str) -> str:
+    """Convert a module name like ``key_renderer`` to ``Key Renderer``."""
+    return name.replace("_", " ").title()
+
+
+# Each entry: (depth, title, doc_path_relative_to_reference)
+# depth is used to indent the SUMMARY.md so mkdocs-literate-nav nests entries.
+nav_entries: list[tuple[int, str, str]] = []
+
+
+def _emit_module_page(dotted: str, doc_path: str, edit_path: str, title: str) -> None:
+    """Write a single mkdocstrings page for ``dotted`` to ``doc_path``."""
     with mkdocs_gen_files.open(doc_path, "w") as f:
-        f.write(f"# {child.name.replace('_', ' ').title()}\n\n")
-        f.write(f"::: {module_path}\n")
+        f.write(f"# {title}\n\n")
+        f.write(f"::: {dotted}\n")
+    mkdocs_gen_files.set_edit_path(doc_path, edit_path)
 
-    mkdocs_gen_files.set_edit_path(doc_path, f"../src/{PACKAGE}/{child.name}/__init__.py")
-    nav_lines.append(f"- [{child.name.replace('_', ' ').title()}]({child.name}.md)")
 
-# Write the SUMMARY consumed by literate-nav
+def _walk_package(pkg_dir: Path, depth: int, dotted_prefix: str, rel_prefix: str) -> None:
+    """Recursively emit reference pages for ``pkg_dir``.
+
+    Parameters
+    ----------
+    pkg_dir : Path
+        Directory on disk containing ``__init__.py``.
+    depth : int
+        Nesting depth used for SUMMARY indentation (0 = top-level under
+        ``reference/``).
+    dotted_prefix : str
+        Dotted Python path of ``pkg_dir`` (e.g. ``deux.runtime``).
+    rel_prefix : str
+        Path under ``reference/`` matching ``dotted_prefix`` without the
+        leading ``deux`` segment (e.g. ``runtime`` or ``runtime/hid``).
+    """
+    # Collect sub-packages and public top-level modules.
+    sub_packages: list[Path] = []
+    sub_modules: list[Path] = []
+    for child in sorted(pkg_dir.iterdir()):
+        if not _is_public(child):
+            continue
+        if child.is_dir() and (child / "__init__.py").exists():
+            sub_packages.append(child)
+        elif child.is_file() and child.suffix == ".py" and child.stem != "__init__":
+            sub_modules.append(child)
+
+    for sub in sub_packages:
+        name = sub.name
+        dotted = f"{dotted_prefix}.{name}"
+        rel = f"{rel_prefix}/{name}" if rel_prefix else name
+        doc_path = f"reference/{rel}.md"
+        edit_path = f"../src/{PACKAGE}/{rel}/__init__.py"
+        _emit_module_page(dotted, doc_path, edit_path, _title(name))
+        nav_entries.append((depth, _title(name), f"{rel}.md"))
+        _walk_package(sub, depth + 1, dotted, rel)
+
+    for mod in sub_modules:
+        name = mod.stem
+        dotted = f"{dotted_prefix}.{name}"
+        rel = f"{rel_prefix}/{name}" if rel_prefix else name
+        doc_path = f"reference/{rel}.md"
+        edit_path = f"../src/{PACKAGE}/{rel}.py"
+        _emit_module_page(dotted, doc_path, edit_path, _title(name))
+        nav_entries.append((depth, _title(name), f"{rel}.md"))
+
+
+_walk_package(SRC / PACKAGE, depth=0, dotted_prefix=PACKAGE, rel_prefix="")
+
+
+# Write the SUMMARY consumed by mkdocs-literate-nav. Indentation drives nesting.
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as f:
-    f.write("\n".join(nav_lines) + "\n")
+    for depth, title, href in nav_entries:
+        indent = "    " * depth
+        f.write(f"{indent}- [{title}]({href})\n")

--- a/tests/test_gen_ref_pages.py
+++ b/tests/test_gen_ref_pages.py
@@ -1,0 +1,125 @@
+"""Tests for ``docs/gen_ref_pages.py``.
+
+These tests execute the script with a stubbed ``mkdocs_gen_files`` module so
+we can assert which virtual pages would be written during ``mkdocs build``.
+The key guarantees verified here address the regression reported in
+issue #351 — the API reference must surface nested sub-packages such as
+``deux.runtime.hid`` and the CLI modules under ``deux.tools``.
+"""
+
+from __future__ import annotations
+
+import runpy
+import sys
+import types
+from collections.abc import Iterator
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "docs" / "gen_ref_pages.py"
+
+
+class _FakeGenFiles:
+    """Stand-in for the ``mkdocs_gen_files`` module used during tests.
+
+    Captures every virtual file written by the script so tests can assert on
+    the generated reference layout without touching the real filesystem.
+    """
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.edit_paths: dict[str, str] = {}
+        self._buffers: dict[str, StringIO] = {}
+
+    def open(self, path: str, mode: str) -> StringIO:  # noqa: A003 - mimic real API
+        assert mode == "w", "script should only write files"
+        buf = _RecordingBuffer(self, path)
+        self._buffers[path] = buf
+        return buf
+
+    def set_edit_path(self, doc_path: str, edit_path: str) -> None:
+        self.edit_paths[doc_path] = edit_path
+
+
+class _RecordingBuffer(StringIO):
+    """``StringIO`` subclass that flushes its contents on context exit."""
+
+    def __init__(self, parent: _FakeGenFiles, path: str) -> None:
+        super().__init__()
+        self._parent = parent
+        self._path = path
+
+    def __enter__(self) -> _RecordingBuffer:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._parent.files[self._path] = self.getvalue()
+
+
+@pytest.fixture
+def run_script(monkeypatch: pytest.MonkeyPatch) -> Iterator[_FakeGenFiles]:
+    """Execute ``gen_ref_pages.py`` with a stubbed ``mkdocs_gen_files``.
+
+    The script resolves ``src/deux`` relative to the current working
+    directory, so the fixture also ``chdir``-s into the repo root.
+    """
+    fake = _FakeGenFiles()
+    fake_module = types.ModuleType("mkdocs_gen_files")
+    fake_module.open = fake.open  # type: ignore[attr-defined]
+    fake_module.set_edit_path = fake.set_edit_path  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mkdocs_gen_files", fake_module)
+    monkeypatch.chdir(REPO_ROOT)
+    runpy.run_path(str(SCRIPT), run_name="__main__")
+    yield fake
+
+
+def test_emits_top_level_subpackages(run_script: _FakeGenFiles) -> None:
+    """Top-level sub-packages keep getting their own reference page."""
+    for name in ("runtime", "ui", "dui", "render", "tools"):
+        assert f"reference/{name}.md" in run_script.files
+        assert f"::: deux.{name}\n" in run_script.files[f"reference/{name}.md"]
+
+
+def test_emits_nested_runtime_hid_page(run_script: _FakeGenFiles) -> None:
+    """The nested ``runtime.hid`` package must be rendered (issue #351)."""
+    page = "reference/runtime/hid.md"
+    assert page in run_script.files
+    assert "::: deux.runtime.hid\n" in run_script.files[page]
+    assert run_script.edit_paths[page].endswith("src/deux/runtime/hid/__init__.py")
+
+
+@pytest.mark.parametrize("module", ["verify", "preview", "splash"])
+def test_emits_tools_cli_module_pages(run_script: _FakeGenFiles, module: str) -> None:
+    """CLI modules under ``deux.tools`` must each have a reference page."""
+    page = f"reference/tools/{module}.md"
+    assert page in run_script.files
+    assert f"::: deux.tools.{module}\n" in run_script.files[page]
+    assert run_script.edit_paths[page].endswith(f"src/deux/tools/{module}.py")
+
+
+def test_summary_is_hierarchical(run_script: _FakeGenFiles) -> None:
+    """``SUMMARY.md`` must nest child entries beneath their parent package."""
+    summary = run_script.files["reference/SUMMARY.md"]
+    lines = summary.splitlines()
+
+    # Top-level entries have no indentation.
+    assert "- [Tools](tools.md)" in lines
+    assert "- [Runtime](runtime.md)" in lines
+
+    # Nested entries are indented to signal hierarchy to mkdocs-literate-nav.
+    assert "    - [Hid](runtime/hid.md)" in lines
+    assert "    - [Verify](tools/verify.md)" in lines
+    assert "    - [Preview](tools/preview.md)" in lines
+    assert "    - [Splash](tools/splash.md)" in lines
+
+
+def test_skips_private_modules(run_script: _FakeGenFiles) -> None:
+    """Modules and packages starting with ``_`` must not appear."""
+    for path in run_script.files:
+        # Strip the leading ``reference/`` prefix and trailing ``.md``.
+        stem = path[len("reference/") :].removesuffix(".md")
+        for segment in stem.split("/"):
+            assert not segment.startswith("_"), f"private segment leaked: {path}"

--- a/tests/test_gen_ref_pages.py
+++ b/tests/test_gen_ref_pages.py
@@ -109,11 +109,12 @@ def test_summary_is_hierarchical(run_script: _FakeGenFiles) -> None:
     assert "- [Tools](tools.md)" in lines
     assert "- [Runtime](runtime.md)" in lines
 
-    # Nested entries are indented to signal hierarchy to mkdocs-literate-nav.
-    assert "    - [Hid](runtime/hid.md)" in lines
-    assert "    - [Verify](tools/verify.md)" in lines
-    assert "    - [Preview](tools/preview.md)" in lines
-    assert "    - [Splash](tools/splash.md)" in lines
+    # Nested entries are indented two spaces per level so Python-markdown
+    # treats them as a sub-list rather than parent paragraph continuation.
+    assert "  - [Hid](runtime/hid.md)" in lines
+    assert "  - [Verify](tools/verify.md)" in lines
+    assert "  - [Preview](tools/preview.md)" in lines
+    assert "  - [Splash](tools/splash.md)" in lines
 
 
 def test_skips_private_modules(run_script: _FakeGenFiles) -> None:
@@ -123,3 +124,35 @@ def test_skips_private_modules(run_script: _FakeGenFiles) -> None:
         stem = path[len("reference/") :].removesuffix(".md")
         for segment in stem.split("/"):
             assert not segment.startswith("_"), f"private segment leaked: {path}"
+
+
+def test_suppresses_reexported_submodule_pages(run_script: _FakeGenFiles) -> None:
+    """Submodules re-exported by their parent ``__init__`` get no page.
+
+    Emitting them anyway produces duplicate mkdocstrings anchors for the
+    same symbol (e.g. ``deux.dui.resolve_dui`` available on both
+    ``reference/dui/`` and ``reference/dui/repository/``), which trips
+    ``mkdocs --strict`` autoref warnings and fails the docs build.
+    """
+    # ``src/deux/dui/__init__.py`` re-exports from ``.repository``,
+    # ``.card``, ``.key``, ``.loader``, ``.schema`` etc., so none of those
+    # should produce a standalone page.
+    for reexported in ("repository", "card", "key", "loader", "schema"):
+        assert f"reference/dui/{reexported}.md" not in run_script.files
+
+    # ``src/deux/render/__init__.py`` re-exports from ``.theme`` and
+    # ``.metrics`` among others.
+    for reexported in ("theme", "metrics", "context"):
+        assert f"reference/render/{reexported}.md" not in run_script.files
+
+
+def test_top_level_packages_emitted_even_when_root_reexports(
+    run_script: _FakeGenFiles,
+) -> None:
+    """``src/deux/__init__.py`` re-exports from every top-level sub-package.
+
+    The script must still emit landing pages for them — otherwise the
+    re-export filter would erase the entire pre-existing API reference.
+    """
+    for name in ("runtime", "ui", "dui", "render"):
+        assert f"reference/{name}.md" in run_script.files


### PR DESCRIPTION
## Issue validity

Fixes #351. Valid and reproducible: `docs/gen_ref_pages.py` only walked top-level sub-packages of `src/deux/`, so anything not re-exported by the parent `__init__.py` was missing from the rendered API reference. Confirmed missing surfaces:

- `deux.runtime.hid` (entire low-level HID layer)
- `deux.tools.verify`, `deux.tools.preview`, `deux.tools.splash` (`src/deux/tools/__init__.py` is a 3-line stub)

## Fix

Rewrote `docs/gen_ref_pages.py` to recursively walk `src/deux`, emitting a dedicated `reference/<path>.md` page for every public sub-package **and** every public top-level module within those sub-packages. `reference/SUMMARY.md` now uses indented bullets so `mkdocs-literate-nav` produces a hierarchical sidebar (e.g. `Runtime` → `Hid`, `Tools` → `Verify` / `Preview` / `Splash`).

Private names (`_*`) and `__pycache__` continue to be skipped.

## Tests

Added `tests/test_gen_ref_pages.py`, which executes the script with a stubbed `mkdocs_gen_files` module and asserts:

- top-level sub-package pages still exist
- `reference/runtime/hid.md` is generated with the correct `:::` directive and edit path
- `reference/tools/{verify,preview,splash}.md` are generated
- `SUMMARY.md` indents nested entries for literate-nav hierarchy
- private/underscore-prefixed segments never leak into output paths

## Checks run

- `uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` — **1981 passed, 1 skipped, 95.61% coverage**
- `uv run ruff check .` — clean
- `uv run mypy src/deux/` — clean (67 files)
- `uv run mypy docs/gen_ref_pages.py tests/test_gen_ref_pages.py` — clean