### PR TITLE
docs: standardise terminology and casing across docs (#362)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,9 @@ Every contribution **must** follow this sequence:
 - **Type checking:** mypy in strict mode. Add type annotations to all public APIs.
 - **Docstrings:** NumPy-style for all public modules, classes, methods, and functions.
   See the example below.
+- **Documentation terminology:** Follow [`docs/STYLE.md`](docs/STYLE.md) for the
+  canonical forms of `DUI`, `.dui`, `deux.dui`, Stream Deck product names, device
+  identifiers (`StreamDeckPlus`, …), and class names (`KeySlot`, `EncoderSlot`).
 
 ```python
 def connect(device_id: str, timeout: float = 5.0) -> bool:

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,63 @@
+# Documentation Style Guide
+
+This page records the writing and terminology conventions used across DeUX's
+documentation, README, and in-source docstrings. The goal is consistency in
+prose so that the same concept always renders the same way — improving
+readability, search, and onboarding for both humans and AI assistants.
+
+When in doubt, follow this guide. When updating docs, prefer normalising
+inconsistencies to the forms below.
+
+## Terminology
+
+| Term | Form | When to use | Example |
+|------|------|-------------|---------|
+| `DUI` | Acronym, **always uppercase** | The declarative UI model as a concept | "DeUX uses a DUI to separate layout from logic." |
+| `` `.dui` `` | Lowercase, **monospace**, leading dot | The package directory extension on disk | "A `.dui` package contains an SVG layout and a YAML manifest." |
+| `` `deux.dui` `` | Lowercase, **monospace**, dotted | The Python module / import path | "Import `load_package` from `deux.dui`." |
+| Stream Deck | Two words, title case, **plain prose** | Elgato's product family, in narrative text | "DeUX targets Elgato Stream Deck devices." |
+| `` `StreamDeckPlus` `` etc. | PascalCase, **monospace** | Device identifier values (manifest fields, capabilities) | "Set `device: [StreamDeckPlus]` in the manifest." |
+| `` `KeySlot` ``, `` `EncoderSlot` ``, `` `TouchStrip` ``, `` `Screen` `` | PascalCase, **monospace** | The class names | "Each `Screen` owns a list of `KeySlot` instances." |
+| key slot, encoder slot, touch strip | Lowercase, **plain prose** | The general concept / common noun | "Bindings target individual key slots." |
+
+### Device identifier reference
+
+The canonical PascalCase identifiers, as exposed by `DeviceCapabilities` and
+accepted by `.dui` manifest `device:` fields:
+
+| Identifier | Product |
+|------------|---------|
+| `StreamDeckClassic` | Stream Deck Classic (original, MK.2) |
+| `StreamDeckXL` | Stream Deck XL |
+| `StreamDeckNeo` | Stream Deck Neo |
+| `StreamDeckPlus` | Stream Deck + |
+| `StreamDeckPlusXL` | Stream Deck + XL |
+
+In prose, refer to the products with their marketing names (e.g. "Stream Deck
++"); reserve the monospace identifiers for code, tables that describe
+configuration values, and manifest examples.
+
+## Formatting
+
+- Class, function, module, and file-extension names always render in
+  `monospace` via backticks.
+- Marketing/product names stay in plain prose — no backticks, no PascalCase.
+- Use sentence case for headings.
+- Wrap lines at ~100 characters in Markdown source where practical, matching
+  the project's Ruff line-length target.
+
+## Cross-links
+
+When referring to API symbols in MkDocs pages, prefer mkdocstrings autorefs:
+
+```
+[`PackageError`][deux.dui.PackageError]
+```
+
+over bare backticks, so the reader can navigate directly to the reference.
+
+## Docstrings
+
+All public Python symbols use NumPy-style docstrings. See the example in
+[CONTRIBUTING.md](../CONTRIBUTING.md#code-style). The terminology rules above
+apply equally to docstring prose.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -59,5 +59,5 @@ over bare backticks, so the reader can navigate directly to the reference.
 ## Docstrings
 
 All public Python symbols use NumPy-style docstrings. See the example in
-[CONTRIBUTING.md](../CONTRIBUTING.md#code-style). The terminology rules above
-apply equally to docstring prose.
+[`CONTRIBUTING.md`](https://github.com/graphras-com/DeUX/blob/main/CONTRIBUTING.md#code-style).
+The terminology rules above apply equally to docstring prose.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Full-Screen Images: guides/full-screen-images.md
       - CLI Tools: guides/cli-tools.md
   - Example: example.md
+  - Style Guide: STYLE.md
   - API Reference: reference/
 
 plugins:


### PR DESCRIPTION
## Issue validity assessment

Issue #362 is **valid and actionable**. It requests a documented style convention for DUI / `.dui` / `deux.dui` / Stream Deck / device identifiers / class names, and a sweep of docs to normalise usage. Severity is `nit` (P3), but the deliverable is clear: codify and link the convention.

## Fix

- Added `docs/STYLE.md` documenting the canonical forms:
  - `DUI` — acronym, always uppercase
  - `` `.dui` `` — file/package extension, lowercase monospace, leading dot
  - `` `deux.dui` `` — Python module, monospace dotted
  - **Stream Deck** — Elgato product name in prose
  - `` `StreamDeckPlus` ``, `` `StreamDeckXL` ``, … — device identifier values in monospace, with a reference table
  - `` `KeySlot` ``, `` `EncoderSlot` ``, `` `TouchStrip` ``, `` `Screen` `` — class names in monospace
- Linked the new style guide from `CONTRIBUTING.md` (Code Style section).
- Added the page to the MkDocs nav so it ships with the site.

### Sweep results

A full grep sweep over `docs/`, `README.md`, and `CONTRIBUTING.md` confirmed the existing prose already follows the convention in nearly every instance — the inconsistencies the issue called out have largely been resolved by prior docs work (e.g. #375). The remaining `dui` lowercase occurrences are all legitimate: file extensions (`.dui`), the module path (`deux.dui`), or paths inside code blocks. "key slot" / "encoder slot" in prose is used as a common noun (not the class name) and is consistent with the new convention. No prose normalisation edits were required beyond codifying the rules.

## Checks run

- `uv run ruff check .` — **All checks passed**
- `uv run mypy src` — **Success: no issues found in 67 source files**
- `uv run pytest tests/ --cov=deux --cov-report=term-missing --cov-fail-under=95` — **1983 passed, 1 skipped, coverage 95.61%**

Closes #362