### PR TITLE
docs: document list, transform, and css_class bindings (#352)

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -236,6 +236,71 @@ status_icon:
 
 Icons are fetched from the Iconify API and cached in-process.
 
+### list
+
+Render a dynamic list of items as repeated child elements of a parent SVG node (typically a `<text>` element).
+Each item is either a plain text label or an Iconify icon reference (prefix with `icon:`).
+The item at `default_index` receives `active_attrs`; all others receive `inactive_attrs`.
+
+```yaml
+nav:
+  type: list
+  node: pager                # ID of the parent SVG element
+  child_tag: tspan           # SVG element generated per item (default "tspan")
+  default_items:             # initial list of labels (default [])
+    - Main
+    - Settings
+    - "icon:mdi:home"        # prefix with "icon:" to render an Iconify icon
+  default_index: 0           # active item index; use null or -1 for "no active item"
+  active_attrs:              # attributes applied to the active item
+    fill: "#ffffff"
+    font-weight: bold
+  inactive_attrs:            # attributes applied to all inactive items
+    fill: "#888888"
+  separator: " · "           # inserted between items; empty string disables (default)
+  icon_size: 14              # pixel size for "icon:" items (default 16)
+```
+
+Runtime updates may provide a partial payload (`{"items": [...]}` or `{"index": N}`); the other half is preserved.
+An index of `-1` is normalised to `None` (no active item).
+Setting `items` without `index` clamps the existing index to the new bounds.
+
+### transform
+
+Apply one or more SVG transforms to a node proportional to a 0–1 value.
+The only currently supported `kind` is `rotate`, which interpolates linearly between two angles.
+Multiple transforms in the list are composed (space-separated) in order.
+
+```yaml
+gauge:
+  type: transform
+  node: needle
+  default: 0.0               # initial normalised value (0.0–1.0)
+  transforms:
+    - kind: rotate
+      from: -90              # angle in degrees when value is 0.0 (default 0)
+      to: 90                 # angle in degrees when value is 1.0 (default 360)
+      origin: center         # "center" (default) or an explicit "x y" pair
+```
+
+`origin: center` resolves to the element's bounding box center at render time.
+Providing an explicit `"x y"` string (e.g. `"60 60"`) sets a fixed origin in SVG user-space coordinates.
+The `transforms` list must be non-empty.
+
+### css_class
+
+Bind a CSS class string to an SVG element's `class` attribute.
+The binding replaces the entire `class` attribute on the target node; setting an empty string removes the attribute.
+
+```yaml
+style:
+  type: css_class
+  node: card
+  default: ""                # initial class value (default "")
+```
+
+This is useful when the layout SVG embeds a `<style>` block and you want to switch between named visual states (e.g. `default: "muted"` then update to `"active"` at runtime).
+
 ---
 
 ## Events


### PR DESCRIPTION
Closes #352.

## Issue validity

Valid. `BindingType` in \`src/deux/dui/schema.py:25\` defines 11 members but \`docs/guides/creating-dui-packages.md\` only documented eight. Authors had no way to discover \`list\`, \`transform\`, or \`css_class\` without reading source.

## Fix

Added three new subsections under \"Bindings\" in \`docs/guides/creating-dui-packages.md\`, mirroring the format of the existing eight types:

- **\`list\`** — parent node, \`child_tag\`, \`default_items\` (with the \`icon:\` prefix convention), \`default_index\` (including \`null\` / \`-1\` semantics), \`active_attrs\`, \`inactive_attrs\`, \`separator\`, \`icon_size\`, plus partial-update merge behaviour.
- **\`transform\`** — \`kind: rotate\` with \`from\`, \`to\`, \`origin\` (note: YAML keys are \`from\` / \`to\`, **not** \`from_angle\` / \`to_angle\` as the issue suggested — verified against \`_parse_rotate_transform\` in \`src/deux/dui/loader.py:500\`), normalised 0–1 \`default\`, composition order.
- **\`css_class\`** — \`node\`, \`default\`, full-attribute replacement semantics.

Each example matches a valid manifest fragment shape used by the existing test suite (\`tests/test_dui_loader.py\` and \`tests/test_dui_transform.py\`).

## Checks run

- \`ruff check .\` — pass
- \`uv run mypy src/deux/\` (matches CI) — pass, 67 files clean
- \`uv run python -m pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95\` — 1983 passed, 1 skipped, coverage 95.61%

No code or tests changed; this is a docs-only change verified against existing loader/parser logic and test fixtures.