### PR TITLE
docs: clarify DuiKey("IconKey") string-name usage in quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ async def main():
     @manager.on_connect()
     async def handle(deck):
         screen = deck.screen("main")
+        # DuiKey accepts a built-in package name (e.g. "IconKey") or a PackageSpec
+        # returned by load_package(). See docs/guides/dui-repository.md for details.
         key = DuiKey("IconKey")
         key.set("label", "Hello")
         key.set("icon", "mdi:hand-wave")


### PR DESCRIPTION
## Issue assessment

Issue #360 is **valid and actionable**. The README quick-start passes the bare string `"IconKey"` to `DuiKey` without explaining that it is resolved against the built-in DUI package repository, which is a recurring source of confusion for new users.

## Fix

Applied the exact one-line annotation suggested in the issue, immediately above the `DuiKey("IconKey")` call in `README.md` (which is also surfaced as `docs/index.md` via symlink). The comment points readers to `docs/guides/dui-repository.md` for details.

## Validation

- `ruff check .` — passed
- `mypy src/deux` — passed (67 files, strict mode, no issues)
- `uv run pytest tests/ --cov=deux --cov-fail-under=95` — 1983 passed, 1 skipped, coverage 95.61%

Closes #360