### PR TITLE
docs(dui): clarify DuiCard vs DuiKey render API (#354)

### DIFF
--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -770,8 +770,11 @@ async def on_toggle():
 async def on_next():
     ...
 
-# Render to image
+# Render to a PIL Image (panel-sized, sized from the SVG's intrinsic dimensions)
 image = card.render()
+
+# Or render directly to encoded device-ready bytes
+panel_bytes = card.render_bytes(panel_width=800, panel_height=100)
 ```
 
 ### Physical Key
@@ -788,9 +791,19 @@ key.set("indicator_color", "#00ff00")
 async def on_activate():
     ...
 
-# Render to encoded image bytes
-image_bytes = key.render_image()
+# Render to encoded image bytes. key_size is REQUIRED — pass the
+# target key dimensions (width, height) in pixels.
+image_bytes = key.render_image(key_size=(120, 120))
 ```
+
+> **Render API note.** `DuiCard` and `DuiKey` deliberately expose different
+> render entry points:
+>
+> - `DuiCard.render()` returns a PIL `Image`. For encoded bytes, use
+>   `DuiCard.render_bytes(panel_width=..., panel_height=...)` or, when
+>   composing a touch strip, `DuiCard.render_panel_bytes(...)`.
+> - `DuiKey.render_image(key_size, image_format="JPEG")` returns encoded
+>   device-ready `bytes` directly; there is no `DuiKey.render()` method.
 
 ---
 


### PR DESCRIPTION
Closes #354.

## Issue validity

Valid and actionable. Verified against the source:

- `DuiCard.render()` (`src/deux/dui/card.py:458`) returns `PIL.Image`; no `render_image()` exists.
- `DuiKey.render_image(key_size, image_format="JPEG")` (`src/deux/dui/key.py:293`) returns `bytes` and `key_size` is required.
- The existing doc snippet `key.render_image()` would raise `TypeError` at runtime.
- `DuiCard.render_bytes()` and `DuiCard.render_panel_bytes()` exist but were not mentioned in the guide.

All four render methods already carry NumPy-style docstrings, so no source changes were needed there.

## Fix

`docs/guides/creating-dui-packages.md` only:

- Pass the required `key_size=(120, 120)` argument in the `DuiKey.render_image()` example.
- Add a `DuiCard.render_bytes(...)` example alongside `card.render()`.
- Add a short note explaining the deliberate asymmetry (PIL `Image` vs encoded `bytes`) and pointing to `render_bytes` / `render_panel_bytes` for byte output.

## Checks run

- `ruff check .` — passed
- `mypy src/deux` — passed (strict, 67 files)
- `uv run pytest tests/ --cov=deux --cov-fail-under=95` — 1983 passed, 1 skipped, coverage 95.61%

No tests added: change is doc-only and the corrected snippet is the documented public API signature, which is already covered by existing unit tests for `DuiKey.render_image` and `DuiCard.render_bytes`.