### PR TITLE
docs: clarify DeckManager on_connect/on_disconnect decorator asymmetry (#353)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ async def main():
 asyncio.run(main())
 ```
 
+> **Note:** `on_connect()` is a decorator factory (call with parens) and accepts
+> optional `serial=` / `deck_type=` filters. `on_disconnect` is a property —
+> use it bare, without parens (`@manager.on_disconnect`).
+
 ## Configuration
 
 No environment variables are required. Device capabilities are auto-detected from hardware.

--- a/docs/example.md
+++ b/docs/example.md
@@ -81,6 +81,13 @@ async def run() -> None:
 deck is ready, and re-fires it on reconnects when `auto_reconnect=True`.
 On disconnect, the example shuts down its background tasks cleanly.
 
+> **Note:** the two hooks have different shapes. `on_connect()` is a
+> decorator factory (call with parens) and accepts optional `serial=` /
+> `deck_type=` filters to scope the handler to specific devices.
+> `on_disconnect` is a property that returns the decorator directly — use
+> it bare, without parens (`@manager.on_disconnect`). Calling
+> `@manager.on_disconnect()` will raise `TypeError`.
+
 ## Highlights
 
 ### Real countdown timer

--- a/src/deux/runtime/manager.py
+++ b/src/deux/runtime/manager.py
@@ -175,6 +175,12 @@ class DeckManager:
         -------
         Callable
             Decorator that registers the handler.
+
+        Notes
+        -----
+        Unlike :attr:`on_disconnect`, this is a decorator *factory* and
+        must be invoked with parentheses (``@manager.on_connect()``) even
+        when no filter arguments are passed.
         """
         filters = {"serial": serial, "deck_type": deck_type}
 
@@ -203,6 +209,12 @@ class DeckManager:
         -------
         Callable
             Decorator that registers the handler.
+
+        Notes
+        -----
+        Unlike :meth:`on_connect`, this is a property returning the
+        decorator directly. Use it bare (``@manager.on_disconnect``);
+        calling it with parentheses raises :class:`TypeError`.
         """
 
         def decorator(handler: AsyncHandler) -> AsyncHandler:


### PR DESCRIPTION
## Issue assessment

Valid bug, scope: docs. `DeckManager.on_connect` is a decorator factory (parens required, accepts `serial=`/`deck_type=` filters); `DeckManager.on_disconnect` is a `@property` returning the decorator directly (bare, no parens). The asymmetry is real and undocumented, so users naturally write `@manager.on_disconnect()` and get a `TypeError`. No code change required — the runtime behavior is intentional.

## Fix

- **README.md**: added a note immediately after the quick-start snippet explaining both shapes.
- **docs/example.md**: expanded the lifecycle section with the same note plus an explicit `TypeError` warning.
- **src/deux/runtime/manager.py**: added NumPy-style `Notes` sections to both docstrings cross-referencing each other so the asymmetry surfaces in IDE help and Sphinx output.

## Checks

- `ruff check .` — passed
- `mypy src/deux` — passed (67 files, strict mode)
- `pytest tests/ --cov=deux --cov-fail-under=95` — 1983 passed, 1 skipped, **95.61%** coverage

Closes #353