### PR TITLE
docs: expand thin docstrings on public render/runtime symbols (#359)

### DIFF
--- a/src/deux/render/defaults/__init__.py
+++ b/src/deux/render/defaults/__init__.py
@@ -25,8 +25,20 @@ _device_map: dict[tuple[int, int], dict[str, str]] = {}
 class SurfaceBackgrounds(TypedDict, total=False):
     """Mapping of surface type to raw SVG bytes.
 
-    Keys are ``"key"``, ``"touchscreen"``, and/or ``"screen"``
-    depending on the device's hardware capabilities.
+    A ``TypedDict`` with three optional keys; only those matching the
+    device's hardware capabilities are populated.
+
+    Keys
+    ----
+    key : bytes
+        Raw SVG bytes used as the default background for individual key
+        images.
+    touchscreen : bytes
+        Raw SVG bytes used as the default background for the full
+        touchscreen strip (Stream Deck+ family).
+    screen : bytes
+        Raw SVG bytes used as the default background for the secondary
+        information screen (Stream Deck Neo and similar).
     """
 
     key: bytes

--- a/src/deux/render/metrics.py
+++ b/src/deux/render/metrics.py
@@ -26,11 +26,53 @@ class RenderMetrics:
 
     Parameters
     ----------
-    caps
+    caps : DeviceCapabilities
         Device capabilities to derive metrics from.
+
+    Attributes
+    ----------
+    key_size : tuple[int, int]
+        ``(width, height)`` of a single key image in pixels.
+    key_image_format : str
+        Native key image format expected by the device (e.g. ``"JPEG"``
+        or ``"BMP"``).
+    key_count : int
+        Total number of physical keys on the device.
+    touchscreen_width : int
+        Width of the touchscreen surface in pixels, or ``0`` if the
+        device has no touchscreen.
+    touchscreen_height : int
+        Height of the touchscreen surface in pixels, or ``0`` if the
+        device has no touchscreen.
+    panel_count : int
+        Number of logical touchscreen panels (typically one per dial on
+        Stream Deck+), or ``0`` on devices without a touchscreen.
+    panel_width : int
+        Width of a single touchscreen panel in pixels. ``0`` when the
+        device has no touchscreen or no panels.
+    panel_height : int
+        Height of a single touchscreen panel in pixels. ``0`` when the
+        device has no touchscreen.
+    screen_width : int
+        Width of the secondary information screen in pixels, or ``0``
+        if absent.
+    screen_height : int
+        Height of the secondary information screen in pixels, or ``0``
+        if absent.
+    dial_count : int
+        Number of rotary encoders (dials) on the device.
     """
 
     def __init__(self, caps: DeviceCapabilities) -> None:
+        """Derive rendering metrics from device capabilities.
+
+        Parameters
+        ----------
+        caps : DeviceCapabilities
+            Capabilities of the device the metrics apply to. All
+            attributes are computed eagerly from this object; the
+            capabilities reference is retained for later inspection.
+        """
         self._caps = caps
 
         self.key_size: tuple[int, int] = (caps.key_pixel_width, caps.key_pixel_height)

--- a/src/deux/runtime/transport.py
+++ b/src/deux/runtime/transport.py
@@ -78,14 +78,32 @@ class AsyncTransport:
         return self._queue
 
     def start(self) -> None:
-        """Start the input polling background task."""
+        """Start the input polling background task.
+
+        Spawns an asyncio task that continuously polls the underlying
+        HID device for input events and forwards decoded events to
+        :attr:`queue`. Calling :meth:`start` more than once without an
+        intervening :meth:`stop` will replace the previous polling task
+        reference; callers should treat the method as one-shot per
+        transport lifetime.
+
+        Notes
+        -----
+        Must be called from within a running asyncio event loop.
+        """
         self._running = True
         self._poll_task = asyncio.create_task(
             self._poll_loop(), name="deux-hid-poll"
         )
 
     def stop(self) -> None:
-        """Stop polling."""
+        """Stop polling.
+
+        Signals the polling loop to exit and cancels the background
+        task if it is still running. Safe to call multiple times and
+        safe to call when :meth:`start` was never invoked; in both
+        cases the method becomes a no-op.
+        """
         self._running = False
         if self._poll_task and not self._poll_task.done():
             self._poll_task.cancel()


### PR DESCRIPTION
Closes #359.

## Issue validity assessment

Partially valid. A full audit of every symbol re-exported from `deux.render`, `deux.runtime`, and `deux.dui` showed that the docstring coverage is in fact **very strong** — every symbol has at least a NumPy-style docstring, and most include the relevant `Parameters` / `Returns` / `Raises` / `Examples` sections. The issue's premise that many symbols lack docstrings was overstated.

That said, three genuine gaps were identified and are addressed here:

1. **`deux.render.metrics.RenderMetrics`** — class docstring documented only the `caps` parameter; the 11 public attributes set in `__init__` (`key_size`, `key_image_format`, `key_count`, `touchscreen_width/height`, `panel_count`, `panel_width/height`, `screen_width/height`, `dial_count`) were undocumented. mkdocstrings would render them as bare attributes.
2. **`deux.render.defaults.SurfaceBackgrounds`** — TypedDict described its keys only in prose; each optional key is now documented explicitly.
3. **`deux.runtime.transport.AsyncTransport.start` / `.stop`** — thin one-liners; expanded to describe idempotency, side effects, and event-loop requirements.

All other audited symbols already meet the AGENTS.md convention and were left untouched (no churn for churn's sake).

## Fix

Targeted docstring expansions in:
- `src/deux/render/metrics.py` — added `Attributes` section + `__init__` docstring on `RenderMetrics`.
- `src/deux/render/defaults/__init__.py` — expanded `SurfaceBackgrounds` TypedDict docstring with per-key descriptions.
- `src/deux/runtime/transport.py` — expanded `AsyncTransport.start` and `.stop` docstrings.

No behavioral changes.

## Checks run

- `ruff check .` — all checks passed
- `mypy src/deux` — success, no issues found in 67 source files
- `uv run pytest --cov=deux --cov-fail-under=95` — 1983 passed, 1 skipped, coverage 95.61%