### PR TITLE
chore(examples): ignore generated screenshot artefacts

### DIFF
--- a/examples/screenshots/.gitignore
+++ b/examples/screenshots/.gitignore
@@ -1,0 +1,4 @@
+# Demo run artefacts — keep folder tracked, ignore generated screenshots.
+*
+!.gitignore
+!.gitkeep


### PR DESCRIPTION
The streamdeck demo writes per-key and per-card PNGs into `examples/screenshots/` whenever the "Screenshot" scene is activated. Those files are runtime artefacts and should not be tracked.

Adds a folder-local `.gitignore` that ignores everything in the directory except itself and the existing `.gitkeep`, so the folder stays present in the repo (so the demo can write into it without an `mkdir`) while the generated PNGs are filtered out of `git status`.

## Verification

```
$ git check-ignore -v examples/screenshots/key_0.png
examples/screenshots/.gitignore:2:*	examples/screenshots/key_0.png
```

No code or test changes — pure repo hygiene.