### PR TITLE
fix(transport) + feat(dui/iconkey): kill phantom release events and add notification badge

### DIFF
--- a/examples/mock_backend.py
+++ b/examples/mock_backend.py
@@ -44,12 +44,6 @@ MEDIA_CATALOG: list[dict[str, str]] = [
         "cover": "assets/album_cover_1.png",
     },
     {
-        "artist": "King Crimson",
-        "album": "In the Court of the Crimson King",
-        "title": "In the Court of the Crimson King",
-        "cover": "assets/album_cover_2.png",
-    },
-    {
         "artist": "Procol Harum",
         "album": "Procol Harum",
         "title": "A Whiter Shade of Pale",

--- a/examples/streamdeck.py
+++ b/examples/streamdeck.py
@@ -1082,7 +1082,7 @@ class SceneController:
         self._svc = MockScenesService()
         self._keys: list[DuiKey] = []
         self._deck: Deck | None = None
-
+        self.screenshots = EXAMPLES_DIR.joinpath("screenshots")
         # In a real app this subscriber would update an "active scene"
         # indicator.  Here it just demonstrates that the activation
         # round-trips through the service.
@@ -1093,14 +1093,16 @@ class SceneController:
                 if self._deck is not None:
                     screen = self._deck.active_screen
                     if screen is not None:
-                        screen.screenshot("/tmp/deck_screenshot")
-                        log.info("Screenshot saved to /tmp/deck_screenshot")
+                        screen.screenshot(self.screenshots)
+                        log.info(f"Screenshot saved to {self.screenshots}")
             else:
                 log.info("Scene confirmed active: %s", label)
 
         for scene in self._scenes:
             key = DuiKey("IconKey")
             key.set_many(label=scene["label"], icon=scene["icon"])
+            if scene["label"] == "Screenshot":
+                key.set("show_notification", True)
             self._wire_key(key, scene["label"])
             self._keys.append(key)
 
@@ -1147,19 +1149,27 @@ class SceneController:
 
         @key.on("press")
         async def _press() -> None:
+            log.info(f'{key.get("label")} pressed')
             key.set("background_class", "success")
             await key.request_refresh()
 
         @key.on("release")
         async def _release() -> None:
+            log.info(f'{key.get("label")} release')
+            if key.get("label") == "Screenshot":
+                key.set("show_notification", False)
             key.set("background_class", background_class)
             await key.request_refresh()
 
+        """
         @key.on("click")
         async def _click() -> None:
             key.set("background_class", background_class)
+            log.info(key.get("label"))
+            if key.get("label") == "Screenshot":
+                key.set("show_notification", False)
             await key.request_refresh()
-
+        """
         key.forward("click", lambda: self._svc.activate(label))
 
 class ScreenCycler:

--- a/src/deux/dui/packages/IconKey.dui/layout.svg
+++ b/src/deux/dui/packages/IconKey.dui/layout.svg
@@ -14,6 +14,10 @@
     <g id="icon" class="icon" transform="translate(32.5 20)" filter="url(#shadow)">
         <svg xmlns="http://www.w3.org/2000/svg" width="55" height="55" viewBox="0 0 256 256"><path fill="currentColor" d="M208 28H48a20 20 0 0 0-20 20v160a20 20 0 0 0 20 20h160a20 20 0 0 0 20-20V48a20 20 0 0 0-20-20m-4 159L69 52h135ZM52 69l135 135H52Z"/></svg>
     </g>
+    <g id="notification" transform="translate(82.5 25)" filter="url(#shadow)">
+      <circle class="error" cx="0" cy="0" r="15" fill="currentColor" />
+      <text id="notification_count" class="text-primary" x="0" y="2" font-size="18" fill="currentColor" text-anchor="middle" dominant-baseline="middle">2</text>
+    </g>
     <text id="label" class="text-primary" x="60" y="100" font-size="18" text-anchor="middle" fill="currentColor" filter="url(#shadow)">
       Icon Key
     </text>

--- a/src/deux/dui/packages/IconKey.dui/manifest.yaml
+++ b/src/deux/dui/packages/IconKey.dui/manifest.yaml
@@ -29,6 +29,16 @@ bindings:
     type: css_class
     node: background
     default: background-dark
+  
+  show_notification:
+    type: visibility
+    node: notification
+    default: false
+
+  notification_count:
+    type: text
+    node: notification_count
+    default: "1"
 
 spinner:
   type: rotation

--- a/src/deux/runtime/transport.py
+++ b/src/deux/runtime/transport.py
@@ -69,8 +69,10 @@ class AsyncTransport:
         self._queue: asyncio.Queue[DeckEvent] = asyncio.Queue()
         self._running = False
         self._poll_task: asyncio.Task[None] | None = None
-        self._prev_key_states: tuple[bool, ...] = ()
-        self._prev_encoder_states: tuple[bool, ...] = ()
+        key_count = caps.key_count if caps is not None else 0
+        dial_count = caps.dial_count if caps is not None else 0
+        self._prev_key_states: tuple[bool, ...] = (False,) * key_count
+        self._prev_encoder_states: tuple[bool, ...] = (False,) * dial_count
 
     @property
     def queue(self) -> asyncio.Queue[DeckEvent]:
@@ -186,7 +188,10 @@ class AsyncTransport:
             The current key state snapshot.
         """
         for idx, pressed in enumerate(event.states):
-            if idx < len(self._prev_key_states) and pressed == self._prev_key_states[idx]:
+            if (
+                idx < len(self._prev_key_states)
+                and pressed == self._prev_key_states[idx]
+            ):
                 continue
             self._queue.put_nowait(KeyEvent(key=idx, pressed=pressed))
         self._prev_key_states = event.states

--- a/tests/test_example_streamdeck.py
+++ b/tests/test_example_streamdeck.py
@@ -26,6 +26,7 @@ from deux.dui.schema import (
     TextBinding,
     ToggleBinding,
     TransformBinding,
+    VisibilityBinding,
 )
 
 # Make examples importable
@@ -97,6 +98,11 @@ _KEY_SVG = (
     '<g id="foreground" color="#dedede">'
     '<g id="icon"></g>'
     '<text id="label" x="60" y="100" font-size="14" fill="currentColor">Key</text>'
+    '<g id="notification" display="none">'
+    '<circle cx="100" cy="20" r="10" fill="red"/>'
+    '<text id="notification_count" x="100" y="24" font-size="10" '
+    'text-anchor="middle" fill="white">1</text>'
+    "</g>"
     "</g>"
     "</svg>"
 )
@@ -375,9 +381,16 @@ def _iconkey_spec() -> PackageSpec:
             "icon_class": CssClassBinding(
                 node="icon", default="icon"
             ),
+            "show_notification": VisibilityBinding(
+                node="notification", default=False
+            ),
+            "notification_count": TextBinding(
+                node="notification_count", default="1"
+            ),
         },
         events=(
             EventMapping(name="click", source="key_press_release", max_duration_ms=300),
+            EventMapping(name="hold", source="key_hold", hold_ms=350),
             EventMapping(name="press", source="key_press"),
             EventMapping(name="release", source="key_release"),
         ),
@@ -939,9 +952,12 @@ class TestFavoritesController:
         self, ctrl: FavoritesController
     ) -> None:
         screen = MagicMock()
-        ctrl.install(screen, [0, 1, 4, 5])
-        positions = [call.args[0] for call in screen.set_key.call_args_list]
-        assert positions == [0, 1, 4, 5]
+        # ``install`` pairs positions with keys via ``zip(strict=False)``,
+        # so only the first ``len(ctrl.keys)`` positions are consumed.
+        positions = list(range(len(ctrl.keys)))
+        ctrl.install(screen, positions)
+        called_positions = [call.args[0] for call in screen.set_key.call_args_list]
+        assert called_positions == positions
 
     def test_install_truncates_to_fewer_positions(
         self, ctrl: FavoritesController

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -110,16 +110,32 @@ class TestTranslateKeyState:
         transport._translate_event(event)
         assert transport.queue.empty()
 
-    async def test_initial_state_emits_all_keys(self, mock_device):
-        """First key state with no previous state emits events for all keys."""
+    async def test_initial_state_emits_only_pressed_keys(self, mock_device):
+        """First key snapshot emits events only for keys actually pressed.
+
+        Regression: the transport used to start with an empty
+        ``_prev_key_states`` tuple, which meant the first
+        :class:`KeyStateEvent` enqueued a :class:`KeyEvent` for *every*
+        key index -- including released keys, whose spurious
+        ``pressed=False`` events triggered ``release`` handlers on every
+        other key on the screen.
+
+        After the fix, ``_prev_key_states`` is initialised to all-False
+        with the device's ``key_count``, so the first snapshot only
+        emits events for keys whose state differs from "not pressed".
+        """
         transport = AsyncTransport(mock_device, STREAM_DECK_PLUS)
         transport._running = True
-        event = KeyStateEvent(states=(True, False, True, False))
+        # Stream Deck + reports 8 keys; press indices 0 and 2.
+        states = tuple(i in {0, 2} for i in range(8))
+        event = KeyStateEvent(states=states)
         transport._translate_event(event)
         events = []
         while not transport.queue.empty():
             events.append(transport.queue.get_nowait())
-        assert len(events) == 4  # all keys emit on first report
+        # Exactly two events, both for pressed keys.
+        assert len(events) == 2
+        assert {(e.key, e.pressed) for e in events} == {(0, True), (2, True)}
 
 
 class TestTranslateTouchEvents:
@@ -217,6 +233,25 @@ class TestTranslateEncoderEvents:
         event = EncoderButtonEvent(states=(False, False, False, False))
         transport._translate_event(event)
         assert transport.queue.empty()
+
+    async def test_initial_encoder_state_emits_only_pressed(self, mock_device):
+        """First encoder snapshot emits events only for buttons actually pressed.
+
+        Regression: same root cause as the key-state initial-snapshot
+        bug -- ``_prev_encoder_states`` used to start empty, so the
+        first :class:`EncoderButtonEvent` enqueued a release-style event
+        for every encoder.
+        """
+        transport = AsyncTransport(mock_device, STREAM_DECK_PLUS)
+        transport._running = True
+        event = EncoderButtonEvent(states=(False, True, False, False))
+        transport._translate_event(event)
+        events = []
+        while not transport.queue.empty():
+            events.append(transport.queue.get_nowait())
+        assert len(events) == 1
+        assert events[0].encoder == 1
+        assert events[0].pressed is True
 
     async def test_encoder_zero_rotation_ignored(self, mock_device):
         """Zero-tick encoders produce no events."""


### PR DESCRIPTION
## Summary

Three logically distinct changes surfaced while running the `examples/streamdeck.py` demo against a real Stream Deck +.

### 1. `fix(transport)`: phantom release events on every key

`AsyncTransport` initialised `_prev_key_states` and `_prev_encoder_states` to empty tuples. On the first `KeyStateEvent`/`EncoderButtonEvent` the per-index guard `idx < len(self._prev_*_states)` was always false, so the transport enqueued a `KeyEvent`/`EncoderButtonEvent` for **every** index in the snapshot — including released keys. Each spurious `pressed=False` event then fired a `release` handler on every other `DuiKey` on the screen, manifesting as random keys briefly flashing into their release state whenever any key was pressed.

Fix: seed both tuples to all-False sized from the device's `key_count` / `dial_count`. First snapshot now correctly emits events only for keys/buttons whose state differs from the assumed-released baseline. Two regression tests added.

### 2. `feat(dui/iconkey)`: notification badge

Adds two bindings to the bundled `IconKey.dui` package:

- `show_notification` (visibility, default `false`) — toggles a notification badge in the upper-right of the key.
- `notification_count` (text, default `"1"`) — number rendered inside the badge.

Badge is a coloured circle (uses the `error` CSS class) with a centred number, positioned at (82.5, 25) in the 120x120 key space and rendered with the existing drop-shadow filter for visual consistency with the icon and label.

`tests/test_example_streamdeck.py` fixture updated to mirror the manifest (new bindings, badge SVG nodes, and the existing `hold` event mapping).

### 3. `chore(examples)`: demo the notification + tidy screenshot path

- `SceneController` now toggles `show_notification` on the "Screenshot" `IconKey` so the badge appears when wired and clears on release.
- Screenshot path moved from `/tmp/deck_screenshot` to `examples/screenshots/` so artefacts stay with the example.
- `MEDIA_CATALOG` trimmed 4 → 3 entries.
- A few `log.info` traces on press/release to make the example easier to follow.

## Testing

```
1986 passed, 1 skipped in 36.74s
Required test coverage of 95% reached. Total coverage: 95.62%
ruff: All checks passed!
mypy: Success: no issues found in 67 source files
```

## Related

- Spinner rotation regression discovered during the same demo session is filed separately as #385 — not addressed here.

## Commits

1. `7d9800e` fix(transport): seed prev key/encoder states from device capabilities
2. `7df6c4f` feat(dui/iconkey): add notification badge with show/count bindings
3. `84f7418` chore(examples): demo IconKey notification and route screenshots to examples dir
