### PR TITLE
docs: document public exports — theming, error handling, DialAccumulator (#358)

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -161,6 +161,28 @@ def _walk_package(pkg_dir: Path, depth: int, dotted_prefix: str, rel_prefix: str
 _walk_package(SRC / PACKAGE, depth=0, dotted_prefix=PACKAGE, rel_prefix="")
 
 
+# Emit a top-level landing page for the ``deux`` package so symbols that
+# are only re-exported at the top level (e.g. ``DeuxError``, ``SSRFError``,
+# ``set_allow_private_urls`` from underscore-prefixed modules) have a
+# canonical mkdocstrings anchor that cross-references can resolve.
+_top_doc = "reference/index.md"
+with mkdocs_gen_files.open(_top_doc, "w") as f:
+    f.write(f"# {PACKAGE}\n\n")
+    f.write(f"::: {PACKAGE}\n")
+    f.write("    options:\n")
+    f.write("      members:\n")
+    # Restrict to symbols not already documented elsewhere to avoid
+    # duplicate anchors. These are the underscore-module-backed
+    # re-exports.
+    for sym in ("DeuxError", "SSRFError", "set_allow_private_urls"):
+        f.write(f"        - {sym}\n")
+    f.write("      show_submodules: false\n")
+mkdocs_gen_files.set_edit_path(_top_doc, f"../src/{PACKAGE}/__init__.py")
+# Insert at the top of the SUMMARY so it appears first under the API
+# Reference root.
+nav_entries.insert(0, (0, "Top-level Package", "index.md"))
+
+
 # Write the SUMMARY consumed by mkdocs-literate-nav. Indentation drives nesting.
 # Python-markdown's list parser requires each nested level to be indented by
 # *two* spaces relative to the parent's bullet content; using four spaces

--- a/docs/guides/creating-dui-packages.md
+++ b/docs/guides/creating-dui-packages.md
@@ -445,6 +445,24 @@ async def handle(steps: int):
 - `accumulate_delay` must be a positive number
 - `accumulate_max_steps` must be a positive integer
 
+**Under the hood:** accumulated turns are powered by
+[`DialAccumulator`][deux.ui.DialAccumulator], a small asyncio debounce
+primitive. `accumulate_delay` maps to its `delay` constructor argument
+and `accumulate_max_steps` maps to `max_steps`. You can use
+`DialAccumulator` directly from Python code (outside of `.dui` packages)
+when you need the same debounce behaviour on an
+[`EncoderSlot`][deux.EncoderSlot]:
+
+```python
+from deux.ui import DialAccumulator
+
+acc = DialAccumulator(my_handler, delay=0.2, max_steps=5)
+
+@encoder.on_turn
+async def on_turn(direction: int) -> None:
+    acc.tick(direction)
+```
+
 ---
 
 ## Regions (TouchStripCard Only)

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,0 +1,109 @@
+# Error Handling
+
+Every exception raised by DeUX inherits from a single root class,
+[`deux.DeuxError`][deux.DeuxError]. A single `except deux.DeuxError`
+handler is therefore sufficient to catch any library error without
+masking unrelated exceptions from your own code.
+
+```python
+import deux
+
+try:
+    card = deux.DuiCard("DashboardCard")
+except deux.DeuxError as exc:
+    log.error("DUI load failed: %s", exc)
+```
+
+## Exception hierarchy
+
+```
+DeuxError
+├── DeckError              # runtime device / transport failures
+├── PackageError           # malformed or unloadable .dui packages
+├── SSRFError              # blocked private / loopback URL access
+├── IconifyError           # iconify fetch / cache failures
+├── ImageFetchError        # image binding fetch failures
+├── RasterizeError         # SVG rasterisation failures
+└── SplashError            # splash-screen rendering failures
+```
+
+The publicly re-exported names from `deux` are
+[`DeuxError`][deux.DeuxError], [`DeckError`][deux.runtime.DeckError],
+[`PackageError`][deux.dui.PackageError], and
+[`SSRFError`][deux.SSRFError].
+The remaining classes are accessible through their owning sub-packages
+(for example [`IconifyError`][deux.dui.IconifyError],
+[`ImageFetchError`][deux.render.ImageFetchError]).
+
+## URL safety and SSRF
+
+`.dui` packages are designed to be distributed between users. To
+mitigate Server-Side Request Forgery (SSRF), DeUX validates every URL
+used by `image:` and `iconify:` bindings before fetching. Hostnames are
+resolved via DNS and rejected when any resulting IP address falls in a
+blocked range:
+
+- Loopback — `127.0.0.0/8`, `::1`
+- Private (RFC 1918) — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- Link-local — `169.254.0.0/16`, `fe80::/10`
+- Cloud metadata — `169.254.169.254`
+
+A blocked request raises [`SSRFError`][deux.SSRFError]:
+
+```python
+import deux
+
+try:
+    deux.DuiCard("SomeCard")  # contains image binding to 192.168.1.1
+except deux.SSRFError as exc:
+    log.warning("Blocked private URL in DUI: %s", exc)
+```
+
+### Allowing private URLs
+
+If you genuinely need to fetch from LAN resources (a local Home
+Assistant, a self-hosted icon server, …) opt in explicitly with
+[`set_allow_private_urls`][deux.set_allow_private_urls]:
+
+```python
+import deux
+
+# Permit private / loopback / link-local addresses for this process.
+deux.set_allow_private_urls(True)
+```
+
+This is process-global; only enable it when you trust the DUI packages
+your application loads.
+
+## Patterns
+
+**Fail fast on package load:** catch `PackageError` during startup to
+surface broken packages before the device session begins.
+
+```python
+try:
+    deux.load_all_packages()
+except deux.PackageError as exc:
+    sys.exit(f"Refusing to start with bad DUI packages: {exc}")
+```
+
+**Resilient runtime:** within event handlers, catch the narrow
+sub-class you care about and let everything else bubble up to the deck
+manager's logger.
+
+```python
+@card.on("refresh")
+async def handle():
+    try:
+        await refresh_data()
+    except deux.DeckError as exc:
+        log.warning("device unavailable, skipping refresh: %s", exc)
+```
+
+## See also
+
+- [`deux.DeuxError`][deux.DeuxError]
+- [`deux.runtime.DeckError`][deux.runtime.DeckError]
+- [`deux.dui.PackageError`][deux.dui.PackageError]
+- [`deux.SSRFError`][deux.SSRFError]
+- [`deux.set_allow_private_urls`][deux.set_allow_private_urls]

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -1,0 +1,104 @@
+# Theming
+
+DeUX includes a small theme system that drives the CSS palette used to
+rasterise DUI SVG layouts. A theme is a primary RGB colour plus a font
+family; from those two inputs DeUX derives an 18-entry palette covering
+backgrounds, text, borders, icons, and semantic states (success, warning,
+error).
+
+All public theming entry points are re-exported from the top-level
+`deux` package:
+
+```python
+from deux import Theme, get_active_theme, set_active_theme
+```
+
+## Built-in default
+
+A baseline theme is applied automatically when `deux.render` is imported,
+so DUI packages render correctly out of the box. The default uses
+`rgb(39, 87, 179)` with the `Inter` font family.
+
+```python
+from deux import get_active_theme
+
+theme = get_active_theme()
+print(theme.primary)        # (39, 87, 179)
+print(theme.font_family)    # 'Inter'
+```
+
+## Building a theme
+
+Themes are immutable; create them via the factory class methods on
+[`Theme`][deux.Theme]:
+
+```python
+from deux import Theme
+
+# From an explicit primary colour
+brand = Theme.from_color(255, 0, 128, font_family="Roboto")
+
+# Or generate a random, readable palette
+random_theme = Theme.from_random()
+
+# Or reset to the bundled default
+default = Theme.default()
+```
+
+Each theme exposes:
+
+- `primary` — the `(r, g, b)` tuple used to derive the palette
+- `font_family` — the CSS font-family name applied to every SVG
+- `palette` — a `dict[str, str]` mapping CSS class names to hex colours
+- `css` — the complete stylesheet string used by the SVG rasteriser
+
+## Activating a theme
+
+[`set_active_theme`][deux.set_active_theme] swaps the system-wide theme
+and updates the SVG rasteriser's stylesheet so all subsequent renders
+pick up the new palette:
+
+```python
+from deux import Theme, set_active_theme
+
+set_active_theme(Theme.from_color(64, 164, 96))
+
+# Later, restore the default
+set_active_theme(None)
+```
+
+Because rendered key images are cached, you typically call
+`set_active_theme` once during startup before any cards or keys are
+drawn.
+
+## CSS classes available to DUI layouts
+
+DUI SVG layouts reference the palette through CSS class names. The full
+list, in the order they are generated:
+
+| Class | Role |
+|-------|------|
+| `background-dark` | Card / key background base |
+| `background-light` | Raised background tier |
+| `border-primary` | Primary borders |
+| `border-secondary` | Subtle borders / dividers |
+| `text-primary` | Main label text |
+| `text-secondary` | Tinted secondary text |
+| `text-accent` | Accent text |
+| `text-muted` | De-emphasised text |
+| `text-selected` | Selected / highlighted text |
+| `text-fancy` | Complementary highlight text |
+| `success` | Positive state |
+| `warning` | Caution state |
+| `error` | Error state |
+| `icon` | Default icon stroke / fill |
+| `icon-active` | Active icon state |
+| `icon-inactive` | Inactive icon state |
+| `sliders` | Slider track / handle |
+| `dynamic` | Dynamic / animated accents |
+
+## See also
+
+- [`deux.Theme`][deux.Theme]
+- [`deux.get_active_theme`][deux.get_active_theme]
+- [`deux.set_active_theme`][deux.set_active_theme]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ nav:
   - Guides:
       - DUI Repository & Built-in Packages: guides/dui-repository.md
       - Creating DUI Packages: guides/creating-dui-packages.md
+      - Theming: guides/theming.md
+      - Error Handling: guides/error-handling.md
       - CLI Tools: guides/cli-tools.md
   - Example: example.md
   - API Reference: reference/


### PR DESCRIPTION
Closes #358.

## Issue validity assessment

**Valid and actionable.** The listed symbols are part of the public API (re-exported from `deux`, `deux.ui`, `deux.dui`, `deux.runtime`, `deux.render`) but had no user-facing discoverability outside the auto-generated mkdocstrings reference. Symbols backed by underscore-prefixed modules (`DeuxError`, `SSRFError`, `set_allow_private_urls`) had no reference anchor at all, so even cross-links from new guides would not resolve.

## Fix

Smallest correct change focused on the documentation gap (no rename / no API change):

- **`docs/guides/theming.md`** — new guide covering `Theme`, `get_active_theme`, `set_active_theme`, the factory class methods, and the 18-class CSS palette consumed by DUI layouts.
- **`docs/guides/error-handling.md`** — new guide covering the `DeuxError` hierarchy, the SSRF threat model, `SSRFError`, and the `set_allow_private_urls` opt-in.
- **`docs/guides/creating-dui-packages.md`** — extend the *Accumulated Turns* section with a reference to `DialAccumulator` and a Python-only usage example.
- **`docs/gen_ref_pages.py`** — emit a top-level `reference/index.md` for the `deux` package so the underscore-module-backed re-exports (`DeuxError`, `SSRFError`, `set_allow_private_urls`) gain mkdocstrings anchors that guide cross-references can resolve under `mkdocs --strict`.
- **`mkdocs.yml`** — register the two new guides in the nav.

The other symbols listed in the issue (`IconifyError`, `fetch_icon`, `prefetch_icons`, `clear_iconify_cache`, `SpinnerAnimator`, `SpinnerFrames`, `AsyncEvent`, `AsyncTransport`, `get_executor`, `shutdown_executor`, `list_devices`, `BackgroundLayer`, `RenderingContext`, `RenderProfiler`, `compose_touchstrip`, `render_blank_key`) are already auto-rendered into the API reference via the existing `gen_ref_pages.py` because their parent `__init__.py` re-exports them; this PR makes them reachable from prose guides through links like `deux.dui.IconifyError` and `deux.render.compose_touchstrip`.

## Tests / checks run

- `ruff check .` — clean
- `mypy src/deux/` — clean (matches CI invocation in `.github/workflows/python-typecheck.yml`)
- `pytest tests/ --cov=deux --cov-fail-under=95` — 1983 passed, 1 skipped, 95.61% coverage
- `mkdocs build --strict` — builds without warnings (previous attempt surfaced 8 unresolved autorefs which the new top-level reference page resolves)