### PR TITLE
examples: add ClockKey DUI package and ClockController

### DIFF
--- a/examples/ClockKey.dui/layout.svg
+++ b/examples/ClockKey.dui/layout.svg
@@ -38,13 +38,19 @@
         </g>
         <g filter="url(#shadow)">
             <g transform="rotate(-90)">
-                <polygon id="hour_hand" class="sliders" transform="rotate(59)" points="-6,-1 38,-0.5 38,0.5 -6,1" fill="currentColor" />
+                <polygon id="hour_hand" class="sliders" transform="rotate(59)" points="-6,-2 38,-1 38,1 -6,2" fill="currentColor" />
             </g>
         </g>
         <g filter="url(#shadow)">
             <g transform="rotate(-90)">
                 <polygon id="minute_hand" class="sliders" transform="rotate(-55)" points="-6,-1.5 48,-0.5 48,0.5 -6,1.5" fill="currentColor" />
-                <circle class="sliders" cx="0" cy="0" r="3" fill="currentColor" />
+                <circle class="sliders" cx="0" cy="0" r="4" fill="currentColor" />
+            </g>
+        </g>
+        <g filter="url(#shadow)">
+            <g transform="rotate(-90)">
+                <polygon id="second_hand" class="sucess" transform="rotate(-15)" points="-15,-1 48,-0.5 48,0.5 -15,1" fill="currentColor" />
+                <circle class="sliders" cx="0" cy="0" r="2" fill="currentColor" />
             </g>
         </g>
         <circle class="icon-active" cx="0" cy="0" r="1" fill="currentColor" filter="url(#shadow)"/>

--- a/examples/ClockKey.dui/layout.svg
+++ b/examples/ClockKey.dui/layout.svg
@@ -1,0 +1,52 @@
+<svg id="Button" xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+    <defs>
+        <linearGradient id="backgroundGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop class="background-dark" offset="0%" stop-color="currentColor" />
+            <stop class="background-light" offset="100%" stop-color="currentColor" />
+        </linearGradient>
+        <filter id="shadow" x="-100%" y="-100%" width="210%" height="210%">
+            <feDropShadow dx="-1" dy="-1" stdDeviation="1" flood-color="black" flood-opacity=".5"/>
+        </filter>
+    </defs>
+    <rect class="background-dark" x="0" y="0" width="120" height="120" fill="currentColor"  />
+    <rect x="4" y="4" width="112" height="112" fill="url(#backgroundGradient)" rx="15" />
+    <text class="icon" font-size="12" x="60" y="48" text-anchor="middle" fill="currentColor">DeUX</text>
+    <g class="border-primary" transform="translate(60 60)" filter="url(#shadow)">
+        <g>
+            <rect x="40" y="-1" width="10" height="2" fill="currentColor" />
+            <rect x="-50" y="-1" width="10" height="2" fill="currentColor" />
+        </g>
+        <g transform="rotate(30)">
+            <rect x="40" y="-1" width="10" height="2" fill="currentColor" />
+            <rect x="-50" y="-1" width="10" height="2" fill="currentColor" />
+        </g>
+        <g transform="rotate(60)">
+            <rect x="40" y="-1" width="10" height="2" fill="currentColor" />
+            <rect x="-50" y="-1" width="10" height="2" fill="currentColor" />
+        </g>
+        <g transform="rotate(90)">
+            <rect x="40" y="-1" width="10" height="2" fill="currentColor" />
+            <rect x="-50" y="-1" width="10" height="2" fill="currentColor" />
+        </g>
+        <g transform="rotate(120)">
+            <rect x="40" y="-1" width="10" height="2" fill="currentColor" />
+            <rect x="-50" y="-1" width="10" height="2" fill="currentColor" />
+        </g>
+        <g transform="rotate(150)">
+            <rect x="40" y="-1" width="10" height="2" fill="currentColor" />
+            <rect x="-50" y="-1" width="10" height="2" fill="currentColor" />
+        </g>
+        <g filter="url(#shadow)">
+            <g transform="rotate(-90)">
+                <polygon id="hour_hand" class="sliders" transform="rotate(59)" points="-6,-1 38,-0.5 38,0.5 -6,1" fill="currentColor" />
+            </g>
+        </g>
+        <g filter="url(#shadow)">
+            <g transform="rotate(-90)">
+                <polygon id="minute_hand" class="sliders" transform="rotate(-55)" points="-6,-1.5 48,-0.5 48,0.5 -6,1.5" fill="currentColor" />
+                <circle class="sliders" cx="0" cy="0" r="3" fill="currentColor" />
+            </g>
+        </g>
+        <circle class="icon-active" cx="0" cy="0" r="1" fill="currentColor" filter="url(#shadow)"/>
+    </g>
+</svg>

--- a/examples/ClockKey.dui/manifest.yaml
+++ b/examples/ClockKey.dui/manifest.yaml
@@ -8,6 +8,16 @@ category: utilities
 layout: layout.svg
 
 bindings:
+  second_hand:
+    type: transform
+    node: second_hand
+    default: 0
+    transforms:
+      - kind: rotate
+        from: 00
+        to: 360
+        origin: 0 0
+
   minute_hand:
     type: transform
     node: minute_hand

--- a/examples/ClockKey.dui/manifest.yaml
+++ b/examples/ClockKey.dui/manifest.yaml
@@ -1,0 +1,44 @@
+name: ClockKey
+type: Key
+version: 1
+description: Analog Clock
+author: Graphras.com
+license: Apache-2.0
+category: utilities
+layout: layout.svg
+
+bindings:
+  minute_hand:
+    type: transform
+    node: minute_hand
+    default: 0
+    transforms:
+      - kind: rotate
+        from: 00
+        to: 360
+        origin: 0 0
+
+  hour_hand:
+    type: transform
+    node: hour_hand
+    default: 0
+    transforms:
+      - kind: rotate
+        from: 0
+        to: 360
+        origin: 0 0
+
+events:
+  - name: click
+    source: key_press_release
+    max_duration_ms: 300
+
+  - name: hold
+    source: key_hold
+    hold_ms: 350
+
+  - name: press
+    source: key_press
+
+  - name: release
+    source: key_release

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -96,6 +96,7 @@ from deux import (
     DeviceInfo,
     DuiCard,
     DuiKey,
+    KeyController,
     Theme,
     add_dui_path,
 )
@@ -860,6 +861,160 @@ class GaugeController(CardController):
     async def on_detach(self) -> None:
         """Stop the background drift simulator."""
         await self._svc.stop()
+
+class ClockController(KeyController):
+    """Analog clock key -- ticking hour and minute hands driven by system time.
+
+    Loads ``ClockKey.dui`` and updates two transform bindings,
+    ``hour_hand`` and ``minute_hand``, with rotation angles in degrees
+    derived from the local system clock.  Both bindings are declared in
+    the manifest as ``rotate`` transforms whose ``from``/``to`` span the
+    full ``0 -- 360`` degree range, so the controller writes confirmed
+    domain values (degrees) through :meth:`~deux.DuiKey.set_range` with
+    ``min_val=0`` and ``max_val=360``.
+
+    Angle calculation
+    ~~~~~~~~~~~~~~~~~
+    * **Minute hand** -- ``6 degrees per minute``  (``360 / 60``), with
+      sub-minute precision contributed by the seconds component
+      (``0.1 deg/s``).  At 12 o'clock the angle is ``0``.
+    * **Hour hand** -- ``0.5 degrees per minute``  (``30 / 60``), i.e.
+      ``30 degrees per hour`` plus a smooth drift across the hour driven
+      by the minutes (and seconds).  The hour value is taken modulo 12
+      so that 12:00 and 00:00 both render at ``0``.
+
+    Because this is a pure display (no user input changes the time), the
+    controller does not own a backend service.  It runs a single
+    ``asyncio`` task that ticks once per second, recomputes the hand
+    angles, writes them to the key, and requests a refresh.  The task is
+    started in :meth:`on_attach` and cancelled in :meth:`on_detach`, so
+    it is safe across reconnect cycles.
+
+    Notes
+    -----
+    The tick task only requests a refresh when at least one hand angle
+    actually changes since the last tick, avoiding redundant renders
+    while the second hand is between visible positions.
+    """
+
+    TICK_INTERVAL_S = 1.0
+    ANGLE_MIN = 0
+    ANGLE_MAX = 360
+    DEGREES_PER_MINUTE_MINUTE_HAND = 6.0
+    DEGREES_PER_MINUTE_HOUR_HAND = 0.5
+
+    def __init__(self) -> None:
+        self.key = DuiKey("ClockKey")
+        self._tick_task: asyncio.Task[None] | None = None
+        self._last_hour_angle: float | None = None
+        self._last_minute_angle: float | None = None
+
+    @classmethod
+    def compute_angles(cls, now: datetime.datetime) -> tuple[float, float]:
+        """Compute the (hour, minute) hand angles in degrees for *now*.
+
+        Both angles are normalised so that ``0`` corresponds to the
+        12 o'clock position and values increase clockwise.
+
+        Parameters
+        ----------
+        now : datetime.datetime
+            The point in time to render.  Only the ``hour``, ``minute``,
+            and ``second`` fields are used.
+
+        Returns
+        -------
+        tuple[float, float]
+            ``(hour_angle, minute_angle)`` both in the range
+            ``[0, 360)`` degrees.
+        """
+        total_minutes = now.minute + now.second / 60.0
+        minute_angle = (
+            total_minutes * cls.DEGREES_PER_MINUTE_MINUTE_HAND
+        ) % cls.ANGLE_MAX
+        hour_angle = (
+            (now.hour % 12) * 30.0
+            + total_minutes * cls.DEGREES_PER_MINUTE_HOUR_HAND
+        ) % cls.ANGLE_MAX
+        return hour_angle, minute_angle
+
+    def _apply_now(self, now: datetime.datetime) -> bool:
+        """Update the key bindings for time *now*.
+
+        Parameters
+        ----------
+        now : datetime.datetime
+            The time to render.
+
+        Returns
+        -------
+        bool
+            ``True`` if either hand angle changed since the previous
+            call, ``False`` otherwise.
+        """
+        hour_angle, minute_angle = self.compute_angles(now)
+        if (
+            hour_angle == self._last_hour_angle
+            and minute_angle == self._last_minute_angle
+        ):
+            return False
+        self.key.set_range(
+            "hour_hand",
+            hour_angle,
+            min_val=self.ANGLE_MIN,
+            max_val=self.ANGLE_MAX,
+        )
+        self.key.set_range(
+            "minute_hand",
+            minute_angle,
+            min_val=self.ANGLE_MIN,
+            max_val=self.ANGLE_MAX,
+        )
+        self._last_hour_angle = hour_angle
+        self._last_minute_angle = minute_angle
+        return True
+
+    async def on_attach(self, deck: Deck) -> None:
+        """Render the current time and start the per-second tick task.
+
+        Idempotent so reconnects do not stack background tasks.
+
+        Parameters
+        ----------
+        deck
+            The :class:`~deux.Deck` instance (unused -- the clock is
+            independent of deck state).
+        """
+        del deck
+        self._apply_now(datetime.datetime.now())
+        if self._tick_task is None or self._tick_task.done():
+            self._tick_task = asyncio.create_task(
+                self._tick_loop(), name="clock-tick"
+            )
+
+    async def on_detach(self) -> None:
+        """Cancel the tick task and unsubscribe key events."""
+        task = self._tick_task
+        self._tick_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await super().on_detach()
+
+    async def _tick_loop(self) -> None:
+        """Drive hand updates once per second.
+
+        Only requests a refresh when a visible angle actually changes,
+        so the renderer is not woken up unnecessarily.
+        """
+        try:
+            while True:
+                await asyncio.sleep(self.TICK_INTERVAL_S)
+                if self._apply_now(datetime.datetime.now()):
+                    await self.key.request_refresh()
+        except asyncio.CancelledError:
+            pass
 
 class SceneController:
     """Scene-activation keys -- one :class:`DuiKey` per scene definition.

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -74,6 +74,7 @@ import asyncio
 import contextlib
 import datetime
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
@@ -914,6 +915,33 @@ class ClockController(KeyController):
         self._last_hour_angle: float | None = None
         self._last_minute_angle: float | None = None
         self._last_second_angle: float | None = None
+
+        # Log every manifest input event at INFO so the clock key is
+        # easy to verify on a live device.  These are pure observers --
+        # they do not mutate any binding.
+        for event_name in ("press", "release", "click", "hold"):
+            self.key.on(event_name)(self._log_event(event_name))
+
+    @staticmethod
+    def _log_event(name: str) -> Callable[[], Awaitable[None]]:
+        """Build an async handler that logs *name* at INFO when invoked.
+
+        Parameters
+        ----------
+        name : str
+            The DUI event name to embed in the log message.
+
+        Returns
+        -------
+        Callable[[], Awaitable[None]]
+            An async, zero-argument handler suitable for
+            :meth:`~deux.DuiKey.on`.
+        """
+
+        async def _handler() -> None:
+            log.info("ClockKey event: %s", name)
+
+        return _handler
 
     @classmethod
     def compute_angles(

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -863,18 +863,20 @@ class GaugeController(CardController):
         await self._svc.stop()
 
 class ClockController(KeyController):
-    """Analog clock key -- ticking hour and minute hands driven by system time.
+    """Analog clock key -- ticking hour, minute, and second hands driven by system time.
 
-    Loads ``ClockKey.dui`` and updates two transform bindings,
-    ``hour_hand`` and ``minute_hand``, with rotation angles in degrees
-    derived from the local system clock.  Both bindings are declared in
-    the manifest as ``rotate`` transforms whose ``from``/``to`` span the
-    full ``0 -- 360`` degree range, so the controller writes confirmed
-    domain values (degrees) through :meth:`~deux.DuiKey.set_range` with
-    ``min_val=0`` and ``max_val=360``.
+    Loads ``ClockKey.dui`` and updates three transform bindings,
+    ``hour_hand``, ``minute_hand``, and ``second_hand``, with rotation
+    angles in degrees derived from the local system clock.  All three
+    bindings are declared in the manifest as ``rotate`` transforms whose
+    ``from``/``to`` span the full ``0 -- 360`` degree range, so the
+    controller writes confirmed domain values (degrees) through
+    :meth:`~deux.DuiKey.set_range` with ``min_val=0`` and ``max_val=360``.
 
     Angle calculation
     ~~~~~~~~~~~~~~~~~
+    * **Second hand** -- ``6 degrees per second`` (``360 / 60``). At
+      ``:00`` the angle is ``0`` (12 o'clock position).
     * **Minute hand** -- ``6 degrees per minute``  (``360 / 60``), with
       sub-minute precision contributed by the seconds component
       (``0.1 deg/s``).  At 12 o'clock the angle is ``0``.
@@ -893,13 +895,16 @@ class ClockController(KeyController):
     Notes
     -----
     The tick task only requests a refresh when at least one hand angle
-    actually changes since the last tick, avoiding redundant renders
-    while the second hand is between visible positions.
+    actually changes since the last tick, avoiding redundant renders.
+    With a one-second tick the second hand changes every iteration, so
+    in practice a refresh is issued each tick while the controller is
+    attached.
     """
 
     TICK_INTERVAL_S = 1.0
     ANGLE_MIN = 0
     ANGLE_MAX = 360
+    DEGREES_PER_SECOND_SECOND_HAND = 6.0
     DEGREES_PER_MINUTE_MINUTE_HAND = 6.0
     DEGREES_PER_MINUTE_HOUR_HAND = 0.5
 
@@ -908,12 +913,15 @@ class ClockController(KeyController):
         self._tick_task: asyncio.Task[None] | None = None
         self._last_hour_angle: float | None = None
         self._last_minute_angle: float | None = None
+        self._last_second_angle: float | None = None
 
     @classmethod
-    def compute_angles(cls, now: datetime.datetime) -> tuple[float, float]:
-        """Compute the (hour, minute) hand angles in degrees for *now*.
+    def compute_angles(
+        cls, now: datetime.datetime
+    ) -> tuple[float, float, float]:
+        """Compute the (hour, minute, second) hand angles in degrees for *now*.
 
-        Both angles are normalised so that ``0`` corresponds to the
+        All angles are normalised so that ``0`` corresponds to the
         12 o'clock position and values increase clockwise.
 
         Parameters
@@ -924,11 +932,14 @@ class ClockController(KeyController):
 
         Returns
         -------
-        tuple[float, float]
-            ``(hour_angle, minute_angle)`` both in the range
-            ``[0, 360)`` degrees.
+        tuple[float, float, float]
+            ``(hour_angle, minute_angle, second_angle)`` all in the
+            range ``[0, 360)`` degrees.
         """
         total_minutes = now.minute + now.second / 60.0
+        second_angle = (
+            now.second * cls.DEGREES_PER_SECOND_SECOND_HAND
+        ) % cls.ANGLE_MAX
         minute_angle = (
             total_minutes * cls.DEGREES_PER_MINUTE_MINUTE_HAND
         ) % cls.ANGLE_MAX
@@ -936,7 +947,7 @@ class ClockController(KeyController):
             (now.hour % 12) * 30.0
             + total_minutes * cls.DEGREES_PER_MINUTE_HOUR_HAND
         ) % cls.ANGLE_MAX
-        return hour_angle, minute_angle
+        return hour_angle, minute_angle, second_angle
 
     def _apply_now(self, now: datetime.datetime) -> bool:
         """Update the key bindings for time *now*.
@@ -949,13 +960,14 @@ class ClockController(KeyController):
         Returns
         -------
         bool
-            ``True`` if either hand angle changed since the previous
-            call, ``False`` otherwise.
+            ``True`` if any hand angle changed since the previous call,
+            ``False`` otherwise.
         """
-        hour_angle, minute_angle = self.compute_angles(now)
+        hour_angle, minute_angle, second_angle = self.compute_angles(now)
         if (
             hour_angle == self._last_hour_angle
             and minute_angle == self._last_minute_angle
+            and second_angle == self._last_second_angle
         ):
             return False
         self.key.set_range(
@@ -970,8 +982,15 @@ class ClockController(KeyController):
             min_val=self.ANGLE_MIN,
             max_val=self.ANGLE_MAX,
         )
+        self.key.set_range(
+            "second_hand",
+            second_angle,
+            min_val=self.ANGLE_MIN,
+            max_val=self.ANGLE_MAX,
+        )
         self._last_hour_angle = hour_angle
         self._last_minute_angle = minute_angle
+        self._last_second_angle = second_angle
         return True
 
     async def on_attach(self, deck: Deck) -> None:
@@ -1218,6 +1237,7 @@ class StreamDeckApp:
         self.lights = LightsController()
         self.timer = TimerController()
         self.gauge = GaugeController(simulate=False)
+        self.clock = ClockController()
         self.dashboard = DashboardController()
         self.favorites = FavoritesController(catalog, self.audio)
         self.scenes = SceneController(scene_defs)
@@ -1234,6 +1254,12 @@ class StreamDeckApp:
             self.timer,
             self.gauge,
             self.dashboard,
+        ]
+        # KeyController-derived objects follow the same lifecycle but
+        # are tracked separately because they expose ``key`` instead of
+        # ``card`` and the typed list above is constrained to cards.
+        self._key_controllers: list[KeyController] = [
+            self.clock,
         ]
 
     async def on_connect(self, deck: Deck) -> None:
@@ -1279,6 +1305,8 @@ class StreamDeckApp:
         # Drive the uniform lifecycle on every controller.
         for controller in self._controllers:
             await controller.on_attach(deck)
+        for key_controller in self._key_controllers:
+            await key_controller.on_attach(deck)
         self.nav.on_attach(deck)
         self.scenes.set_deck(deck)
 
@@ -1302,11 +1330,17 @@ class StreamDeckApp:
         )
         for controller in self._controllers:
             await controller.on_detach()
+        for key_controller in self._key_controllers:
+            await key_controller.on_detach()
 
     # -- screen construction -------------------------------------------
 
     def _build_main_screen(self, deck: Deck) -> None:
-        """Layout: favourites + scenes on keys, all four cards on the strip."""
+        """Layout: clock on key 0, favourites + scenes on the remaining keys.
+
+        Cards (audio, lights, gauge, dashboard) fill the touch strip
+        when the deck has one.
+        """
         caps = deck.capabilities
         screen = deck.screen("Main")
 
@@ -1316,13 +1350,31 @@ class StreamDeckApp:
             screen.set_card(2, self.gauge.card)
             screen.set_card(3, self.dashboard.card)
 
-        num_favs = min(len(self.favorites.keys), caps.key_count)
-        remaining = max(0, caps.key_count - num_favs)
+        # Reserve key 0 for the analog clock; lay favourites and scenes
+        # on the remaining keys in order.
+        clock_slot = 0
+        if caps.key_count > clock_slot:
+            screen.set_key(clock_slot, self.clock.key)
+            next_slot = clock_slot + 1
+        else:
+            next_slot = 0
+
+        remaining = max(0, caps.key_count - next_slot)
+        num_favs = min(len(self.favorites.keys), remaining)
+        remaining -= num_favs
         num_scenes = min(len(self.scenes.keys), remaining)
 
-        self.favorites.install(screen, list(range(num_favs)))
+        self.favorites.install(
+            screen, list(range(next_slot, next_slot + num_favs))
+        )
         self.scenes.install(
-            screen, list(range(num_favs, num_favs + num_scenes))
+            screen,
+            list(
+                range(
+                    next_slot + num_favs,
+                    next_slot + num_favs + num_scenes,
+                )
+            ),
         )
 
     def _build_settings_screen(self, deck: Deck) -> None:


### PR DESCRIPTION
Adds a new analog clock example to the streamdeck demo.

## Changes

- **New DUI package** `examples/ClockKey.dui` -- analog clock face with three transform-bound hands (`hour_hand`, `minute_hand`, `second_hand`), each mapped to a 0-360 degree rotation.
- **`ClockController(KeyController)`** in `examples/streamdeck.py`:
  - Computes hand angles from local system time (6 deg/sec for the second hand, 6 deg/min for the minute hand, 0.5 deg/min for the hour hand).
  - Writes confirmed degree values through `set_range(min_val=0, max_val=360)` matching the manifest mapping.
  - Drives updates from a single 1Hz `asyncio` task started in `on_attach` and cancelled in `on_detach` (safe across reconnect cycles).
  - Only requests a refresh when an angle actually changes.
  - No backend service -- this is a pure display controller.
  - Logs `press`, `release`, `click`, `hold` events at INFO for live-device verification.
- **`StreamDeckApp` wiring**:
  - New `self._key_controllers: list[KeyController]` so `KeyController`-derived controllers share the same uniform `on_attach`/`on_detach` lifecycle as cards.
  - `_build_main_screen` reserves key 0 for the clock, then lays favourites and scenes on the remaining keys (fixes a previous off-by-one in the favourite slot range).

## Verification

- `ruff check` clean.
- `mypy`: no new errors (same 23 pre-existing errors as on `main`, all related to the `CardController`/`KeyController` 'Any base class' pattern shared by every controller in the file).
- `pytest tests/ --cov=deux --cov-fail-under=95`: **1983 passed**, coverage **95.61%**.