### PR TITLE
docs(example): fix outdated controller list and screen layout

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -41,15 +41,21 @@ that each own one widget plus its state. A top-level
 
 ```
 StreamDeckApp
-├── AudioController        ── AudioCard.dui      (touch-strip card 0)
-├── LightsController       ── LightCard.dui      (touch-strip card 1)
-├── TimerController        ── TimerCard.dui      (touch-strip card 2)
-├── DashboardController    ── DashboardCard.dui  (touch-strip card 3)
-├── FavoritesController    ── PictureKey.dui     (keys 0..N favourites)
-├── SceneController        ── IconKey.dui        (remaining keys)
+├── AudioController        ── AudioCard.dui      (local;    Main card 0)
+├── LightsController       ── LightCard.dui      (local;    Main card 1)
+├── GaugeController        ── GaugeCard.dui      (local;    Main card 2)
+├── TimerController        ── TimerCard.dui      (local;    Settings card 2)
+├── DashboardController    ── DashboardCard.dui  (built-in; cards 3 on both screens)
+├── FavoritesController    ── PictureKey.dui     (built-in; Main keys 0..N favourites)
+├── SceneController        ── IconKey.dui        (built-in; remaining Main keys)
 └── ScreenCycler           ── (no widget; bound to dashboard's
                                  ``next_screen`` event)
 ```
+
+`.dui` packages tagged ``local`` live under ``examples/`` and are loaded
+by path. Packages tagged ``built-in`` ship inside DeUX at
+``src/deux/dui/packages/`` and are resolved automatically by the
+``DuiRepository`` — no path required.
 
 Controllers never talk to the deck directly. They mutate their card's
 bindings via `set`/`set_many` and call `card.request_refresh()` when the
@@ -141,11 +147,12 @@ async def _click():
 ### Two screens, cycled by an encoder press
 
 `ScreenCycler` swaps between a busy `main` screen (favourites, scenes,
-all four cards) and a focused `settings` screen (dashboard and lights
-only). The dashboard card stays in the same slot on every screen so
-the encoder used to cycle screens is always the rightmost one. The
-same controllers appear on both — DeUX re-renders whatever is
-installed on the active screen.
+plus the audio, lights, gauge, and dashboard cards) and a focused
+`settings` screen (timer and dashboard cards, with the remaining keys
+as unassigned `IconKey` templates). The dashboard card stays in the
+same slot on every screen so the encoder used to cycle screens is
+always the rightmost one. The same controllers appear on both — DeUX
+re-renders whatever is installed on the active screen.
 
 The cycler doesn't own any widget. Instead, `DashboardCard.dui`
 declares a `next_screen` event mapped to an encoder press-release, and
@@ -192,6 +199,8 @@ Once running, here are some interactions to try:
 | Click the timer encoder | Start or pause the countdown |
 | Hold the timer encoder | Reset the timer |
 | Turn the timer encoder | Add/remove 30 seconds |
+| Turn the gauge encoder | Adjust the gauge needle |
+| Press the gauge encoder | Toggle the gauge's background drift simulator |
 | Press the dashboard encoder | Cycle to the next screen |
 
 ## Full source


### PR DESCRIPTION
## Issue validity

Valid (closes #355). `docs/example.md` was out of date relative to `examples/streamdeck.py`:

- Controller tree listed 7 entries; the example actually defines 8 user-facing controllers plus `StreamDeckApp`. `GaugeController` / `GaugeCard.dui` were missing.
- No distinction was drawn between local `.dui` packages (`examples/*.dui`) and built-in ones shipped under `src/deux/dui/packages/`.
- The `ScreenCycler` paragraph described "all four cards" on main and "dashboard and lights only" on settings, which no longer matches `_build_main_screen` (audio/lights/gauge/dashboard) or `_build_settings_screen` (timer/dashboard + IconKey templates).
- The Try-it table omitted the gauge encoder.

## Fix

Documentation-only changes to `docs/example.md`:

- Updated the controller tree to list all 8 controllers with their actual screen/card slots.
- Tagged each `.dui` package as `local` or `built-in`.
- Rewrote the `ScreenCycler` paragraph to match current layouts.
- Added gauge encoder turn / press rows to the Try-it table.

## Checks

- `ruff check .` — All checks passed
- `mypy src/deux` — Success, no issues
- `uv run pytest tests/ --cov=deux --cov-fail-under=95` — 1983 passed, 1 skipped, coverage 95.61%