### PR TITLE
fix(deck): swallow HID errors in refresh() after disconnect

### DIFF
--- a/src/deux/runtime/deck.py
+++ b/src/deux/runtime/deck.py
@@ -987,20 +987,27 @@ class Deck:
             for key_index, key_slot in screen.keys.items()
             if key_slot.is_dirty and self._is_dui_key(key_slot)
         ]
-        if dirty_keys:
-            await asyncio.gather(
-                *(self._render_dui_key(ks, ki) for ki, ks in dirty_keys)
-            )
+        try:
+            if dirty_keys:
+                await asyncio.gather(
+                    *(self._render_dui_key(ks, ki) for ki, ks in dirty_keys)
+                )
 
-        if screen.key_bg_dirty:
-            await self._render_all_keys()
-            screen.clear_key_bg_dirty()
+            if screen.key_bg_dirty:
+                await self._render_all_keys()
+                screen.clear_key_bg_dirty()
 
-        if screen.touch_strip is not None and screen.touch_strip.any_dirty:
-            await self._render_touchscreen()
+            if screen.touch_strip is not None and screen.touch_strip.any_dirty:
+                await self._render_touchscreen()
 
-        if screen.info_screen is not None and screen.info_screen.is_dirty:
-            await self._render_info_screen()
+            if screen.info_screen is not None and screen.info_screen.is_dirty:
+                await self._render_info_screen()
+        except (HidWriteTimeout, HidApiError) as exc:
+            # The device was torn down (disconnect, stop) while a
+            # background task (clock tick, spinner, timer) was driving a
+            # refresh.  Refresh is best-effort: swallow the error so the
+            # caller's task doesn't crash with an unhandled exception.
+            logger.debug("Refresh skipped — device unavailable: %s", exc)
 
     async def _check_timeouts(self) -> None:
         """Check all card selection timeouts on the active screen."""

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -299,6 +299,40 @@ class TestDeckRefresh:
         await deck.refresh()
         deck._render_touchscreen.assert_not_awaited()
 
+    async def test_swallows_hidwritetimeout(self, deck):
+        """refresh() must not raise when the device was torn down mid-refresh.
+
+        Background tasks (clock ticks, spinners, timers) call
+        ``request_refresh()`` without knowing the deck's lifecycle, so a
+        disconnect that closes the device between the refresh starting
+        and the executor writing must surface as a silent no-op rather
+        than an unhandled task exception.
+        """
+        from deux.runtime.deck import HidWriteTimeout
+
+        p = deck.screen("main")
+        deck._active_screen = p
+        deck._render_touchscreen = AsyncMock(
+            side_effect=HidWriteTimeout("device closed")
+        )
+
+        # Must not raise.
+        await deck.refresh()
+        deck._render_touchscreen.assert_awaited_once()
+
+    async def test_swallows_hidapierror(self, deck):
+        """A bare HidApiError from deeper in the stack is also tolerated."""
+        from deux.runtime.deck import HidApiError
+
+        p = deck.screen("main")
+        deck._active_screen = p
+        deck._render_touchscreen = AsyncMock(
+            side_effect=HidApiError("Device is not open")
+        )
+
+        await deck.refresh()
+        deck._render_touchscreen.assert_awaited_once()
+
 
 class TestDeckDispatch:
     async def test_no_active_screen(self, deck):


### PR DESCRIPTION
## Problem

Running `examples/streamdeck.py` and unplugging the Stream Deck while the `ClockController` tick loop is active produces an unhandled task exception:

```
WARNING: Deck disconnected: A00WA4221NAA3I -- waiting for reconnect...
ERROR: Task exception was never retrieved
future: <Task finished name='clock-tick' coro=<ClockController._tick_loop() ...>
    exception=HidApiError('Device is not open')>
Traceback (most recent call last):
  File "examples/streamdeck.py", line 1062, in _tick_loop
    await self.key.request_refresh()
  ...
  File "src/deux/runtime/hid/device.py", line 211, in _ensure_open
    raise HidApiError("Device is not open")
```

## Root cause

Background tasks (clock ticks, spinners, timers) call `KeySlot.request_refresh()` -> `Deck.refresh()` without knowing the deck's lifecycle. When `DeckManager` tears down the device after a disconnect, an in-flight refresh that has already been scheduled lands in `_exec_device_io`, where the executor calls `device.set_key_image` on a closed handle and raises a bare `HidApiError` from ctypes hidapi. That exception bubbles up to the user's tick task, which has no reasonable way to guard every call site.

## Fix

Treat `Deck.refresh()` as best-effort: catch `HidApiError` and `HidWriteTimeout` from the per-control render+push stage and log at DEBUG. The manager's disconnect handler already emits a user-facing warning and re-attaches on reconnect, so silent recovery here is the right boundary.

## Tests

- `test_swallows_hidwritetimeout` -- refresh tolerates a `HidWriteTimeout` from any push.
- `test_swallows_hidapierror` -- same for a bare `HidApiError` deeper in the stack.
- Full suite passes; coverage 95.62%.